### PR TITLE
Refactor and enhance Javadoc comments across SMB classes

### DIFF
--- a/src/main/java/jcifs/internal/SmbNegotiationResponse.java
+++ b/src/main/java/jcifs/internal/SmbNegotiationResponse.java
@@ -30,10 +30,10 @@ import jcifs.util.transport.Response;
 public interface SmbNegotiationResponse extends CommonServerMessageBlock, Response {
 
     /**
+     * Check if the negotiation response is valid
      * 
-     * @param cifsContext
-     * @param singingEnforced
-     * @param request
+     * @param cifsContext the CIFS context
+     * @param request the negotiation request
      * @return whether the protocol negotiation was successful
      */
     boolean isValid ( CIFSContext cifsContext, SmbNegotiationRequest request );

--- a/src/main/java/jcifs/internal/smb2/ServerMessageBlock2.java
+++ b/src/main/java/jcifs/internal/smb2/ServerMessageBlock2.java
@@ -610,10 +610,12 @@ public abstract class ServerMessageBlock2 implements CommonServerMessageBlock {
 
 
     /**
-     * @param buffer
-     * @param bufferIndex
-     * @return
-     * @throws Smb2ProtocolDecodingException
+     * Read error response from buffer
+     * 
+     * @param buffer the buffer to read from
+     * @param bufferIndex the starting index in the buffer
+     * @return the number of bytes read
+     * @throws SMBProtocolDecodingException if decoding fails
      */
     protected int readErrorResponse ( byte[] buffer, int bufferIndex ) throws SMBProtocolDecodingException {
         int start = bufferIndex;

--- a/src/main/java/jcifs/internal/smb2/ServerMessageBlock2Request.java
+++ b/src/main/java/jcifs/internal/smb2/ServerMessageBlock2Request.java
@@ -239,8 +239,11 @@ public abstract class ServerMessageBlock2Request <T extends ServerMessageBlock2R
 
 
     /**
-     * @param config2
-     * @return
+     * Create the response object for this request
+     * 
+     * @param tc the CIFS context
+     * @param req the request object
+     * @return the response object
      */
     protected abstract T createResponse ( CIFSContext tc, ServerMessageBlock2Request<T> req );
 

--- a/src/main/java/jcifs/internal/smb2/create/Smb2CloseRequest.java
+++ b/src/main/java/jcifs/internal/smb2/create/Smb2CloseRequest.java
@@ -88,8 +88,8 @@ public class Smb2CloseRequest extends ServerMessageBlock2Request<Smb2CloseRespon
     /**
      * {@inheritDoc}
      *
-     * @see jcifs.internal.smb2.ServerMessageBlock2#createResponse(jcifs.Configuration,
-     *      jcifs.internal.smb2.ServerMessageBlock2)
+     * @see jcifs.internal.smb2.ServerMessageBlock2Request#createResponse(jcifs.CIFSContext,
+     *      jcifs.internal.smb2.ServerMessageBlock2Request)
      */
     @Override
     protected Smb2CloseResponse createResponse ( CIFSContext tc, ServerMessageBlock2Request<Smb2CloseResponse> req ) {

--- a/src/main/java/jcifs/internal/smb2/create/Smb2CreateResponse.java
+++ b/src/main/java/jcifs/internal/smb2/create/Smb2CreateResponse.java
@@ -234,7 +234,7 @@ public class Smb2CreateResponse extends ServerMessageBlock2Response implements S
     /**
      * {@inheritDoc}
      * 
-     * @throws Smb2ProtocolDecodingException
+     * @throws SMBProtocolDecodingException
      *
      * @see jcifs.internal.smb2.ServerMessageBlock2#readBytesWireFormat(byte[], int)
      */

--- a/src/main/java/jcifs/internal/smb2/nego/Smb2NegotiateRequest.java
+++ b/src/main/java/jcifs/internal/smb2/nego/Smb2NegotiateRequest.java
@@ -152,7 +152,7 @@ public class Smb2NegotiateRequest extends ServerMessageBlock2Request<Smb2Negotia
     /**
      * {@inheritDoc}
      *
-     * @see jcifs.internal.smb2.ServerMessageBlock2Request#createResponse(jcifs.Configuration,
+     * @see jcifs.internal.smb2.ServerMessageBlock2Request#createResponse(jcifs.CIFSContext,
      *      jcifs.internal.smb2.ServerMessageBlock2Request)
      */
     @Override

--- a/src/main/java/jcifs/internal/smb2/session/Smb2LogoffResponse.java
+++ b/src/main/java/jcifs/internal/smb2/session/Smb2LogoffResponse.java
@@ -52,7 +52,7 @@ public class Smb2LogoffResponse extends ServerMessageBlock2Response {
     /**
      * {@inheritDoc}
      * 
-     * @throws Smb2ProtocolDecodingException
+     * @throws SMBProtocolDecodingException
      *
      * @see jcifs.internal.smb2.ServerMessageBlock2#readBytesWireFormat(byte[], int)
      */

--- a/src/main/java/jcifs/internal/smb2/session/Smb2SessionSetupResponse.java
+++ b/src/main/java/jcifs/internal/smb2/session/Smb2SessionSetupResponse.java
@@ -98,7 +98,7 @@ public class Smb2SessionSetupResponse extends ServerMessageBlock2Response {
     /**
      * {@inheritDoc}
      * 
-     * @throws Smb2ProtocolDecodingException
+     * @throws SMBProtocolDecodingException
      *
      * @see jcifs.internal.smb2.ServerMessageBlock2#readBytesWireFormat(byte[], int)
      */

--- a/src/main/java/jcifs/internal/smb2/tree/Smb2TreeConnectResponse.java
+++ b/src/main/java/jcifs/internal/smb2/tree/Smb2TreeConnectResponse.java
@@ -240,7 +240,7 @@ public class Smb2TreeConnectResponse extends ServerMessageBlock2Response impleme
     /**
      * {@inheritDoc}
      * 
-     * @throws Smb2ProtocolDecodingException
+     * @throws SMBProtocolDecodingException
      *
      * @see jcifs.internal.smb2.ServerMessageBlock2#readBytesWireFormat(byte[], int)
      */

--- a/src/main/java/jcifs/internal/smb2/tree/Smb2TreeDisconnectResponse.java
+++ b/src/main/java/jcifs/internal/smb2/tree/Smb2TreeDisconnectResponse.java
@@ -52,7 +52,7 @@ public class Smb2TreeDisconnectResponse extends ServerMessageBlock2Response {
     /**
      * {@inheritDoc}
      * 
-     * @throws Smb2ProtocolDecodingException
+     * @throws SMBProtocolDecodingException
      *
      * @see jcifs.internal.smb2.ServerMessageBlock2#readBytesWireFormat(byte[], int)
      */

--- a/src/main/java/jcifs/netbios/NameServiceClientImpl.java
+++ b/src/main/java/jcifs/netbios/NameServiceClientImpl.java
@@ -778,8 +778,8 @@ public class NameServiceClientImpl implements Runnable, NameServiceClient {
 
 
     /**
+     * Get the address of the active WINS server
      * 
-     * @param tc
      * @return address of active WINS server
      */
     protected InetAddress getWINSAddress () {

--- a/src/main/java/jcifs/smb/DfsReferral.java
+++ b/src/main/java/jcifs/smb/DfsReferral.java
@@ -40,7 +40,7 @@ public class DfsReferral extends SmbException {
 
 
     /**
-     * @param dr
+     * @param data the DFS referral data
      */
     public DfsReferral ( DfsReferralData data ) {
         this.data = data;

--- a/src/main/java/jcifs/smb/DirFileEntryEnumIterator2.java
+++ b/src/main/java/jcifs/smb/DirFileEntryEnumIterator2.java
@@ -74,11 +74,10 @@ public class DirFileEntryEnumIterator2 extends DirFileEntryEnumIteratorBase {
 
 
     /**
-     * @param th
-     * @param parent
-     * @param wildcard
-     * @return
-     * @throws CIFSException
+     * Opens a directory for enumeration
+     * 
+     * @return the opened directory file entry
+     * @throws CIFSException if an error occurs opening the directory
      */
     @SuppressWarnings ( "resource" )
     @Override

--- a/src/main/java/jcifs/smb/SmbPipeHandleInternal.java
+++ b/src/main/java/jcifs/smb/SmbPipeHandleInternal.java
@@ -79,23 +79,24 @@ public interface SmbPipeHandleInternal extends SmbPipeHandle {
 
 
     /**
-     * @param buf
-     * @param off
-     * @param length
-     * @param direct
-     * @return received bytes
-     * @throws CIFSException
-     * @throws IOException
+     * Receive data from the pipe
+     * 
+     * @param buf buffer to receive data into
+     * @param off offset in the buffer
+     * @param length maximum length to receive
+     * @return number of bytes received
+     * @throws IOException if an I/O error occurs
      */
     int recv ( byte[] buf, int off, int length ) throws IOException;
 
 
     /**
-     * @param buf
-     * @param off
-     * @param length
-     * @param direct
-     * @throws IOException
+     * Send data to the pipe
+     * 
+     * @param buf buffer containing data to send
+     * @param off offset in the buffer
+     * @param length length of data to send
+     * @throws IOException if an I/O error occurs
      */
     void send ( byte[] buf, int off, int length ) throws IOException;
 

--- a/src/main/java/jcifs/smb1/netbios/NbtAddress.java
+++ b/src/main/java/jcifs/smb1/netbios/NbtAddress.java
@@ -54,12 +54,12 @@ import jcifs.smb1.util.Hexdump;
  * 
  *    Name               Type         Status
  * ---------------------------------------------
- * JMORRIS2        <00>  UNIQUE      Registered
- * BILLING-NY      <00>  GROUP       Registered
- * JMORRIS2        <03>  UNIQUE      Registered
- * JMORRIS2        <20>  UNIQUE      Registered
- * BILLING-NY      <1E>  GROUP       Registered
- * JMORRIS         <03>  UNIQUE      Registered
+ * JMORRIS2        &lt;00&gt;  UNIQUE      Registered
+ * BILLING-NY      &lt;00&gt;  GROUP       Registered
+ * JMORRIS2        &lt;03&gt;  UNIQUE      Registered
+ * JMORRIS2        &lt;20&gt;  UNIQUE      Registered
+ * BILLING-NY      &lt;1E&gt;  GROUP       Registered
+ * JMORRIS         &lt;03&gt;  UNIQUE      Registered
  * 
  * MAC Address = 00-B0-34-21-FA-3B
  * </blockquote></pre>

--- a/src/main/java/jcifs/smb1/smb1/SmbFile.java
+++ b/src/main/java/jcifs/smb1/smb1/SmbFile.java
@@ -2663,7 +2663,7 @@ if (this instanceof SmbNamedPipe) {
 
 /**
  * Turn off the read-only attribute of this file. This is shorthand for
- * <tt>setAttributes( getAttributes() & ~ATTR_READONLY )</tt>.
+ * <tt>setAttributes( getAttributes() &amp; ~ATTR_READONLY )</tt>.
  *
  * @throws SmbException
  */
@@ -2928,7 +2928,7 @@ if (this instanceof SmbNamedPipe) {
  * share. There are actually two different ACLs for shares - the ACL on
  * the share and the ACL on the folder being shared.
  * Go to <i>Computer Management</i>
- * &gt; <i>System Tools</i> &gt; <i>Shared Folders</i> &gt <i>Shares</i> and
+ * &gt; <i>System Tools</i> &gt; <i>Shared Folders</i> &gt; <i>Shares</i> and
  * look at the <i>Properties</i> for a share. You will see two tabs - one
  * for "Share Permissions" and another for "Security". These correspond to
  * the ACLs returned by <tt>getShareSecurity</tt> and <tt>getSecurity</tt>


### PR DESCRIPTION
This PR cleans up and enriches Javadoc documentation in several core classes, improving parameter descriptions, exception tag accuracy, and HTML formatting. Key updates include:

- SmbNegotiationResponse: Added descriptive text and clarified `@param` tags for cifsContext and request.
- ServerMessageBlock2 & ServerMessageBlock2Request: Improved method summaries, parameter names, and updated exception types (SMBProtocolDecodingException).
- Smb2CloseRequest, Smb2CreateResponse, Smb2LogoffResponse, Smb2SessionSetupResponse, Smb2TreeConnectResponse, Smb2TreeDisconnectResponse, Smb2NegotiateRequest: Aligned `@see` references to ServerMessageBlock2Request and CIFSContext.
- NameServiceClientImpl: Documented return value meaning for getWINSAddress().
- DfsReferral: Named the `@param` for clarity.
- DirFileEntryEnumIterator2: Provided high-level summary and consolidated `@throws`.
- SmbPipeHandleInternal: Rewrote recv/send comments to describe parameters, return values, and exceptions uniformly.
- NbtAddress: Escaped HTML in example block (<00> → &lt;00&gt;).
- SmbFile: Fixed HTML escaping in inline code examples.

These documentation enhancements improve readability, ensure consistency, and make the API contract clearer for maintainers and users.