### PR TITLE
Set user domain as default target domain.

### DIFF
--- a/src/main/java/jcifs/smb/SmbTreeConnection.java
+++ b/src/main/java/jcifs/smb/SmbTreeConnection.java
@@ -499,7 +499,7 @@ class SmbTreeConnection {
      * @throws IOException
      */
     public synchronized SmbTreeHandleImpl connectHost ( SmbResourceLocatorImpl loc, String host, DfsReferralData referral ) throws IOException {
-        String targetDomain = null;
+        String targetDomain = ctx.getCredentials().getUserDomain();
         try ( SmbTreeImpl t = getTree() ) {
             if ( t != null ) {
                 if ( log.isDebugEnabled() ) {


### PR DESCRIPTION
Hello everyone,

I want to use JCIFS library for SMB protocol with Kerberos Authentication in a similar degree of freedom like a SFTP Client.
Which means I want to setup connection without any system wide settings or configuration files.
Same Java program should be able to connect to smb@domain1 and smb@domain2 like connection to sftp-server-1 and sftp-server-2

For requesting ticket from Kerberos Server I use the Kerby Library because JVM implementation has System wide flags / configuration files.
Then I convert the Kerberos Ticket to a Subject which is Java API and therefore accepted by Kerb5Authenticator from JCIFS.

Here is my setup for the CIFSContext and I already try to inject the target domain with properties:

Kerb5Authenticator auth = new Kerb5Authenticator(subject, finalRealm, finalUserNameWithoutDomain, password);
Properties prop = new Properties();
prop.put("jcifs.smb.client.domain", finalRealm);
PropertyConfiguration config = new PropertyConfiguration(prop);
CIFSContext context = new BaseContext(config).withCredentials(auth);

However I have come across with a problem during access.
JCIFS tries to solve the target domain and this somehow runs until default realm settings in the JVM configuration in.
SmbTreeConnection.connectHost
method.

Since I am running my program in a completely domain decoupled Linux Server I get:
Caused by: org.ietf.jgss.GSSException: Invalid name provided (Mechanism level: KrbException: Cannot locate default realm)

If I run this on a domain connected server it works since the system wide domain settings are somehow available to JVM and JVM uses it.
I could fix that by patching the JCIFS library in SmbTreeConnection.connectHost method by initializing targetDomain with injected domain setting:
String targetDomain = ctx.getCredentials().getUserDomain();

Do you have any other idea or could you accept this fix?