### PR TITLE
Exclude test directory from Apache RAT license check in Maven configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,6 +251,7 @@
 						<exclude>src/main/java/jcifs/dcerpc/msrpc/lsarpc.java</exclude>
 						<exclude>src/main/java/jcifs/dcerpc/rpc.java</exclude>
 						<exclude>src/main/java/jcifs/smb1/**</exclude>
+						<exclude>src/test/java/**</exclude>
 					</excludes>
 					<licenses>
 						<license implementation="org.apache.rat.analysis.license.SimplePatternBasedLicense">


### PR DESCRIPTION
This update modifies the pom.xml configuration for the Apache RAT plugin by adding an exclusion for the src/test/java/** directory.
This change ensures that test source files are not included in license compliance checks, which helps avoid unnecessary build warnings or failures due to missing license headers in test code.