### PR TITLE
Add SMB3 Encryption Context Support to SmbSessionImpl and SmbTransportImpl

### DIFF
--- a/src/main/java/jcifs/config/BaseConfiguration.java
+++ b/src/main/java/jcifs/config/BaseConfiguration.java
@@ -734,7 +734,7 @@ public class BaseConfiguration implements Configuration {
 
     protected void initProtocolVersions ( DialectVersion min, DialectVersion max ) {
         this.minVersion = min != null ? min : DialectVersion.SMB1;
-        this.maxVersion = max != null ? max : DialectVersion.SMB210;
+        this.maxVersion = max != null ? max : DialectVersion.SMB311;
 
         if ( this.minVersion.atLeast(this.maxVersion) ) {
             this.maxVersion = this.minVersion;

--- a/src/main/java/jcifs/internal/smb2/Smb2EncryptionContext.java
+++ b/src/main/java/jcifs/internal/smb2/Smb2EncryptionContext.java
@@ -1,0 +1,317 @@
+/*
+ * © 2025 CodeLibs, Inc.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package jcifs.internal.smb2;
+
+
+import java.security.SecureRandom;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.bouncycastle.crypto.modes.CCMBlockCipher;
+import org.bouncycastle.crypto.modes.AEADBlockCipher;
+import org.bouncycastle.crypto.engines.AESEngine;
+import org.bouncycastle.crypto.params.AEADParameters;
+import org.bouncycastle.crypto.params.KeyParameter;
+
+import jcifs.CIFSException;
+import jcifs.DialectVersion;
+import jcifs.internal.smb2.nego.EncryptionNegotiateContext;
+
+
+/**
+ * SMB2/SMB3 Encryption Context
+ * 
+ * Manages encryption and decryption operations for SMB2/SMB3 sessions.
+ * Handles both AES-CCM (SMB 3.0/3.0.2) and AES-GCM (SMB 3.1.1) cipher suites.
+ * 
+ * @author mbechler
+ */
+public class Smb2EncryptionContext {
+
+    private final int cipherId;
+    private final DialectVersion dialect;
+    private final byte[] encryptionKey;
+    private final byte[] decryptionKey;
+    private final AtomicLong nonceCounter = new AtomicLong(0);
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    // Encryption algorithms
+    public static final int CIPHER_AES_128_CCM = EncryptionNegotiateContext.CIPHER_AES128_CCM;
+    public static final int CIPHER_AES_128_GCM = EncryptionNegotiateContext.CIPHER_AES128_GCM;
+    // Note: AES-256 variants are not currently defined in the negotiate context
+
+    // Transform header flags
+    public static final int TRANSFORM_FLAG_ENCRYPTED = 0x0001;
+
+
+    /**
+     * Create encryption context
+     * 
+     * @param cipherId
+     *            negotiated cipher identifier
+     * @param dialect
+     *            SMB dialect version
+     * @param encryptionKey
+     *            key for client->server encryption
+     * @param decryptionKey
+     *            key for server->client decryption
+     */
+    public Smb2EncryptionContext ( int cipherId, DialectVersion dialect, byte[] encryptionKey, byte[] decryptionKey ) {
+        this.cipherId = cipherId;
+        this.dialect = dialect;
+        this.encryptionKey = encryptionKey.clone();
+        this.decryptionKey = decryptionKey.clone();
+    }
+
+
+    /**
+     * @return the negotiated cipher ID
+     */
+    public int getCipherId () {
+        return this.cipherId;
+    }
+
+
+    /**
+     * @return the SMB dialect version
+     */
+    public DialectVersion getDialect () {
+        return this.dialect;
+    }
+
+
+    /**
+     * Generate a unique nonce for encryption
+     * 
+     * @return 16-byte nonce
+     */
+    public byte[] generateNonce () {
+        byte[] nonce = new byte[16];
+        
+        // Use combination of counter and random data for uniqueness
+        long counter = this.nonceCounter.incrementAndGet();
+        System.arraycopy(longToBytes(counter), 0, nonce, 0, 8);
+        
+        // Fill remaining 8 bytes with random data
+        byte[] randomBytes = new byte[8];
+        this.secureRandom.nextBytes(randomBytes);
+        System.arraycopy(randomBytes, 0, nonce, 8, 8);
+        
+        return nonce;
+    }
+
+
+    /**
+     * Encrypt an SMB2 message
+     * 
+     * @param message
+     *            plaintext message to encrypt
+     * @param sessionId
+     *            session identifier
+     * @return encrypted message with transform header
+     * @throws CIFSException
+     *             if encryption fails
+     */
+    public byte[] encryptMessage ( byte[] message, long sessionId ) throws CIFSException {
+        try {
+            byte[] nonce = generateNonce();
+            int flags = getTransformFlags();
+            
+            Smb2TransformHeader transformHeader = new Smb2TransformHeader(nonce, message.length, flags, sessionId);
+            byte[] associatedData = transformHeader.getAssociatedData();
+            
+            byte[] ciphertext;
+            byte[] authTag;
+            
+            if ( isGCMCipher() ) {
+                // Use AES-GCM
+                Cipher cipher = createGCMCipher(true, nonce);
+                cipher.updateAAD(associatedData);
+                byte[] encrypted = cipher.doFinal(message);
+                
+                // Split ciphertext and authentication tag
+                int tagLength = getAuthTagLength();
+                ciphertext = new byte[encrypted.length - tagLength];
+                authTag = new byte[tagLength];
+                System.arraycopy(encrypted, 0, ciphertext, 0, ciphertext.length);
+                System.arraycopy(encrypted, ciphertext.length, authTag, 0, tagLength);
+            }
+            else {
+                // Use AES-CCM with Bouncy Castle
+                AEADBlockCipher cipher = createCCMCipher(true, nonce, associatedData.length, message.length);
+                
+                byte[] input = new byte[associatedData.length + message.length];
+                System.arraycopy(associatedData, 0, input, 0, associatedData.length);
+                System.arraycopy(message, 0, input, associatedData.length, message.length);
+                
+                byte[] output = new byte[cipher.getOutputSize(input.length)];
+                int len = cipher.processBytes(input, 0, input.length, output, 0);
+                len += cipher.doFinal(output, len);
+                
+                // Split ciphertext and authentication tag
+                int tagLength = getAuthTagLength();
+                ciphertext = new byte[message.length];
+                authTag = new byte[tagLength];
+                System.arraycopy(output, associatedData.length, ciphertext, 0, message.length);
+                System.arraycopy(output, output.length - tagLength, authTag, 0, tagLength);
+            }
+            
+            // Set authentication tag in transform header
+            transformHeader.setSignature(authTag);
+            
+            // Build final encrypted message
+            byte[] result = new byte[Smb2TransformHeader.TRANSFORM_HEADER_SIZE + ciphertext.length];
+            transformHeader.encode(result, 0);
+            System.arraycopy(ciphertext, 0, result, Smb2TransformHeader.TRANSFORM_HEADER_SIZE, ciphertext.length);
+            
+            return result;
+        }
+        catch ( Exception e ) {
+            throw new CIFSException("Failed to encrypt message", e);
+        }
+    }
+
+
+    /**
+     * Decrypt an SMB2 message
+     * 
+     * @param encryptedMessage
+     *            encrypted message with transform header
+     * @return decrypted plaintext message
+     * @throws CIFSException
+     *             if decryption fails
+     */
+    public byte[] decryptMessage ( byte[] encryptedMessage ) throws CIFSException {
+        try {
+            // Parse transform header
+            Smb2TransformHeader transformHeader = Smb2TransformHeader.decode(encryptedMessage, 0);
+            byte[] associatedData = transformHeader.getAssociatedData();
+            byte[] nonce = transformHeader.getNonce();
+            byte[] authTag = transformHeader.getSignature();
+            
+            // Extract ciphertext
+            int ciphertextLength = encryptedMessage.length - Smb2TransformHeader.TRANSFORM_HEADER_SIZE;
+            byte[] ciphertext = new byte[ciphertextLength];
+            System.arraycopy(encryptedMessage, Smb2TransformHeader.TRANSFORM_HEADER_SIZE, ciphertext, 0, ciphertextLength);
+            
+            byte[] plaintext;
+            
+            if ( isGCMCipher() ) {
+                // Use AES-GCM
+                Cipher cipher = createGCMCipher(false, nonce);
+                cipher.updateAAD(associatedData);
+                
+                // Combine ciphertext and auth tag for decryption
+                byte[] input = new byte[ciphertext.length + authTag.length];
+                System.arraycopy(ciphertext, 0, input, 0, ciphertext.length);
+                System.arraycopy(authTag, 0, input, ciphertext.length, authTag.length);
+                
+                plaintext = cipher.doFinal(input);
+            }
+            else {
+                // Use AES-CCM with Bouncy Castle
+                AEADBlockCipher cipher = createCCMCipher(false, nonce, associatedData.length, ciphertext.length);
+                
+                byte[] input = new byte[associatedData.length + ciphertext.length + authTag.length];
+                System.arraycopy(associatedData, 0, input, 0, associatedData.length);
+                System.arraycopy(ciphertext, 0, input, associatedData.length, ciphertext.length);
+                System.arraycopy(authTag, 0, input, associatedData.length + ciphertext.length, authTag.length);
+                
+                byte[] output = new byte[cipher.getOutputSize(input.length)];
+                int len = cipher.processBytes(input, 0, input.length, output, 0);
+                len += cipher.doFinal(output, len);
+                
+                plaintext = new byte[ciphertext.length];
+                System.arraycopy(output, associatedData.length, plaintext, 0, ciphertext.length);
+            }
+            
+            return plaintext;
+        }
+        catch ( Exception e ) {
+            throw new CIFSException("Failed to decrypt message", e);
+        }
+    }
+
+
+    private boolean isGCMCipher () {
+        return this.cipherId == CIPHER_AES_128_GCM;
+    }
+
+
+    private int getKeyLength () {
+        // Currently only AES-128 is supported
+        if ( this.cipherId == CIPHER_AES_128_CCM || this.cipherId == CIPHER_AES_128_GCM ) {
+            return 16;
+        }
+        else {
+            throw new IllegalArgumentException("Unsupported cipher: " + this.cipherId);
+        }
+    }
+
+
+    private int getAuthTagLength () {
+        return 16; // All SMB3 ciphers use 16-byte authentication tags
+    }
+
+
+    private int getTransformFlags () {
+        if ( this.dialect.atLeast(DialectVersion.SMB311) ) {
+            return TRANSFORM_FLAG_ENCRYPTED;
+        }
+        else {
+            // For SMB 3.0/3.0.2, this field contains the encryption algorithm
+            return this.cipherId;
+        }
+    }
+
+
+    private Cipher createGCMCipher ( boolean encrypt, byte[] nonce ) throws Exception {
+        String algorithm = getKeyLength() == 16 ? "AES" : "AES";
+        SecretKeySpec keySpec = new SecretKeySpec(encrypt ? this.encryptionKey : this.decryptionKey, algorithm);
+        
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        GCMParameterSpec gcmSpec = new GCMParameterSpec(getAuthTagLength() * 8, nonce);
+        cipher.init(encrypt ? Cipher.ENCRYPT_MODE : Cipher.DECRYPT_MODE, keySpec, gcmSpec);
+        
+        return cipher;
+    }
+
+
+    private AEADBlockCipher createCCMCipher ( boolean encrypt, byte[] nonce, int aadLength, int plaintextLength ) {
+        AEADBlockCipher cipher = new CCMBlockCipher(new AESEngine());
+        
+        KeyParameter keyParam = new KeyParameter(encrypt ? this.encryptionKey : this.decryptionKey);
+        AEADParameters params = new AEADParameters(keyParam, getAuthTagLength() * 8, nonce, null);
+        
+        cipher.init(encrypt, params);
+        
+        return cipher;
+    }
+
+
+    private static byte[] longToBytes ( long value ) {
+        byte[] bytes = new byte[8];
+        for ( int i = 0; i < 8; i++ ) {
+            bytes[ i ] = (byte) ( value >>> ( 8 * ( 7 - i ) ) );
+        }
+        return bytes;
+    }
+}

--- a/src/main/java/jcifs/internal/smb2/Smb2EncryptionContext.java
+++ b/src/main/java/jcifs/internal/smb2/Smb2EncryptionContext.java
@@ -284,7 +284,7 @@ public class Smb2EncryptionContext {
 
 
     private Cipher createGCMCipher ( boolean encrypt, byte[] nonce ) throws Exception {
-        String algorithm = getKeyLength() == 16 ? "AES" : "AES";
+        String algorithm = "AES";
         SecretKeySpec keySpec = new SecretKeySpec(encrypt ? this.encryptionKey : this.decryptionKey, algorithm);
         
         Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");

--- a/src/main/java/jcifs/internal/smb2/Smb2TransformHeader.java
+++ b/src/main/java/jcifs/internal/smb2/Smb2TransformHeader.java
@@ -1,0 +1,297 @@
+/*
+ * © 2025 CodeLibs, Inc.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package jcifs.internal.smb2;
+
+
+import jcifs.Encodable;
+import jcifs.internal.util.SMBUtil;
+
+
+/**
+ * SMB2 Transform Header for encrypted messages
+ * 
+ * This header is used to encrypt SMB2/SMB3 messages and provides the necessary
+ * cryptographic parameters for decryption including the nonce, session ID, and
+ * authentication tag.
+ * 
+ * @author mbechler
+ */
+public class Smb2TransformHeader implements Encodable {
+
+    /**
+     * Transform header protocol identifier: 0xFD534D42 (0xFD 'S' 'M' 'B')
+     */
+    public static final int TRANSFORM_PROTOCOL_ID = 0xFD534D42;
+
+    /**
+     * Size of the transform header in bytes
+     */
+    public static final int TRANSFORM_HEADER_SIZE = 52;
+
+    private byte[] signature = new byte[16];
+    private byte[] nonce = new byte[16];
+    private int originalMessageSize;
+    private int flags;
+    private long sessionId;
+
+
+    /**
+     * Create a new SMB2 Transform Header
+     */
+    public Smb2TransformHeader () {}
+
+
+    /**
+     * Create a new SMB2 Transform Header with specified parameters
+     * 
+     * @param nonce
+     *            16-byte nonce for encryption
+     * @param originalMessageSize
+     *            size of the original unencrypted message
+     * @param flags
+     *            transform flags (SMB 3.1.1) or encryption algorithm (SMB 3.0/3.0.2)
+     * @param sessionId
+     *            session identifier
+     */
+    public Smb2TransformHeader ( byte[] nonce, int originalMessageSize, int flags, long sessionId ) {
+        if ( nonce.length != 16 ) {
+            throw new IllegalArgumentException("Nonce must be 16 bytes");
+        }
+        System.arraycopy(nonce, 0, this.nonce, 0, 16);
+        this.originalMessageSize = originalMessageSize;
+        this.flags = flags;
+        this.sessionId = sessionId;
+    }
+
+
+    /**
+     * @return the signature/authentication tag
+     */
+    public byte[] getSignature () {
+        return this.signature;
+    }
+
+
+    /**
+     * @param signature
+     *            the signature/authentication tag to set
+     */
+    public void setSignature ( byte[] signature ) {
+        if ( signature.length != 16 ) {
+            throw new IllegalArgumentException("Signature must be 16 bytes");
+        }
+        System.arraycopy(signature, 0, this.signature, 0, 16);
+    }
+
+
+    /**
+     * @return the nonce
+     */
+    public byte[] getNonce () {
+        return this.nonce;
+    }
+
+
+    /**
+     * @param nonce
+     *            the nonce to set
+     */
+    public void setNonce ( byte[] nonce ) {
+        if ( nonce.length != 16 ) {
+            throw new IllegalArgumentException("Nonce must be 16 bytes");
+        }
+        System.arraycopy(nonce, 0, this.nonce, 0, 16);
+    }
+
+
+    /**
+     * @return the original message size
+     */
+    public int getOriginalMessageSize () {
+        return this.originalMessageSize;
+    }
+
+
+    /**
+     * @param originalMessageSize
+     *            the original message size to set
+     */
+    public void setOriginalMessageSize ( int originalMessageSize ) {
+        this.originalMessageSize = originalMessageSize;
+    }
+
+
+    /**
+     * @return the flags (SMB 3.1.1) or encryption algorithm (SMB 3.0/3.0.2)
+     */
+    public int getFlags () {
+        return this.flags;
+    }
+
+
+    /**
+     * @param flags
+     *            the flags to set
+     */
+    public void setFlags ( int flags ) {
+        this.flags = flags;
+    }
+
+
+    /**
+     * @return the session ID
+     */
+    public long getSessionId () {
+        return this.sessionId;
+    }
+
+
+    /**
+     * @param sessionId
+     *            the session ID to set
+     */
+    public void setSessionId ( long sessionId ) {
+        this.sessionId = sessionId;
+    }
+
+
+    @Override
+    public int size () {
+        return TRANSFORM_HEADER_SIZE;
+    }
+
+
+    @Override
+    public int encode ( byte[] dst, int dstIndex ) {
+        int start = dstIndex;
+
+        // Protocol ID
+        SMBUtil.writeInt4(TRANSFORM_PROTOCOL_ID, dst, dstIndex);
+        dstIndex += 4;
+
+        // Signature (16 bytes)
+        System.arraycopy(this.signature, 0, dst, dstIndex, 16);
+        dstIndex += 16;
+
+        // Nonce (16 bytes)
+        System.arraycopy(this.nonce, 0, dst, dstIndex, 16);
+        dstIndex += 16;
+
+        // Original message size
+        SMBUtil.writeInt4(this.originalMessageSize, dst, dstIndex);
+        dstIndex += 4;
+
+        // Reserved (2 bytes)
+        SMBUtil.writeInt2(0, dst, dstIndex);
+        dstIndex += 2;
+
+        // Flags (2 bytes)
+        SMBUtil.writeInt2(this.flags, dst, dstIndex);
+        dstIndex += 2;
+
+        // Session ID (8 bytes)
+        SMBUtil.writeInt8(this.sessionId, dst, dstIndex);
+        dstIndex += 8;
+
+        return dstIndex - start;
+    }
+
+
+    /**
+     * Decode a transform header from byte array
+     * 
+     * @param buffer
+     *            buffer to decode from
+     * @param bufferIndex
+     *            offset in buffer
+     * @return new transform header instance
+     */
+    public static Smb2TransformHeader decode ( byte[] buffer, int bufferIndex ) {
+        Smb2TransformHeader header = new Smb2TransformHeader();
+
+        // Check protocol ID
+        int protocolId = SMBUtil.readInt4(buffer, bufferIndex);
+        if ( protocolId != TRANSFORM_PROTOCOL_ID ) {
+            throw new IllegalArgumentException("Invalid transform header protocol ID: 0x" + Integer.toHexString(protocolId));
+        }
+        bufferIndex += 4;
+
+        // Read signature
+        System.arraycopy(buffer, bufferIndex, header.signature, 0, 16);
+        bufferIndex += 16;
+
+        // Read nonce
+        System.arraycopy(buffer, bufferIndex, header.nonce, 0, 16);
+        bufferIndex += 16;
+
+        // Read original message size
+        header.originalMessageSize = SMBUtil.readInt4(buffer, bufferIndex);
+        bufferIndex += 4;
+
+        // Skip reserved (2 bytes)
+        bufferIndex += 2;
+
+        // Read flags
+        header.flags = SMBUtil.readInt2(buffer, bufferIndex);
+        bufferIndex += 2;
+
+        // Read session ID
+        header.sessionId = SMBUtil.readInt8(buffer, bufferIndex);
+
+        return header;
+    }
+
+
+    /**
+     * Get the associated data for AEAD encryption (everything except signature)
+     * 
+     * @return byte array containing associated data
+     */
+    public byte[] getAssociatedData () {
+        byte[] aad = new byte[36]; // Total header size minus signature
+        int index = 0;
+
+        // Protocol ID
+        SMBUtil.writeInt4(TRANSFORM_PROTOCOL_ID, aad, index);
+        index += 4;
+
+        // Skip signature (16 bytes of zeros for AAD)
+        index += 16;
+
+        // Nonce
+        System.arraycopy(this.nonce, 0, aad, index, 16);
+        index += 16;
+
+        // Original message size
+        SMBUtil.writeInt4(this.originalMessageSize, aad, index);
+        index += 4;
+
+        // Reserved
+        SMBUtil.writeInt2(0, aad, index);
+        index += 2;
+
+        // Flags
+        SMBUtil.writeInt2(this.flags, aad, index);
+        index += 2;
+
+        // Session ID
+        SMBUtil.writeInt8(this.sessionId, aad, index);
+
+        return aad;
+    }
+}

--- a/src/main/java/jcifs/internal/smb2/Smb3KeyDerivation.java
+++ b/src/main/java/jcifs/internal/smb2/Smb3KeyDerivation.java
@@ -33,7 +33,7 @@ import org.bouncycastle.crypto.params.KDFCounterParameters;
  * @author mbechler
  *
  */
-final class Smb3KeyDerivation {
+public final class Smb3KeyDerivation {
 
     private static final byte[] SIGNCONTEXT_300 = toCBytes("SmbSign");
     private static final byte[] SIGNLABEL_300 = toCBytes("SMB2AESCMAC");

--- a/src/test/java/jcifs/tests/ContextConfigTest.java
+++ b/src/test/java/jcifs/tests/ContextConfigTest.java
@@ -149,7 +149,8 @@ public class ContextConfigTest {
         prop1.setProperty("jcifs.smb.client.minVersion", "SMB302");
         PropertyConfiguration p1 = new PropertyConfiguration(prop1);
         assertEquals(DialectVersion.SMB302, p1.getMinimumVersion());
-        assertEquals(DialectVersion.SMB302, p1.getMaximumVersion());
+        // maxVersion defaults to SMB311, which is >= SMB302
+        assertEquals(DialectVersion.SMB311, p1.getMaximumVersion());
 
         Properties prop2 = new Properties();
         prop2.setProperty("jcifs.smb.client.maxVersion", "SMB302");
@@ -163,8 +164,8 @@ public class ContextConfigTest {
         PropertyConfiguration p3 = new PropertyConfiguration(prop3);
         assertEquals(DialectVersion.SMB202, p3.getMinimumVersion());
 
-        // needs to be adjusted when default changes
-        assertEquals(DialectVersion.SMB210, p3.getMaximumVersion());
+        // needs to be adjusted when default changes - updated for SMB3 support
+        assertEquals(DialectVersion.SMB311, p3.getMaximumVersion());
 
     }
 
@@ -186,8 +187,8 @@ public class ContextConfigTest {
         PropertyConfiguration p2 = new PropertyConfiguration(prop2);
 
         assertEquals(DialectVersion.SMB1, p2.getMinimumVersion());
-        // needs to be adjusted when default changes
-        assertEquals(DialectVersion.SMB210, p2.getMaximumVersion());
+        // needs to be adjusted when default changes - updated for SMB3 support
+        assertEquals(DialectVersion.SMB311, p2.getMaximumVersion());
 
         Properties prop3 = new Properties();
         prop3.setProperty("jcifs.smb.client.enableSMB2", "true");


### PR DESCRIPTION
This pull request introduces significant enhancements to the SMB (Server Message Block) protocol implementation, focusing on adding support for encryption in SMB2/SMB3 sessions and updating the default protocol version. The most important changes include introducing the `Smb2EncryptionContext` class to handle encryption and decryption, integrating encryption support into the `SmbSessionImpl` class, and updating the default maximum protocol version to SMB 3.1.1.

### Encryption Support Enhancements:

* **New `Smb2EncryptionContext` class**: Implements encryption and decryption for SMB2/SMB3 sessions, supporting AES-CCM and AES-GCM cipher suites. It includes methods for generating nonces, encrypting, and decrypting messages, as well as managing cryptographic parameters. (`src/main/java/jcifs/internal/smb2/Smb2EncryptionContext.java`)

* **Integration into `SmbSessionImpl`**:
  - Added an `encryptionContext` field to manage session-level encryption.
  - Introduced methods to check if encryption is enabled (`isEncryptionEnabled`) and to encrypt/decrypt messages (`encryptMessage`, `decryptMessage`).
  - Updated session setup to create an encryption context if the server requires encryption. (`src/main/java/jcifs/smb/SmbSessionImpl.java`) [[1]](diffhunk://#diff-08d10da1f15b0d9f3a0bf2e04c4f7676e23d5155c04cc580e511534ec5dcc361R106) [[2]](diffhunk://#diff-08d10da1f15b0d9f3a0bf2e04c4f7676e23d5155c04cc580e511534ec5dcc361L587-R600) [[3]](diffhunk://#diff-08d10da1f15b0d9f3a0bf2e04c4f7676e23d5155c04cc580e511534ec5dcc361R1318-R1363)

### Protocol Version Update:

* **Default maximum protocol version**: Updated the default maximum protocol version from SMB 2.1 (SMB210) to SMB 3.1.1 (SMB311) to support modern SMB features, including encryption. (`src/main/java/jcifs/config/BaseConfiguration.java`)

### Supporting Changes:

* **`Smb2TransformHeader` class**: Added to define the SMB2 transform header used for encrypted messages. It manages cryptographic parameters such as nonce, session ID, and authentication tags. (`src/main/java/jcifs/internal/smb2/Smb2TransformHeader.java`)

* **`Smb3KeyDerivation` visibility**: Changed the `Smb3KeyDerivation` class from `final` to `public final` to allow broader access for encryption-related operations. (`src/main/java/jcifs/internal/smb2/Smb3KeyDerivation.java`)