### PR TITLE
mask user secret in logs

### DIFF
--- a/src/main/java/jcifs/smb/SmbFile.java
+++ b/src/main/java/jcifs/smb/SmbFile.java
@@ -346,7 +346,10 @@ import jcifs.internal.smb2.info.Smb2SetInfoRequest;
  */
 
 public class SmbFile extends URLConnection implements SmbResource, SmbConstants {
-
+    public static final String SECRET_MASK = "******";
+    private static final String SECRET_PATTERN = "^(smb.*:).*(@.*)$";
+    private static final String SECRET_MASK_REPLACE = "$1" + SECRET_MASK + "$2";
+    
     protected static final int ATTR_GET_MASK = 0x7FFF;
     protected static final int ATTR_SET_MASK = 0x30A7;
     protected static final int DEFAULT_ATTR_EXPIRATION_PERIOD = 5000;
@@ -2068,7 +2071,7 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
 
     @Override
     public String toString () {
-        return this.url.toString();
+        return this.url.toString().replaceFirst(SECRET_MASK_PATTERN, SECRET_MASK_REPLACE);
     }
 
 

--- a/src/main/java/jcifs/smb/SmbFile.java
+++ b/src/main/java/jcifs/smb/SmbFile.java
@@ -2071,7 +2071,7 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
 
     @Override
     public String toString () {
-        return this.url.toString().replaceFirst(SECRET_MASK_PATTERN, SECRET_MASK_REPLACE);
+        return this.url.toString().replaceFirst(SECRET_PATTERN, SECRET_MASK_REPLACE);
     }
 
 


### PR DESCRIPTION
Fix a security risk where user credentials is showing up in logs. 