### PR TITLE
Migrate from javax.servlet to jakarta.servlet and bump version to 3.0.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs</groupId>
 	<artifactId>jcifs</artifactId>
-	<version>2.2.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>jCIFS</name>
 	<url>https://github.com/codelibs/jcifs</url>
@@ -92,7 +92,7 @@
 						</Export-Package>
 						<Private-Package />
 						<Import-Package>
-							javax.servlet*;resolution:=optional,
+							jakarta.servlet*;resolution:=optional,
 							com.sun.security.jgss;resolution:=optional,
 							org.bouncycastle*;version="1.63",
 							!jcifs.internal*,
@@ -297,15 +297,15 @@
 	</build>
 	<dependencies>
 		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>javax.servlet-api</artifactId>
-			<version>4.0.1</version>
+			<groupId>jakarta.servlet</groupId>
+			<artifactId>jakarta.servlet-api</artifactId>
+			<version>5.0.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>javax.annotation</groupId>
-			<artifactId>javax.annotation-api</artifactId>
-			<version>1.3.2</version>
+			<groupId>jakarta.annotation</groupId>
+			<artifactId>jakarta.annotation-api</artifactId>
+			<version>2.1.1</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/jcifs/http/NetworkExplorer.java
+++ b/src/main/java/jcifs/http/NetworkExplorer.java
@@ -32,12 +32,12 @@ import java.util.LinkedList;
 import java.util.ListIterator;
 import java.util.Properties;
 
-import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
 import org.bouncycastle.util.encoders.Base64;
 import org.slf4j.Logger;

--- a/src/main/java/jcifs/http/NtlmHttpFilter.java
+++ b/src/main/java/jcifs/http/NtlmHttpFilter.java
@@ -28,15 +28,15 @@ import java.net.UnknownHostException;
 import java.util.Enumeration;
 import java.util.Properties;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
 import org.bouncycastle.util.encoders.Base64;
 import org.slf4j.Logger;

--- a/src/main/java/jcifs/http/NtlmHttpServletRequest.java
+++ b/src/main/java/jcifs/http/NtlmHttpServletRequest.java
@@ -22,8 +22,8 @@ package jcifs.http;
 
 import java.security.Principal;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
 
 
 class NtlmHttpServletRequest extends HttpServletRequestWrapper {

--- a/src/main/java/jcifs/http/NtlmServlet.java
+++ b/src/main/java/jcifs/http/NtlmServlet.java
@@ -24,12 +24,12 @@ import java.io.IOException;
 import java.util.Enumeration;
 import java.util.Properties;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
 import org.bouncycastle.util.encoders.Base64;
 

--- a/src/main/java/jcifs/http/NtlmSsp.java
+++ b/src/main/java/jcifs/http/NtlmSsp.java
@@ -24,8 +24,8 @@ package jcifs.http;
 
 import java.io.IOException;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.bouncycastle.util.encoders.Base64;
 

--- a/src/main/java/jcifs/smb1/http/NetworkExplorer.java
+++ b/src/main/java/jcifs/smb1/http/NetworkExplorer.java
@@ -19,8 +19,8 @@
 package jcifs.smb1.http;
 
 import java.io.*;
-import javax.servlet.*;
-import javax.servlet.http.*;
+import jakarta.servlet.*;
+import jakarta.servlet.http.*;
 
 import jcifs.smb1.*;
 import jcifs.smb1.http.*;

--- a/src/main/java/jcifs/smb1/http/NtlmHttpFilter.java
+++ b/src/main/java/jcifs/smb1/http/NtlmHttpFilter.java
@@ -25,8 +25,8 @@ package jcifs.smb1.http;
 import java.io.*;
 import java.util.Enumeration;
 import java.net.UnknownHostException;
-import javax.servlet.*;
-import javax.servlet.http.*;
+import jakarta.servlet.*;
+import jakarta.servlet.http.*;
 
 import jcifs.smb1.*;
 import jcifs.smb1.netbios.NbtAddress;

--- a/src/main/java/jcifs/smb1/http/NtlmHttpServletRequest.java
+++ b/src/main/java/jcifs/smb1/http/NtlmHttpServletRequest.java
@@ -20,8 +20,8 @@
 package jcifs.smb1.http;
 
 import java.security.Principal;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
 
 class NtlmHttpServletRequest extends HttpServletRequestWrapper {
 

--- a/src/main/java/jcifs/smb1/http/NtlmServlet.java
+++ b/src/main/java/jcifs/smb1/http/NtlmServlet.java
@@ -25,11 +25,11 @@ import java.net.UnknownHostException;
 
 import java.util.Enumeration;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
-import javax.servlet.UnavailableException;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.UnavailableException;
 
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpSession;
 
 import jcifs.smb1.Config;
 import jcifs.smb1.UniAddress;
@@ -39,9 +39,9 @@ import jcifs.smb1.smb1.SmbAuthException;
 import jcifs.smb1.smb1.SmbSession;
 import jcifs.smb1.util.Base64;
 
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * This servlet may be used with pre-2.3 servlet containers

--- a/src/main/java/jcifs/smb1/http/NtlmSsp.java
+++ b/src/main/java/jcifs/smb1/http/NtlmSsp.java
@@ -23,10 +23,10 @@ package jcifs.smb1.http;
 
 import java.io.IOException;
 
-import javax.servlet.ServletException;
+import jakarta.servlet.ServletException;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import jcifs.smb1.ntlmssp.NtlmFlags;
 import jcifs.smb1.ntlmssp.Type1Message;

--- a/src/test/java/jcifs/http/NetworkExplorerTest.java
+++ b/src/test/java/jcifs/http/NetworkExplorerTest.java
@@ -23,14 +23,14 @@ import java.io.StringWriter;
 import java.util.Collections;
 import java.util.Vector;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.WriteListener;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/jcifs/http/NtlmHttpFilterTest.java
+++ b/src/test/java/jcifs/http/NtlmHttpFilterTest.java
@@ -16,15 +16,15 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/jcifs/http/NtlmHttpServletRequestTest.java
+++ b/src/test/java/jcifs/http/NtlmHttpServletRequestTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.when;
 
 import java.security.Principal;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/jcifs/http/NtlmServletTest.java
+++ b/src/test/java/jcifs/http/NtlmServletTest.java
@@ -17,11 +17,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/jcifs/http/NtlmSspTest.java
+++ b/src/test/java/jcifs/http/NtlmSspTest.java
@@ -15,8 +15,8 @@ import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.Base64;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/jcifs/smb1/http/NtlmHttpServletRequestTest.java
+++ b/src/test/java/jcifs/smb1/http/NtlmHttpServletRequestTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.when;
 
 import java.security.Principal;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
This update migrates all servlet-related imports from the legacy javax.servlet namespace to the modern jakarta.servlet namespace, ensuring compatibility with Jakarta EE 9+ specifications.
Additional changes include:

- Updated pom.xml dependencies from javax.servlet-api (4.0.1) to jakarta.servlet-api (5.0.0) and from javax.annotation-api (1.3.2) to jakarta.annotation-api (2.1.1).
- Changed OSGi Import-Package entries to use jakarta.servlet*.
- Incremented project version from 2.2.0-SNAPSHOT to 3.0.0-SNAPSHOT to reflect breaking changes.
- Updated all affected Java source files and corresponding test classes.