### PR TITLE
Fix the issue with the JCIFS client not reconnecting after smb server restart

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.codelibs</groupId>
   <artifactId>jcifs</artifactId>
-  <version>1.3.18.3-SNAPSHOT</version>
+  <version>1.3.19-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>jCIFS</name>
   <url>http://jcifs.samba.org</url>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.codelibs</groupId>
   <artifactId>jcifs</artifactId>
-  <version>1.3.19-SNAPSHOT</version>
+  <version>1.3.18.3-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>jCIFS</name>
   <url>http://jcifs.samba.org</url>

--- a/src/jcifs/smb/SmbTransport.java
+++ b/src/jcifs/smb/SmbTransport.java
@@ -318,11 +318,17 @@ public class SmbTransport extends Transport implements SmbConstants {
         try {
             negotiate( port, resp );
         } catch( ConnectException ce ) {
-            port = (port == 0 || port == DEFAULT_PORT) ? 139 : DEFAULT_PORT;
-            negotiate( port, resp );
+            // Try an alternate port if there was an issue communicating to the server
+            // Only set the alternate port to the port property if it was successful
+            int altPort = (port == 0 || port == DEFAULT_PORT) ? 139 : DEFAULT_PORT;
+            negotiate( altPort, resp );
+            port = altPort;
         } catch( NoRouteToHostException nr ) {
-            port = (port == 0 || port == DEFAULT_PORT) ? 139 : DEFAULT_PORT;
-            negotiate( port, resp );
+            // Try an alternate port if there was an issue communicating to the server
+            // Only set the alternate port to the port property if it was successful
+            int altPort = (port == 0 || port == DEFAULT_PORT) ? 139 : DEFAULT_PORT;
+            negotiate( altPort, resp );
+            port = altPort;
         }
 
         if( resp.dialectIndex > 10 ) {


### PR DESCRIPTION
The JCIFS library (which we use to talk to custom file server) is designed to tolerate server connectivity issues. However, when there are many requests for the JCIFS client to download files from the smb server is rebooting, it is possible to put the library in a bad state from which it is unable to recover.
The JCIFS library caches and reuses transport and sessions to the same host/auth combinations. It has a state machine to recognize and reset connections on failures. This state machine can get corrupted during down time if the timing is just right. With a high production load, this happens quite easily.

The bug lies in https://github.com/codelibs/jcifs/blob/master/src/jcifs/smb/SmbTransport.java#L324
If a NoRouteToHostException is thrown during the time the file server is down, it sets the port number to 139 (instead of 445). From that point on, it continues to fail forever.

This PR attempts to fix this issue