### PR TITLE
Update README with SMB3 features, Java 17 requirement, and usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,20 @@ JCIFS
 
 JCIFS is an Open Source client library that implements the CIFS/SMB networking protocol in 100% Java.
 From version 2.x, this project is forked from [jcifs-ng](https://github.com/AgNO3/jcifs-ng) and existing jcifs code is merged as `smb1`.
+Version 3.x introduces SMB3 encryption and enhanced security features, while maintaining backward compatibility with legacy SMB devices.
 
 ## Version
 
 [Versions in Maven Repository](https://repo1.maven.org/maven2/org/codelibs/jcifs/)
 
+## Requirements
+
+- Java 17 or higher (upgraded from Java 8)
+- SLF4J for logging
+
 ## Using Maven
 
-```
+```xml
 <dependency>
     <groupId>org.codelibs</groupId>
     <artifactId>jcifs</artifactId>
@@ -19,28 +25,117 @@ From version 2.x, this project is forked from [jcifs-ng](https://github.com/AgNO
 </dependency>
 ```
 
-## Changes
+For the latest version with SMB3 support (coming soon):
+```xml
+<dependency>
+    <groupId>org.codelibs</groupId>
+    <artifactId>jcifs</artifactId>
+    <version>3.0.0</version>
+</dependency>
+```
 
- * SMB2 (2.02 protocol level) support, some SMB3 support
- * Remove global state
- * Allow per context configuration
- * Logging through SLF4J
- * Drop pre-java 1.7 support
- * Unify authentication subsystem, NTLMSSP/Kerberos support
- * Large ReadX/WriteX support
- * Streaming list operations
- * NtTransNotifyChange support
- * Google patches: various bugfixes, lastAccess support, retrying requests
- * A proper test suite
- * Various fixes
+## Features
+
+### Protocol Support
+ * **SMB1/CIFS**: Legacy protocol support for older devices
+ * **SMB2**: Full SMB 2.0.2, 2.1 support
+ * **SMB3**: SMB 3.0, 3.0.2, 3.1.1 security features with:
+   - AES-128-CCM encryption (SMB 3.0/3.0.2)
+   - AES-128-GCM encryption (SMB 3.1.1)
+   - Pre-Authentication Integrity (SMB 3.1.1)
+   - Automatic protocol negotiation
+   - Transparent encryption when required by server
+
+### Core Features
+ * Per-context configuration (no global state)
+ * SLF4J logging framework
+ * Unified authentication: NTLMSSP, Kerberos, SPNEGO
+ * Large file transfer support (ReadX/WriteX)
+ * Streaming operations for directory listings
+ * DFS (Distributed File System) support
+ * NtTransNotifyChange support for file monitoring
+ * Comprehensive test suite with JUnit 4
+
+### Recent Improvements (v3.x)
+ * Java 17 minimum requirement
+ * Jakarta Servlet namespace migration
+ * SMB3 encryption (AES-CCM/GCM) and signing (AES-CMAC) implementation
+ * Enhanced protocol negotiation
+ * Improved thread safety
+ * Better resource management with AutoCloseable patterns
+
+### Known Limitations
+ * SMB3 advanced features not yet implemented:
+   - Multi-channel support
+   - Persistent handles
+   - Directory leasing
+   - RDMA transport
+ * Uses traditional oplocks instead of SMB3 leases
+
+## Quick Start
+
+### Basic Usage
+
+```java
+import jcifs.CIFSContext;
+import jcifs.context.SingletonContext;
+import jcifs.smb.SmbFile;
+
+// Using default context
+CIFSContext context = SingletonContext.getInstance();
+
+// Access a file
+try (SmbFile file = new SmbFile("smb://server/share/file.txt", context)) {
+    if (file.exists()) {
+        System.out.println("File size: " + file.length());
+    }
+}
+```
+
+### With Authentication
+
+```java
+import jcifs.CIFSContext;
+import jcifs.context.BaseContext;
+import jcifs.smb.NtlmPasswordAuthenticator;
+
+// Create context with credentials
+CIFSContext context = new BaseContext(new jcifs.config.PropertyConfiguration());
+NtlmPasswordAuthenticator auth = new NtlmPasswordAuthenticator("domain", "username", "password");
+CIFSContext authContext = context.withCredentials(auth);
+
+// Use authenticated context
+try (SmbFile file = new SmbFile("smb://server/share/", authContext)) {
+    for (SmbFile f : file.listFiles()) {
+        System.out.println(f.getName());
+    }
+}
+```
 
 ## Others
 
-### This jcifs or jcifs-ng
+### Choosing Between This JCIFS and jcifs-ng
 
-jcifs-ng will be a proper choice for many users. 
-There are a lot of SMB devices in the world.
-Some of them only work with the old jcifs library.
-If you want to support many SMB devices, CodeLibs jcifs library will be helpful.
-For example, since [Fess](https://github.com/codelibs/fess) needs to support many SMB devices, it uses this library.
-However, if you have only a specific SMB device, you should use jcifs-ng library.
+**Use CodeLibs JCIFS when:**
+- You need maximum compatibility with legacy SMB devices
+- You require SMB3 encryption and security features (AES-CCM/GCM, AES-CMAC)
+- You need to support a wide variety of SMB implementations
+- Your application (like [Fess](https://github.com/codelibs/fess)) needs to connect to many different SMB devices
+
+**Use jcifs-ng when:**
+- You only need to connect to modern SMB servers
+- You don't require SMB3 encryption features
+- You have a controlled environment with specific SMB devices
+
+### Contributing
+
+We welcome contributions! Please:
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes with appropriate tests
+4. Run `mvn clean test` to ensure all tests pass
+5. Submit a pull request
+
+### License
+
+JCIFS is licensed under the GNU Lesser General Public License (LGPL). See the LICENSE file for details.

--- a/docs/SMB3_IMPLEMENTATION_PLAN.md
+++ b/docs/SMB3_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,325 @@
+# SMB3 Advanced Features Implementation Plan
+
+## Overview
+This document outlines the implementation plan for advanced SMB3 features that are currently not implemented in JCIFS. These features are essential for enterprise-grade SMB3 support, providing enhanced performance, reliability, and scalability.
+
+## Implementation Phases
+
+### Phase 1: SMB3 Lease Implementation (Foundation)
+**Priority: HIGH** | **Estimated Effort: 3-4 weeks**
+
+SMB3 leases replace the traditional oplock mechanism and are foundational for other features.
+
+#### 1.1 Core Lease Infrastructure
+```
+Package: jcifs.internal.smb2.lease
+├── Smb2LeaseBreak.java          - Lease break notification handling
+├── Smb2LeaseContext.java        - Lease context for create requests
+├── Smb2LeaseKey.java            - 16-byte lease key management
+├── Smb2LeaseState.java          - Lease state flags (R, H, W)
+└── LeaseManager.java            - Central lease management
+```
+
+#### 1.2 Implementation Tasks
+- [ ] Define lease state constants (SMB2_LEASE_READ, SMB2_LEASE_HANDLE, SMB2_LEASE_WRITE)
+- [ ] Implement lease key generation and management
+- [ ] Add lease context to Create request/response
+- [ ] Implement lease break notification handling
+- [ ] Modify SmbFile to support lease-based caching
+- [ ] Add lease upgrade/downgrade logic
+- [ ] Implement lease epoch tracking for v2 leases
+
+#### 1.3 Integration Points
+- Modify `Smb2CreateRequest` to include lease contexts
+- Update `SmbFile` caching logic to use leases
+- Add lease break handling in `SmbTransport`
+
+---
+
+### Phase 2: Persistent Handles
+**Priority: HIGH** | **Estimated Effort: 4-5 weeks**
+
+Persistent handles allow connections to survive network interruptions and server failovers.
+
+#### 2.1 Core Persistent Handle Infrastructure
+```
+Package: jcifs.internal.smb2.persistent
+├── PersistentHandleContext.java     - Persistent handle create context
+├── PersistentHandleManager.java     - Handle persistence management
+├── DurableHandleRequest.java        - Durable handle v1 support
+├── DurableHandleV2Request.java      - Durable handle v2 with timeout
+└── HandleReconnector.java           - Automatic handle reconnection
+```
+
+#### 2.2 Implementation Tasks
+- [ ] Implement persistent/durable handle contexts
+- [ ] Add handle GUID generation and tracking
+- [ ] Implement handle state serialization
+- [ ] Create reconnection logic with handle replay
+- [ ] Add timeout management for durable handles
+- [ ] Implement handle lease association
+- [ ] Add persistent handle capability negotiation
+- [ ] Create handle cache for reconnection
+
+#### 2.3 Integration Points
+- Extend `SmbFile` with persistent handle support
+- Modify `SmbSession` for handle replay during reconnection
+- Update `Smb2CreateRequest/Response` for durable contexts
+
+---
+
+### Phase 3: Multi-Channel Support
+**Priority: MEDIUM** | **Estimated Effort: 5-6 weeks**
+
+Multi-channel enables using multiple network connections for improved performance and reliability.
+
+#### 3.1 Core Multi-Channel Infrastructure
+```
+Package: jcifs.internal.smb2.multichannel
+├── ChannelManager.java           - Manage multiple channels per session
+├── ChannelBinding.java           - Channel binding and security
+├── ChannelSequence.java          - Request sequencing across channels
+├── NetworkInterfaceInfo.java     - Network interface discovery
+├── ChannelLoadBalancer.java      - Load distribution logic
+└── ChannelFailover.java         - Channel failure handling
+```
+
+#### 3.2 Implementation Tasks
+- [ ] Implement FSCTL_QUERY_NETWORK_INTERFACE_INFO
+- [ ] Create channel binding hash calculation
+- [ ] Implement channel establishment protocol
+- [ ] Add request distribution algorithm
+- [ ] Create channel synchronization mechanism
+- [ ] Implement channel failure detection
+- [ ] Add automatic channel recovery
+- [ ] Create channel performance monitoring
+
+#### 3.3 Integration Points
+- Modify `SmbTransportPool` for multiple connections per session
+- Update `SmbSession` for multi-channel awareness
+- Enhance `SmbTransport` for channel management
+
+---
+
+### Phase 4: Directory Leasing
+**Priority: MEDIUM** | **Estimated Effort: 2-3 weeks**
+
+Directory leasing extends the lease concept to directories for improved metadata caching.
+
+#### 4.1 Core Directory Lease Infrastructure
+```
+Package: jcifs.internal.smb2.lease
+├── DirectoryLeaseContext.java    - Directory-specific lease context
+├── DirectoryLeaseCache.java      - Directory metadata cache
+└── DirectoryChangeNotifier.java  - Directory change tracking
+```
+
+#### 4.2 Implementation Tasks
+- [ ] Extend lease implementation for directories
+- [ ] Implement directory metadata caching
+- [ ] Add directory change notification integration
+- [ ] Create parent-child lease relationships
+- [ ] Implement directory lease break handling
+- [ ] Add directory enumeration caching
+
+#### 4.3 Integration Points
+- Extend `SmbFile` for directory lease support
+- Modify directory listing operations for caching
+- Update change notification handling
+
+---
+
+### Phase 5: RDMA (SMB Direct) Support
+**Priority: LOW** | **Estimated Effort: 8-10 weeks**
+
+RDMA provides high-speed, low-latency data transfer for supported network adapters.
+
+#### 5.1 Core RDMA Infrastructure
+```
+Package: jcifs.internal.smb2.rdma
+├── RdmaTransport.java           - RDMA transport implementation
+├── RdmaCapability.java          - RDMA capability detection
+├── RdmaNegotiate.java           - RDMA negotiation context
+├── RdmaBuffer.java              - RDMA buffer management
+├── RdmaChannel.java             - RDMA channel operations
+└── RdmaProvider.java            - RDMA provider abstraction
+```
+
+#### 5.2 Implementation Tasks
+- [ ] Research Java RDMA libraries (e.g., DiSNI, JXIO)
+- [ ] Implement RDMA capability detection
+- [ ] Create RDMA negotiation context
+- [ ] Implement RDMA transport layer
+- [ ] Add RDMA buffer registration
+- [ ] Create RDMA read/write operations
+- [ ] Implement RDMA credits management
+- [ ] Add fallback to TCP when RDMA unavailable
+
+#### 5.3 Integration Points
+- Create new transport type alongside TCP
+- Modify negotiation to include RDMA contexts
+- Update read/write operations for RDMA
+
+---
+
+### Phase 6: Witness Protocol
+**Priority: LOW** | **Estimated Effort: 4-5 weeks**
+
+Witness protocol enables rapid failover notification for clustered file servers.
+
+#### 6.1 Core Witness Infrastructure
+```
+Package: jcifs.internal.witness
+├── WitnessClient.java           - Witness client implementation
+├── WitnessRegistration.java     - Client registration with witness
+├── WitnessNotification.java     - Notification handling
+├── ResourceChange.java          - Resource change events
+└── WitnessTransport.java       - Witness-specific RPC transport
+```
+
+#### 6.2 Implementation Tasks
+- [ ] Implement Witness RPC protocol
+- [ ] Create witness service discovery
+- [ ] Implement client registration
+- [ ] Add notification callback mechanism
+- [ ] Create resource monitoring
+- [ ] Implement automatic re-registration
+- [ ] Add cluster node tracking
+- [ ] Create failover coordination
+
+#### 6.3 Integration Points
+- Integrate with `CIFSContext` for witness support
+- Modify `SmbTransport` for failover handling
+- Update `DfsResolver` for witness-aware resolution
+
+---
+
+## Implementation Dependencies
+
+```mermaid
+graph TD
+    A[SMB3 Leases] --> B[Directory Leasing]
+    A --> C[Persistent Handles]
+    C --> D[Multi-Channel]
+    D --> E[RDMA Support]
+    C --> F[Witness Protocol]
+    D --> F
+```
+
+## Testing Strategy
+
+### Unit Tests
+- Individual component testing for each feature
+- Mock-based testing for protocol interactions
+- State machine validation
+
+### Integration Tests
+- Feature interaction testing
+- Network failure simulation
+- Performance benchmarking
+- Compatibility testing with Windows Server 2016/2019/2022
+
+### Test Infrastructure Requirements
+- Windows Server test environment with:
+  - Failover clustering
+  - RDMA-capable network adapters
+  - DFS namespace
+  - Multiple network interfaces
+
+## Configuration Properties
+
+```properties
+# Lease configuration
+jcifs.smb.client.useLeases=true
+jcifs.smb.client.leaseTimeout=30000
+
+# Persistent handles
+jcifs.smb.client.usePersistentHandles=true
+jcifs.smb.client.durableTimeout=120000
+
+# Multi-channel
+jcifs.smb.client.useMultiChannel=true
+jcifs.smb.client.maxChannels=4
+jcifs.smb.client.channelBindingPolicy=required
+
+# Directory leasing
+jcifs.smb.client.useDirectoryLeasing=true
+jcifs.smb.client.dirCacheTimeout=60000
+
+# RDMA
+jcifs.smb.client.useRDMA=auto
+jcifs.smb.client.rdmaProvider=disni
+
+# Witness
+jcifs.smb.client.useWitness=true
+jcifs.smb.client.witnessNotificationTimeout=5000
+```
+
+## Risk Assessment
+
+### Technical Risks
+1. **RDMA Complexity**: Limited Java RDMA support may require JNI
+2. **Multi-Channel Synchronization**: Complex thread synchronization required
+3. **Persistent Handle State**: Requires reliable state persistence mechanism
+4. **Backward Compatibility**: Must maintain compatibility with SMB2/SMB1
+
+### Mitigation Strategies
+1. Implement features behind configuration flags
+2. Provide graceful fallback mechanisms
+3. Extensive testing with various server configurations
+4. Phased rollout with beta testing
+
+## Resource Requirements
+
+### Development Team
+- 2-3 Senior Java developers with SMB protocol expertise
+- 1 QA engineer for test infrastructure
+- 1 DevOps engineer for CI/CD setup
+
+### Timeline
+- **Total Duration**: 6-8 months for all features
+- **Phases 1-2**: 2-3 months (High priority)
+- **Phases 3-4**: 2 months (Medium priority)
+- **Phases 5-6**: 2-3 months (Low priority)
+
+### Infrastructure
+- Windows Server test lab
+- RDMA-capable test hardware
+- Continuous integration environment
+- Performance testing infrastructure
+
+## Success Metrics
+
+1. **Functional Completeness**: All features pass Windows Protocol Test Suite
+2. **Performance**: 
+   - Multi-channel provides >1.5x throughput improvement
+   - RDMA reduces latency by >50%
+3. **Reliability**: 
+   - Persistent handles survive 99% of network interruptions
+   - Witness protocol achieves <5 second failover time
+4. **Compatibility**: Works with Windows Server 2016+ and Azure Files
+
+## Next Steps
+
+1. **Immediate Actions**:
+   - Set up Windows Server test environment
+   - Create detailed technical specifications for Phase 1
+   - Identify and evaluate Java RDMA libraries
+
+2. **Phase 1 Kickoff**:
+   - Begin SMB3 lease implementation
+   - Create comprehensive test suite
+   - Document API changes
+
+3. **Community Engagement**:
+   - Announce implementation plan
+   - Solicit feedback from users
+   - Identify beta testers for early access
+
+## References
+
+- [MS-SMB2]: Server Message Block (SMB) Protocol Version 2 and 3
+- [MS-SWN]: Service Witness Protocol
+- [MS-SMBD]: SMB2 Remote Direct Memory Access (RDMA) Transport Protocol
+- Windows Protocol Test Suites
+- SMB3 Protocol Documentation

--- a/docs/smb3-features/01-smb3-lease-design.md
+++ b/docs/smb3-features/01-smb3-lease-design.md
@@ -1,0 +1,728 @@
+# SMB3 Lease Feature - Detailed Design Document
+
+## 1. Overview
+
+SMB3 leases provide a client caching mechanism that replaces the traditional oplock mechanism. Leases enable better performance through client-side caching while maintaining cache coherency across multiple clients.
+
+## 2. Protocol Specification Reference
+
+- **MS-SMB2 Section 2.2.13**: SMB2 CREATE Request with Lease Context
+- **MS-SMB2 Section 2.2.14**: SMB2 CREATE Response with Lease State
+- **MS-SMB2 Section 2.2.23**: SMB2 LEASE_BREAK Notification
+- **MS-SMB2 Section 2.2.24**: SMB2 LEASE_BREAK Acknowledgment
+
+## 3. Lease Types and States
+
+### 3.1 Lease State Flags
+```java
+public class Smb2LeaseState {
+    // Lease state flags (can be combined)
+    public static final int SMB2_LEASE_NONE           = 0x00;
+    public static final int SMB2_LEASE_READ_CACHING   = 0x01;  // R - Read caching
+    public static final int SMB2_LEASE_HANDLE_CACHING = 0x02;  // H - Handle caching  
+    public static final int SMB2_LEASE_WRITE_CACHING  = 0x04;  // W - Write caching
+    
+    // Common combinations
+    public static final int SMB2_LEASE_READ_HANDLE    = 0x03;  // RH
+    public static final int SMB2_LEASE_READ_WRITE     = 0x05;  // RW
+    public static final int SMB2_LEASE_FULL           = 0x07;  // RWH
+}
+```
+
+### 3.2 Lease Versions
+- **Lease V1**: Basic lease support (SMB 3.0)
+- **Lease V2**: Adds epoch support for better consistency (SMB 3.0.2+)
+
+## 4. Data Structures
+
+### 4.1 Lease Key Structure
+```java
+package jcifs.internal.smb2.lease;
+
+import java.security.SecureRandom;
+import java.util.Arrays;
+
+public class Smb2LeaseKey {
+    private final byte[] key;  // 16-byte lease key
+    private static final SecureRandom random = new SecureRandom();
+    
+    public Smb2LeaseKey() {
+        this.key = new byte[16];
+        random.nextBytes(this.key);
+    }
+    
+    public Smb2LeaseKey(byte[] key) {
+        if (key.length != 16) {
+            throw new IllegalArgumentException("Lease key must be 16 bytes");
+        }
+        this.key = Arrays.copyOf(key, 16);
+    }
+    
+    public byte[] getKey() {
+        return Arrays.copyOf(key, 16);
+    }
+    
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof Smb2LeaseKey) {
+            return Arrays.equals(key, ((Smb2LeaseKey)obj).key);
+        }
+        return false;
+    }
+    
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(key);
+    }
+}
+```
+
+### 4.2 Lease Context Structure
+```java
+package jcifs.internal.smb2.lease;
+
+import jcifs.internal.smb2.create.Smb2CreateContext;
+
+public class Smb2LeaseContext extends Smb2CreateContext {
+    // Context name for lease request
+    public static final String NAME_REQUEST = "RqLs";
+    public static final String NAME_RESPONSE = "RqLs";
+    
+    private Smb2LeaseKey leaseKey;
+    private int leaseState;
+    private int leaseFlags;
+    private long leaseDuration;  // For V2
+    private Smb2LeaseKey parentLeaseKey;  // For V2
+    private int epoch;  // For V2
+    
+    // Wire format structure
+    // Lease V1: 32 bytes
+    // Lease V2: 52 bytes
+    
+    @Override
+    public void encode(byte[] buffer, int offset) {
+        // Write context header
+        writeInt4(buffer, offset, getName().length());  // NameOffset
+        writeInt4(buffer, offset + 4, getName().length());  // NameLength
+        writeInt4(buffer, offset + 8, 16);  // Reserved
+        
+        int dataOffset = offset + 16 + getName().length();
+        dataOffset = (dataOffset + 7) & ~7;  // 8-byte alignment
+        
+        writeInt4(buffer, offset + 12, dataOffset - offset);  // DataOffset
+        
+        // Write context name
+        System.arraycopy(getName().getBytes(), 0, buffer, offset + 16, getName().length());
+        
+        // Write lease data
+        System.arraycopy(leaseKey.getKey(), 0, buffer, dataOffset, 16);  // LeaseKey
+        writeInt4(buffer, dataOffset + 16, leaseState);  // LeaseState
+        writeInt4(buffer, dataOffset + 20, leaseFlags);  // LeaseFlags
+        writeInt8(buffer, dataOffset + 24, leaseDuration);  // LeaseDuration
+        
+        if (isV2()) {
+            System.arraycopy(parentLeaseKey.getKey(), 0, buffer, dataOffset + 32, 16);  // ParentLeaseKey
+            writeInt2(buffer, dataOffset + 48, epoch);  // Epoch
+            writeInt2(buffer, dataOffset + 50, 0);  // Reserved
+        }
+    }
+    
+    @Override
+    public void decode(byte[] buffer, int offset, int length) {
+        // Decode lease response
+        byte[] keyBytes = new byte[16];
+        System.arraycopy(buffer, offset, keyBytes, 0, 16);
+        this.leaseKey = new Smb2LeaseKey(keyBytes);
+        
+        this.leaseState = readInt4(buffer, offset + 16);
+        this.leaseFlags = readInt4(buffer, offset + 20);
+        this.leaseDuration = readInt8(buffer, offset + 24);
+        
+        if (length >= 52) {  // V2 lease
+            byte[] parentKeyBytes = new byte[16];
+            System.arraycopy(buffer, offset + 32, parentKeyBytes, 0, 16);
+            this.parentLeaseKey = new Smb2LeaseKey(parentKeyBytes);
+            this.epoch = readInt2(buffer, offset + 48);
+        }
+    }
+    
+    public boolean isV2() {
+        return parentLeaseKey != null;
+    }
+}
+```
+
+### 4.3 Lease Manager
+```java
+package jcifs.internal.smb2.lease;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import jcifs.CIFSContext;
+
+public class LeaseManager {
+    private final ConcurrentHashMap<Smb2LeaseKey, LeaseEntry> leases;
+    private final ConcurrentHashMap<String, Smb2LeaseKey> pathToLease;
+    private final ReadWriteLock lock;
+    private final CIFSContext context;
+    
+    public LeaseManager(CIFSContext context) {
+        this.context = context;
+        this.leases = new ConcurrentHashMap<>();
+        this.pathToLease = new ConcurrentHashMap<>();
+        this.lock = new ReentrantReadWriteLock();
+    }
+    
+    public static class LeaseEntry {
+        private final Smb2LeaseKey leaseKey;
+        private volatile int leaseState;
+        private volatile int epoch;
+        private final long createTime;
+        private volatile long lastAccessTime;
+        private final String path;
+        private volatile boolean breaking;
+        
+        public LeaseEntry(Smb2LeaseKey key, String path, int state) {
+            this.leaseKey = key;
+            this.path = path;
+            this.leaseState = state;
+            this.createTime = System.currentTimeMillis();
+            this.lastAccessTime = createTime;
+            this.epoch = 1;
+            this.breaking = false;
+        }
+        
+        public synchronized void updateState(int newState) {
+            this.leaseState = newState;
+            this.lastAccessTime = System.currentTimeMillis();
+        }
+        
+        public synchronized void incrementEpoch() {
+            this.epoch++;
+        }
+        
+        public boolean hasReadCache() {
+            return (leaseState & Smb2LeaseState.SMB2_LEASE_READ_CACHING) != 0;
+        }
+        
+        public boolean hasWriteCache() {
+            return (leaseState & Smb2LeaseState.SMB2_LEASE_WRITE_CACHING) != 0;
+        }
+        
+        public boolean hasHandleCache() {
+            return (leaseState & Smb2LeaseState.SMB2_LEASE_HANDLE_CACHING) != 0;
+        }
+    }
+    
+    public Smb2LeaseKey requestLease(String path, int requestedState) {
+        lock.writeLock().lock();
+        try {
+            // Check if we already have a lease for this path
+            Smb2LeaseKey existingKey = pathToLease.get(path);
+            if (existingKey != null) {
+                LeaseEntry entry = leases.get(existingKey);
+                if (entry != null && !entry.breaking) {
+                    entry.lastAccessTime = System.currentTimeMillis();
+                    return existingKey;
+                }
+            }
+            
+            // Create new lease
+            Smb2LeaseKey newKey = new Smb2LeaseKey();
+            LeaseEntry newEntry = new LeaseEntry(newKey, path, requestedState);
+            leases.put(newKey, newEntry);
+            pathToLease.put(path, newKey);
+            
+            return newKey;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+    
+    public void updateLease(Smb2LeaseKey key, int grantedState) {
+        LeaseEntry entry = leases.get(key);
+        if (entry != null) {
+            entry.updateState(grantedState);
+        }
+    }
+    
+    public LeaseEntry getLease(Smb2LeaseKey key) {
+        return leases.get(key);
+    }
+    
+    public void handleLeaseBreak(Smb2LeaseKey key, int newState) {
+        LeaseEntry entry = leases.get(key);
+        if (entry != null) {
+            entry.breaking = true;
+            entry.updateState(newState);
+            // Flush any cached data if losing write cache
+            if (!entry.hasWriteCache()) {
+                flushCachedWrites(entry.path);
+            }
+            // Invalidate cached data if losing read cache
+            if (!entry.hasReadCache()) {
+                invalidateReadCache(entry.path);
+            }
+            entry.breaking = false;
+        }
+    }
+    
+    public void releaseLease(Smb2LeaseKey key) {
+        lock.writeLock().lock();
+        try {
+            LeaseEntry entry = leases.remove(key);
+            if (entry != null) {
+                pathToLease.remove(entry.path);
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+    
+    private void flushCachedWrites(String path) {
+        // Implementation to flush cached writes
+        // This will be called when losing write cache
+    }
+    
+    private void invalidateReadCache(String path) {
+        // Implementation to invalidate read cache
+        // This will be called when losing read cache
+    }
+}
+```
+
+## 5. Lease Break Handling
+
+### 5.1 Lease Break Notification
+```java
+package jcifs.internal.smb2.lease;
+
+import jcifs.internal.smb2.ServerMessageBlock2;
+
+public class Smb2LeaseBreakNotification extends ServerMessageBlock2 {
+    // Command code for lease break
+    public static final int SMB2_OPLOCK_BREAK = 0x0012;
+    
+    private int structureSize;
+    private int flags;
+    private Smb2LeaseKey leaseKey;
+    private int currentLeaseState;
+    private int newLeaseState;
+    private int breakReason;
+    private int accessMaskHint;
+    private int shareAccessHint;
+    
+    @Override
+    protected int writePayload(byte[] dst, int dstIndex) {
+        int start = dstIndex;
+        
+        // StructureSize (2 bytes) - must be 44
+        writeInt2(dst, dstIndex, 44);
+        dstIndex += 2;
+        
+        // Reserved (2 bytes)
+        writeInt2(dst, dstIndex, 0);
+        dstIndex += 2;
+        
+        // Flags (4 bytes)
+        writeInt4(dst, dstIndex, flags);
+        dstIndex += 4;
+        
+        // LeaseKey (16 bytes)
+        System.arraycopy(leaseKey.getKey(), 0, dst, dstIndex, 16);
+        dstIndex += 16;
+        
+        // CurrentLeaseState (4 bytes)
+        writeInt4(dst, dstIndex, currentLeaseState);
+        dstIndex += 4;
+        
+        // NewLeaseState (4 bytes)
+        writeInt4(dst, dstIndex, newLeaseState);
+        dstIndex += 4;
+        
+        // BreakReason (4 bytes)
+        writeInt4(dst, dstIndex, breakReason);
+        dstIndex += 4;
+        
+        // AccessMaskHint (4 bytes)
+        writeInt4(dst, dstIndex, accessMaskHint);
+        dstIndex += 4;
+        
+        // ShareAccessHint (4 bytes)
+        writeInt4(dst, dstIndex, shareAccessHint);
+        dstIndex += 4;
+        
+        return dstIndex - start;
+    }
+    
+    @Override
+    protected int readPayload(byte[] buffer, int offset) throws SMBProtocolDecodingException {
+        int start = offset;
+        
+        // StructureSize (2 bytes)
+        structureSize = readInt2(buffer, offset);
+        offset += 2;
+        
+        // Reserved (2 bytes)
+        offset += 2;
+        
+        // Flags (4 bytes)
+        flags = readInt4(buffer, offset);
+        offset += 4;
+        
+        // LeaseKey (16 bytes)
+        byte[] keyBytes = new byte[16];
+        System.arraycopy(buffer, offset, keyBytes, 0, 16);
+        leaseKey = new Smb2LeaseKey(keyBytes);
+        offset += 16;
+        
+        // CurrentLeaseState (4 bytes)
+        currentLeaseState = readInt4(buffer, offset);
+        offset += 4;
+        
+        // NewLeaseState (4 bytes)
+        newLeaseState = readInt4(buffer, offset);
+        offset += 4;
+        
+        // BreakReason (4 bytes)
+        breakReason = readInt4(buffer, offset);
+        offset += 4;
+        
+        // AccessMaskHint (4 bytes)
+        accessMaskHint = readInt4(buffer, offset);
+        offset += 4;
+        
+        // ShareAccessHint (4 bytes)
+        shareAccessHint = readInt4(buffer, offset);
+        offset += 4;
+        
+        return offset - start;
+    }
+}
+```
+
+### 5.2 Lease Break Acknowledgment
+```java
+package jcifs.internal.smb2.lease;
+
+public class Smb2LeaseBreakAcknowledgment extends ServerMessageBlock2 {
+    private int structureSize = 36;
+    private int reserved;
+    private int flags;
+    private Smb2LeaseKey leaseKey;
+    private int leaseState;
+    private long leaseDuration;
+    
+    public Smb2LeaseBreakAcknowledgment(Smb2LeaseKey key, int state) {
+        this.leaseKey = key;
+        this.leaseState = state;
+        this.leaseDuration = 0;  // Not used in acknowledgment
+    }
+    
+    @Override
+    protected int writePayload(byte[] dst, int dstIndex) {
+        int start = dstIndex;
+        
+        // StructureSize (2 bytes) - must be 36
+        writeInt2(dst, dstIndex, 36);
+        dstIndex += 2;
+        
+        // Reserved (2 bytes)
+        writeInt2(dst, dstIndex, 0);
+        dstIndex += 2;
+        
+        // Flags (4 bytes)
+        writeInt4(dst, dstIndex, flags);
+        dstIndex += 4;
+        
+        // LeaseKey (16 bytes)
+        System.arraycopy(leaseKey.getKey(), 0, dst, dstIndex, 16);
+        dstIndex += 16;
+        
+        // LeaseState (4 bytes)
+        writeInt4(dst, dstIndex, leaseState);
+        dstIndex += 4;
+        
+        // LeaseDuration (8 bytes)
+        writeInt8(dst, dstIndex, leaseDuration);
+        dstIndex += 8;
+        
+        return dstIndex - start;
+    }
+}
+```
+
+## 6. Integration with Existing Code
+
+### 6.1 Modifying Smb2CreateRequest
+```java
+// In Smb2CreateRequest.java
+public void addLeaseContext(Smb2LeaseKey key, int requestedState, boolean isV2) {
+    Smb2LeaseContext leaseContext = new Smb2LeaseContext();
+    leaseContext.setLeaseKey(key);
+    leaseContext.setLeaseState(requestedState);
+    if (isV2) {
+        leaseContext.setEpoch(1);
+        // Set parent lease key if available
+    }
+    addCreateContext(leaseContext);
+}
+```
+
+### 6.2 Modifying SmbFile
+```java
+// In SmbFile.java
+private Smb2LeaseKey leaseKey;
+private int leaseState;
+private LeaseManager leaseManager;
+
+protected void doConnect() throws IOException {
+    // ... existing connection logic ...
+    
+    if (context.getConfig().isUseLeases() && tree.getSession().supports(SMB3_0)) {
+        // Request lease when opening file
+        leaseManager = tree.getSession().getLeaseManager();
+        int requestedState = isDirectory() ? 
+            Smb2LeaseState.SMB2_LEASE_READ_HANDLE :
+            Smb2LeaseState.SMB2_LEASE_FULL;
+            
+        leaseKey = leaseManager.requestLease(getPath(), requestedState);
+        
+        // Add lease context to create request
+        if (createRequest != null) {
+            createRequest.addLeaseContext(leaseKey, requestedState, 
+                tree.getSession().supports(SMB3_0_2));
+        }
+    }
+    
+    // ... rest of connection logic ...
+}
+
+// Caching methods based on lease state
+public boolean canCacheRead() {
+    if (leaseKey != null) {
+        LeaseEntry entry = leaseManager.getLease(leaseKey);
+        return entry != null && entry.hasReadCache();
+    }
+    return false;  // Fall back to oplock logic
+}
+
+public boolean canCacheWrite() {
+    if (leaseKey != null) {
+        LeaseEntry entry = leaseManager.getLease(leaseKey);
+        return entry != null && entry.hasWriteCache();
+    }
+    return false;
+}
+
+public boolean canCacheHandle() {
+    if (leaseKey != null) {
+        LeaseEntry entry = leaseManager.getLease(leaseKey);
+        return entry != null && entry.hasHandleCache();
+    }
+    return false;
+}
+```
+
+### 6.3 Transport Layer Integration
+```java
+// In SmbTransport.java
+private void handleIncomingMessage(ServerMessageBlock2 msg) {
+    if (msg instanceof Smb2LeaseBreakNotification) {
+        Smb2LeaseBreakNotification breakNotif = (Smb2LeaseBreakNotification) msg;
+        
+        // Get lease manager from session
+        LeaseManager leaseManager = session.getLeaseManager();
+        
+        // Handle the lease break
+        leaseManager.handleLeaseBreak(
+            breakNotif.getLeaseKey(),
+            breakNotif.getNewLeaseState()
+        );
+        
+        // Send acknowledgment
+        Smb2LeaseBreakAcknowledgment ack = new Smb2LeaseBreakAcknowledgment(
+            breakNotif.getLeaseKey(),
+            breakNotif.getNewLeaseState()
+        );
+        
+        sendAsync(ack);  // Send acknowledgment asynchronously
+    }
+    // ... handle other message types ...
+}
+```
+
+## 7. Configuration
+
+### 7.1 Configuration Properties
+```java
+// In PropertyConfiguration.java
+public class PropertyConfiguration implements Configuration {
+    // Lease configuration properties
+    public static final String USE_LEASES = "jcifs.smb.client.useLeases";
+    public static final String LEASE_TIMEOUT = "jcifs.smb.client.leaseTimeout";
+    public static final String MAX_LEASES = "jcifs.smb.client.maxLeases";
+    public static final String LEASE_VERSION = "jcifs.smb.client.leaseVersion";
+    
+    public boolean isUseLeases() {
+        return getBooleanProperty(USE_LEASES, true);
+    }
+    
+    public int getLeaseTimeout() {
+        return getIntProperty(LEASE_TIMEOUT, 30000);  // 30 seconds default
+    }
+    
+    public int getMaxLeases() {
+        return getIntProperty(MAX_LEASES, 1000);  // Max concurrent leases
+    }
+    
+    public int getLeaseVersion() {
+        return getIntProperty(LEASE_VERSION, 2);  // Default to V2 if supported
+    }
+}
+```
+
+## 8. Testing Strategy
+
+### 8.1 Unit Tests
+```java
+package jcifs.tests.smb3;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class LeaseTest {
+    
+    @Test
+    public void testLeaseKeyGeneration() {
+        Smb2LeaseKey key1 = new Smb2LeaseKey();
+        Smb2LeaseKey key2 = new Smb2LeaseKey();
+        
+        assertNotNull(key1.getKey());
+        assertEquals(16, key1.getKey().length);
+        assertFalse(Arrays.equals(key1.getKey(), key2.getKey()));
+    }
+    
+    @Test
+    public void testLeaseStateFlags() {
+        int state = Smb2LeaseState.SMB2_LEASE_READ_WRITE;
+        
+        assertTrue((state & Smb2LeaseState.SMB2_LEASE_READ_CACHING) != 0);
+        assertTrue((state & Smb2LeaseState.SMB2_LEASE_WRITE_CACHING) != 0);
+        assertFalse((state & Smb2LeaseState.SMB2_LEASE_HANDLE_CACHING) != 0);
+    }
+    
+    @Test
+    public void testLeaseManager() {
+        CIFSContext context = new BaseContext(new PropertyConfiguration());
+        LeaseManager manager = new LeaseManager(context);
+        
+        String path = "/share/file.txt";
+        int requestedState = Smb2LeaseState.SMB2_LEASE_FULL;
+        
+        Smb2LeaseKey key = manager.requestLease(path, requestedState);
+        assertNotNull(key);
+        
+        LeaseEntry entry = manager.getLease(key);
+        assertNotNull(entry);
+        assertEquals(requestedState, entry.getLeaseState());
+        
+        // Test lease break
+        manager.handleLeaseBreak(key, Smb2LeaseState.SMB2_LEASE_READ_CACHING);
+        assertEquals(Smb2LeaseState.SMB2_LEASE_READ_CACHING, entry.getLeaseState());
+    }
+}
+```
+
+### 8.2 Integration Tests
+```java
+@Test
+public void testLeaseWithRealServer() throws Exception {
+    // Requires SMB3 capable server
+    CIFSContext context = getTestContext();
+    context.getConfig().setProperty("jcifs.smb.client.useLeases", "true");
+    
+    try (SmbFile file = new SmbFile("smb://server/share/test.txt", context)) {
+        // Open file with lease
+        file.createNewFile();
+        
+        // Verify lease was granted
+        assertTrue(file.canCacheRead());
+        
+        // Write should be cached
+        try (OutputStream os = file.getOutputStream()) {
+            os.write("test data".getBytes());
+        }
+        
+        // Verify caching behavior
+        assertTrue(file.canCacheWrite());
+    }
+}
+```
+
+## 9. Performance Considerations
+
+### 9.1 Memory Management
+- Lease entries should be evicted based on LRU when max leases reached
+- Implement periodic cleanup of expired leases
+
+### 9.2 Thread Safety
+- Use concurrent data structures for lease storage
+- Minimize lock contention in hot paths
+- Async handling of lease breaks
+
+### 9.3 Network Efficiency
+- Batch lease requests when possible
+- Implement lease key reuse for related files
+- Optimize lease break acknowledgment timing
+
+## 10. Error Handling
+
+### 10.1 Lease Break Timeout
+```java
+public void handleLeaseBreakWithTimeout(Smb2LeaseKey key, int newState) {
+    CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
+        handleLeaseBreak(key, newState);
+    });
+    
+    try {
+        future.get(5, TimeUnit.SECONDS);  // 5 second timeout
+    } catch (TimeoutException e) {
+        // Force lease release if break handling times out
+        releaseLease(key);
+        log.warn("Lease break timeout for key: {}", key);
+    }
+}
+```
+
+### 10.2 Fallback to Oplocks
+```java
+if (!context.getConfig().isUseLeases() || !session.supports(SMB3_0)) {
+    // Fall back to traditional oplock mechanism
+    useOplockInstead();
+}
+```
+
+## 11. Monitoring and Metrics
+
+### 11.1 Lease Statistics
+```java
+public class LeaseStatistics {
+    private final AtomicLong leasesRequested = new AtomicLong();
+    private final AtomicLong leasesGranted = new AtomicLong();
+    private final AtomicLong leaseBreaks = new AtomicLong();
+    private final AtomicLong leaseUpgrades = new AtomicLong();
+    private final AtomicLong leaseDowngrades = new AtomicLong();
+    
+    // Getters and increment methods
+}
+```
+
+## 12. Future Enhancements
+
+1. **Directory Leases**: Extend lease support for directories
+2. **Lease Key Persistence**: Save lease keys for reconnection
+3. **Parent-Child Relationships**: Implement hierarchical leases
+4. **Lease Sharing**: Support lease sharing across handles
+5. **Performance Tuning**: Adaptive lease request strategies

--- a/docs/smb3-features/02-persistent-handles-design.md
+++ b/docs/smb3-features/02-persistent-handles-design.md
@@ -1,0 +1,982 @@
+# Persistent Handles Feature - Detailed Design Document
+
+## 1. Overview
+
+Persistent handles (also known as durable handles) allow SMB3 connections to survive network disconnections, server reboots, and client reconnections. This feature is critical for enterprise reliability and seamless failover scenarios.
+
+## 2. Protocol Specification Reference
+
+- **MS-SMB2 Section 2.2.13.2.3**: SMB2_CREATE_DURABLE_HANDLE_REQUEST
+- **MS-SMB2 Section 2.2.13.2.4**: SMB2_CREATE_DURABLE_HANDLE_REQUEST_V2
+- **MS-SMB2 Section 2.2.13.2.5**: SMB2_CREATE_DURABLE_HANDLE_RECONNECT
+- **MS-SMB2 Section 2.2.13.2.12**: SMB2_CREATE_REQUEST_LEASE_V2
+- **MS-SMB2 Section 3.2.1.4**: Durable Open Scavenger Timer
+
+## 3. Handle Types and Capabilities
+
+### 3.1 Handle Types
+```java
+public enum HandleType {
+    NONE(0),                    // No durability
+    DURABLE_V1(1),              // SMB 2.1 - survives network loss
+    DURABLE_V2(2),              // SMB 3.0 - with timeout
+    PERSISTENT(3);              // SMB 3.0 - survives server reboot
+    
+    private final int value;
+    
+    HandleType(int value) {
+        this.value = value;
+    }
+}
+```
+
+### 3.2 Handle Capabilities
+```java
+public class Smb2HandleCapabilities {
+    // Durable handle flags
+    public static final int SMB2_DHANDLE_FLAG_PERSISTENT = 0x00000002;
+    
+    // Timeout values (milliseconds)
+    public static final long DEFAULT_DURABLE_TIMEOUT = 120000;  // 2 minutes
+    public static final long MAX_DURABLE_TIMEOUT = 300000;      // 5 minutes
+    public static final long PERSISTENT_TIMEOUT = 0;            // Infinite for persistent
+}
+```
+
+## 4. Data Structures
+
+### 4.1 Handle GUID Structure
+```java
+package jcifs.internal.smb2.persistent;
+
+import java.util.UUID;
+import java.nio.ByteBuffer;
+
+public class HandleGuid {
+    private final UUID guid;
+    
+    public HandleGuid() {
+        this.guid = UUID.randomUUID();
+    }
+    
+    public HandleGuid(byte[] bytes) {
+        if (bytes.length != 16) {
+            throw new IllegalArgumentException("GUID must be 16 bytes");
+        }
+        ByteBuffer bb = ByteBuffer.wrap(bytes);
+        long mostSig = bb.getLong();
+        long leastSig = bb.getLong();
+        this.guid = new UUID(mostSig, leastSig);
+    }
+    
+    public byte[] toBytes() {
+        ByteBuffer bb = ByteBuffer.allocate(16);
+        bb.putLong(guid.getMostSignificantBits());
+        bb.putLong(guid.getLeastSignificantBits());
+        return bb.array();
+    }
+    
+    @Override
+    public String toString() {
+        return guid.toString();
+    }
+    
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof HandleGuid) {
+            return guid.equals(((HandleGuid)obj).guid);
+        }
+        return false;
+    }
+    
+    @Override
+    public int hashCode() {
+        return guid.hashCode();
+    }
+}
+```
+
+### 4.2 Durable Handle Request Context
+```java
+package jcifs.internal.smb2.persistent;
+
+import jcifs.internal.smb2.create.Smb2CreateContext;
+
+public class DurableHandleRequest extends Smb2CreateContext {
+    public static final String NAME = "DHnQ";  // Durable Handle Request
+    
+    private static final int STRUCTURE_SIZE = 16;
+    private long reserved;  // Must be zero
+    
+    public DurableHandleRequest() {
+        super(NAME);
+        this.reserved = 0;
+    }
+    
+    @Override
+    public void encode(byte[] buffer, int offset) {
+        // Context header
+        int nameLen = getName().length();
+        writeInt4(buffer, offset, 16);  // Next
+        writeInt2(buffer, offset + 4, nameLen);  // NameOffset
+        writeInt2(buffer, offset + 6, nameLen);  // NameLength
+        writeInt2(buffer, offset + 8, 0);  // Reserved
+        writeInt2(buffer, offset + 10, STRUCTURE_SIZE);  // DataOffset
+        writeInt4(buffer, offset + 12, STRUCTURE_SIZE);  // DataLength
+        
+        // Name
+        System.arraycopy(getName().getBytes(), 0, buffer, offset + 16, nameLen);
+        
+        // Data (16 bytes of reserved)
+        int dataOffset = offset + 16 + nameLen;
+        dataOffset = (dataOffset + 7) & ~7;  // 8-byte alignment
+        
+        for (int i = 0; i < 16; i++) {
+            buffer[dataOffset + i] = 0;
+        }
+    }
+    
+    @Override
+    public int size() {
+        int nameLen = getName().length();
+        return 16 + nameLen + ((8 - (nameLen % 8)) % 8) + STRUCTURE_SIZE;
+    }
+}
+```
+
+### 4.3 Durable Handle V2 Request Context
+```java
+package jcifs.internal.smb2.persistent;
+
+public class DurableHandleV2Request extends Smb2CreateContext {
+    public static final String NAME = "DH2Q";  // Durable Handle V2 Request
+    
+    private long timeout;
+    private int flags;
+    private HandleGuid createGuid;
+    
+    public DurableHandleV2Request(long timeout, boolean persistent) {
+        super(NAME);
+        this.timeout = timeout;
+        this.flags = persistent ? Smb2HandleCapabilities.SMB2_DHANDLE_FLAG_PERSISTENT : 0;
+        this.createGuid = new HandleGuid();
+    }
+    
+    @Override
+    public void encode(byte[] buffer, int offset) {
+        // Context header
+        int nameLen = getName().length();
+        writeInt4(buffer, offset, 32);  // Next
+        writeInt2(buffer, offset + 4, nameLen);  // NameOffset
+        writeInt2(buffer, offset + 6, nameLen);  // NameLength
+        writeInt2(buffer, offset + 8, 0);  // Reserved
+        writeInt2(buffer, offset + 10, 32);  // DataOffset
+        writeInt4(buffer, offset + 12, 32);  // DataLength
+        
+        // Name
+        System.arraycopy(getName().getBytes(), 0, buffer, offset + 16, nameLen);
+        
+        // Data
+        int dataOffset = offset + 16 + nameLen;
+        dataOffset = (dataOffset + 7) & ~7;  // 8-byte alignment
+        
+        writeInt8(buffer, dataOffset, timeout);  // Timeout
+        writeInt4(buffer, dataOffset + 8, flags);  // Flags
+        writeInt8(buffer, dataOffset + 12, 0);  // Reserved
+        System.arraycopy(createGuid.toBytes(), 0, buffer, dataOffset + 20, 16);  // CreateGuid
+    }
+}
+```
+
+### 4.4 Durable Handle Reconnect Context
+```java
+package jcifs.internal.smb2.persistent;
+
+public class DurableHandleReconnect extends Smb2CreateContext {
+    public static final String NAME = "DHnC";  // Durable Handle Reconnect
+    
+    private byte[] fileId;  // 16-byte file ID from previous open
+    
+    public DurableHandleReconnect(byte[] fileId) {
+        super(NAME);
+        if (fileId.length != 16) {
+            throw new IllegalArgumentException("File ID must be 16 bytes");
+        }
+        this.fileId = Arrays.copyOf(fileId, 16);
+    }
+    
+    @Override
+    public void encode(byte[] buffer, int offset) {
+        // Context header
+        int nameLen = getName().length();
+        writeInt4(buffer, offset, 16);  // Next
+        writeInt2(buffer, offset + 4, nameLen);  // NameOffset
+        writeInt2(buffer, offset + 6, nameLen);  // NameLength
+        writeInt2(buffer, offset + 8, 0);  // Reserved
+        writeInt2(buffer, offset + 10, 16);  // DataOffset
+        writeInt4(buffer, offset + 12, 16);  // DataLength
+        
+        // Name
+        System.arraycopy(getName().getBytes(), 0, buffer, offset + 16, nameLen);
+        
+        // Data (16-byte file ID)
+        int dataOffset = offset + 16 + nameLen;
+        dataOffset = (dataOffset + 7) & ~7;  // 8-byte alignment
+        System.arraycopy(fileId, 0, buffer, dataOffset, 16);
+    }
+}
+```
+
+### 4.5 Persistent Handle Manager
+```java
+package jcifs.internal.smb2.persistent;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.io.*;
+import java.nio.file.*;
+
+public class PersistentHandleManager {
+    private final ConcurrentHashMap<String, HandleInfo> handles;
+    private final ConcurrentHashMap<HandleGuid, HandleInfo> guidToHandle;
+    private final Path stateDirectory;
+    private final ScheduledExecutorService scheduler;
+    private final CIFSContext context;
+    
+    public PersistentHandleManager(CIFSContext context) {
+        this.context = context;
+        this.handles = new ConcurrentHashMap<>();
+        this.guidToHandle = new ConcurrentHashMap<>();
+        this.scheduler = Executors.newScheduledThreadPool(1);
+        
+        // Create state directory for persistent storage
+        String homeDir = System.getProperty("user.home");
+        this.stateDirectory = Paths.get(homeDir, ".jcifs", "handles");
+        try {
+            Files.createDirectories(stateDirectory);
+        } catch (IOException e) {
+            log.error("Failed to create handle state directory", e);
+        }
+        
+        // Load persisted handles on startup
+        loadPersistedHandles();
+        
+        // Schedule periodic persistence
+        scheduler.scheduleAtFixedRate(this::persistHandles, 30, 30, TimeUnit.SECONDS);
+    }
+    
+    public static class HandleInfo implements Serializable {
+        private static final long serialVersionUID = 1L;
+        
+        private final String path;
+        private final HandleGuid createGuid;
+        private final byte[] fileId;
+        private final HandleType type;
+        private final long timeout;
+        private final long createTime;
+        private volatile long lastAccessTime;
+        private final Smb2LeaseKey leaseKey;  // Associated lease if any
+        private volatile boolean reconnecting;
+        private transient SmbFile file;  // Not serialized
+        
+        public HandleInfo(String path, HandleGuid guid, byte[] fileId, 
+                         HandleType type, long timeout, Smb2LeaseKey leaseKey) {
+            this.path = path;
+            this.createGuid = guid;
+            this.fileId = Arrays.copyOf(fileId, 16);
+            this.type = type;
+            this.timeout = timeout;
+            this.createTime = System.currentTimeMillis();
+            this.lastAccessTime = createTime;
+            this.leaseKey = leaseKey;
+            this.reconnecting = false;
+        }
+        
+        public boolean isExpired() {
+            if (type == HandleType.PERSISTENT) {
+                return false;  // Persistent handles don't expire
+            }
+            long elapsed = System.currentTimeMillis() - lastAccessTime;
+            return elapsed > timeout;
+        }
+        
+        public void updateAccessTime() {
+            this.lastAccessTime = System.currentTimeMillis();
+        }
+    }
+    
+    public HandleGuid requestDurableHandle(String path, HandleType type, 
+                                          long timeout, Smb2LeaseKey leaseKey) {
+        HandleGuid guid = new HandleGuid();
+        
+        // Will be populated after successful create response
+        HandleInfo info = new HandleInfo(path, guid, new byte[16], type, timeout, leaseKey);
+        
+        handles.put(path, info);
+        guidToHandle.put(guid, info);
+        
+        if (type == HandleType.PERSISTENT) {
+            persistHandle(info);
+        }
+        
+        return guid;
+    }
+    
+    public void updateHandleFileId(HandleGuid guid, byte[] fileId) {
+        HandleInfo info = guidToHandle.get(guid);
+        if (info != null) {
+            System.arraycopy(fileId, 0, info.fileId, 0, 16);
+            if (info.type == HandleType.PERSISTENT) {
+                persistHandle(info);
+            }
+        }
+    }
+    
+    public HandleInfo getHandleForReconnect(String path) {
+        HandleInfo info = handles.get(path);
+        if (info != null && !info.isExpired()) {
+            info.reconnecting = true;
+            return info;
+        }
+        return null;
+    }
+    
+    public void completeReconnect(String path, boolean success) {
+        HandleInfo info = handles.get(path);
+        if (info != null) {
+            if (success) {
+                info.updateAccessTime();
+                info.reconnecting = false;
+            } else {
+                // Remove failed handle
+                handles.remove(path);
+                guidToHandle.remove(info.createGuid);
+                removePersistedHandle(info);
+            }
+        }
+    }
+    
+    public void releaseHandle(String path) {
+        HandleInfo info = handles.remove(path);
+        if (info != null) {
+            guidToHandle.remove(info.createGuid);
+            removePersistedHandle(info);
+        }
+    }
+    
+    private void persistHandles() {
+        for (HandleInfo info : handles.values()) {
+            if (info.type == HandleType.PERSISTENT && !info.reconnecting) {
+                persistHandle(info);
+            }
+        }
+    }
+    
+    private void persistHandle(HandleInfo info) {
+        Path handleFile = stateDirectory.resolve(info.createGuid.toString() + ".handle");
+        try (ObjectOutputStream oos = new ObjectOutputStream(
+                Files.newOutputStream(handleFile))) {
+            oos.writeObject(info);
+        } catch (IOException e) {
+            log.error("Failed to persist handle: " + info.path, e);
+        }
+    }
+    
+    private void removePersistedHandle(HandleInfo info) {
+        if (info.type != HandleType.PERSISTENT) {
+            return;
+        }
+        
+        Path handleFile = stateDirectory.resolve(info.createGuid.toString() + ".handle");
+        try {
+            Files.deleteIfExists(handleFile);
+        } catch (IOException e) {
+            log.error("Failed to remove persisted handle", e);
+        }
+    }
+    
+    private void loadPersistedHandles() {
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(
+                stateDirectory, "*.handle")) {
+            for (Path handleFile : stream) {
+                try (ObjectInputStream ois = new ObjectInputStream(
+                        Files.newInputStream(handleFile))) {
+                    HandleInfo info = (HandleInfo) ois.readObject();
+                    
+                    // Only load if not expired
+                    if (!info.isExpired()) {
+                        handles.put(info.path, info);
+                        guidToHandle.put(info.createGuid, info);
+                    } else {
+                        Files.delete(handleFile);
+                    }
+                } catch (Exception e) {
+                    log.error("Failed to load handle file: " + handleFile, e);
+                    Files.deleteIfExists(handleFile);
+                }
+            }
+        } catch (IOException e) {
+            log.error("Failed to load persisted handles", e);
+        }
+    }
+    
+    public void shutdown() {
+        scheduler.shutdown();
+        persistHandles();  // Final persist before shutdown
+    }
+}
+```
+
+## 5. Handle Reconnection Logic
+
+### 5.1 Automatic Reconnection Handler
+```java
+package jcifs.internal.smb2.persistent;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+public class HandleReconnector {
+    private final PersistentHandleManager handleManager;
+    private final int maxRetries;
+    private final long retryDelay;
+    
+    public HandleReconnector(PersistentHandleManager manager) {
+        this.handleManager = manager;
+        this.maxRetries = 3;
+        this.retryDelay = 1000;  // 1 second
+    }
+    
+    public CompletableFuture<SmbFile> reconnectHandle(SmbFile file, Exception cause) {
+        String path = file.getPath();
+        HandleInfo info = handleManager.getHandleForReconnect(path);
+        
+        if (info == null) {
+            return CompletableFuture.failedFuture(
+                new IOException("No durable handle available for reconnection"));
+        }
+        
+        return attemptReconnect(file, info, 0);
+    }
+    
+    private CompletableFuture<SmbFile> attemptReconnect(SmbFile file, 
+                                                        HandleInfo info, 
+                                                        int attempt) {
+        if (attempt >= maxRetries) {
+            handleManager.completeReconnect(info.path, false);
+            return CompletableFuture.failedFuture(
+                new IOException("Failed to reconnect after " + maxRetries + " attempts"));
+        }
+        
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                // Wait before retry (except first attempt)
+                if (attempt > 0) {
+                    Thread.sleep(retryDelay * attempt);
+                }
+                
+                // Create reconnect context
+                DurableHandleReconnect reconnectCtx = 
+                    new DurableHandleReconnect(info.fileId);
+                
+                // Attempt to reopen with reconnect context
+                Smb2CreateRequest createReq = new Smb2CreateRequest();
+                createReq.setPath(info.path);
+                createReq.addCreateContext(reconnectCtx);
+                
+                // Add lease context if associated
+                if (info.leaseKey != null) {
+                    createReq.addLeaseContext(info.leaseKey, 
+                        Smb2LeaseState.SMB2_LEASE_NONE, false);
+                }
+                
+                // Send create request
+                Smb2CreateResponse response = (Smb2CreateResponse) 
+                    file.getTree().send(createReq);
+                
+                if (response.isSuccess()) {
+                    // Update file with new handle
+                    file.setFileId(response.getFileId());
+                    handleManager.completeReconnect(info.path, true);
+                    return file;
+                } else {
+                    throw new IOException("Reconnect failed: " + response.getStatus());
+                }
+                
+            } catch (Exception e) {
+                log.debug("Reconnect attempt {} failed: {}", attempt + 1, e.getMessage());
+                
+                // Retry
+                return attemptReconnect(file, info, attempt + 1).join();
+            }
+        });
+    }
+}
+```
+
+## 6. Integration with Existing Code
+
+### 6.1 Modifying Smb2CreateRequest
+```java
+// In Smb2CreateRequest.java
+public void addDurableHandleContext(HandleType type, long timeout, HandleGuid guid) {
+    switch (type) {
+        case DURABLE_V1:
+            addCreateContext(new DurableHandleRequest());
+            break;
+            
+        case DURABLE_V2:
+            addCreateContext(new DurableHandleV2Request(timeout, false));
+            break;
+            
+        case PERSISTENT:
+            addCreateContext(new DurableHandleV2Request(0, true));
+            break;
+    }
+}
+
+public void addReconnectContext(byte[] fileId) {
+    addCreateContext(new DurableHandleReconnect(fileId));
+}
+```
+
+### 6.2 Modifying SmbFile
+```java
+// In SmbFile.java
+private PersistentHandleManager handleManager;
+private HandleGuid handleGuid;
+private HandleType handleType;
+private boolean durableHandleRequested;
+
+protected void doConnect() throws IOException {
+    // Check for existing durable handle
+    handleManager = tree.getSession().getHandleManager();
+    HandleInfo existingHandle = handleManager.getHandleForReconnect(getPath());
+    
+    if (existingHandle != null) {
+        // Attempt reconnection
+        try {
+            reconnectWithDurableHandle(existingHandle);
+            return;  // Success
+        } catch (IOException e) {
+            log.debug("Durable handle reconnect failed, opening new handle", e);
+        }
+    }
+    
+    // Request new durable handle if configured
+    if (context.getConfig().isUseDurableHandles()) {
+        requestDurableHandle();
+    }
+    
+    // ... rest of normal connection logic ...
+}
+
+private void requestDurableHandle() {
+    Configuration config = context.getConfig();
+    
+    // Determine handle type based on configuration and server capabilities
+    if (tree.getSession().supports(SMB3_0) && config.isUsePersistentHandles()) {
+        handleType = HandleType.PERSISTENT;
+    } else if (tree.getSession().supports(SMB3_0)) {
+        handleType = HandleType.DURABLE_V2;
+    } else if (tree.getSession().supports(SMB2_1)) {
+        handleType = HandleType.DURABLE_V1;
+    } else {
+        return;  // No durable handle support
+    }
+    
+    long timeout = config.getDurableHandleTimeout();
+    Smb2LeaseKey leaseKey = getLeaseKey();  // Get associated lease if any
+    
+    handleGuid = handleManager.requestDurableHandle(getPath(), handleType, 
+                                                    timeout, leaseKey);
+    durableHandleRequested = true;
+    
+    // Add to create request
+    if (createRequest != null) {
+        createRequest.addDurableHandleContext(handleType, timeout, handleGuid);
+    }
+}
+
+private void reconnectWithDurableHandle(HandleInfo handle) throws IOException {
+    Smb2CreateRequest request = new Smb2CreateRequest();
+    request.setPath(handle.path);
+    request.addReconnectContext(handle.fileId);
+    
+    // Add lease context if needed
+    if (handle.leaseKey != null) {
+        request.addLeaseContext(handle.leaseKey, Smb2LeaseState.SMB2_LEASE_NONE, false);
+    }
+    
+    Smb2CreateResponse response = (Smb2CreateResponse) tree.send(request);
+    
+    if (response.isSuccess()) {
+        this.fileId = response.getFileId();
+        this.handleGuid = handle.createGuid;
+        this.handleType = handle.type;
+        handleManager.completeReconnect(handle.path, true);
+    } else {
+        handleManager.completeReconnect(handle.path, false);
+        throw new IOException("Failed to reconnect durable handle");
+    }
+}
+
+@Override
+public void close() throws IOException {
+    try {
+        // Normal close operations
+        super.close();
+    } finally {
+        // Don't release durable handle on close if it's persistent
+        if (handleManager != null && handleType != HandleType.PERSISTENT) {
+            handleManager.releaseHandle(getPath());
+        }
+    }
+}
+
+// Handle network errors with automatic reconnection
+@Override
+protected void handleNetworkError(IOException e) {
+    if (handleType != null && handleType != HandleType.NONE) {
+        // Attempt automatic reconnection
+        HandleReconnector reconnector = new HandleReconnector(handleManager);
+        try {
+            SmbFile reconnected = reconnector.reconnectHandle(this, e).get(5, TimeUnit.SECONDS);
+            // Update this file's state from reconnected file
+            this.fileId = reconnected.fileId;
+        } catch (Exception reconnectError) {
+            log.error("Failed to reconnect durable handle", reconnectError);
+            throw new IOException("Connection lost and reconnection failed", e);
+        }
+    } else {
+        throw e;  // No durable handle, propagate error
+    }
+}
+```
+
+### 6.3 Session Integration
+```java
+// In SmbSession.java
+private PersistentHandleManager handleManager;
+
+public SmbSession(CIFSContext context, SmbTransport transport) {
+    // ... existing initialization ...
+    
+    if (context.getConfig().isUseDurableHandles()) {
+        this.handleManager = new PersistentHandleManager(context);
+    }
+}
+
+public PersistentHandleManager getHandleManager() {
+    return handleManager;
+}
+
+@Override
+public void logoff() throws IOException {
+    if (handleManager != null) {
+        handleManager.shutdown();
+    }
+    // ... existing logoff logic ...
+}
+```
+
+## 7. Configuration
+
+### 7.1 Configuration Properties
+```java
+// In PropertyConfiguration.java
+public static final String USE_DURABLE_HANDLES = "jcifs.smb.client.useDurableHandles";
+public static final String USE_PERSISTENT_HANDLES = "jcifs.smb.client.usePersistentHandles";
+public static final String DURABLE_HANDLE_TIMEOUT = "jcifs.smb.client.durableHandleTimeout";
+public static final String HANDLE_RECONNECT_RETRIES = "jcifs.smb.client.handleReconnectRetries";
+public static final String HANDLE_STATE_DIR = "jcifs.smb.client.handleStateDirectory";
+
+public boolean isUseDurableHandles() {
+    return getBooleanProperty(USE_DURABLE_HANDLES, true);
+}
+
+public boolean isUsePersistentHandles() {
+    return getBooleanProperty(USE_PERSISTENT_HANDLES, false);
+}
+
+public long getDurableHandleTimeout() {
+    return getLongProperty(DURABLE_HANDLE_TIMEOUT, 120000);  // 2 minutes
+}
+
+public int getHandleReconnectRetries() {
+    return getIntProperty(HANDLE_RECONNECT_RETRIES, 3);
+}
+
+public String getHandleStateDirectory() {
+    return getProperty(HANDLE_STATE_DIR, 
+        System.getProperty("user.home") + "/.jcifs/handles");
+}
+```
+
+## 8. Testing Strategy
+
+### 8.1 Unit Tests
+```java
+package jcifs.tests.smb3;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class PersistentHandleTest {
+    
+    @Test
+    public void testHandleGuidGeneration() {
+        HandleGuid guid1 = new HandleGuid();
+        HandleGuid guid2 = new HandleGuid();
+        
+        assertNotEquals(guid1, guid2);
+        assertEquals(16, guid1.toBytes().length);
+        
+        // Test round-trip
+        HandleGuid guid3 = new HandleGuid(guid1.toBytes());
+        assertEquals(guid1, guid3);
+    }
+    
+    @Test
+    public void testHandleInfoExpiration() {
+        HandleInfo info = new HandleInfo(
+            "/test/file.txt",
+            new HandleGuid(),
+            new byte[16],
+            HandleType.DURABLE_V2,
+            1000,  // 1 second timeout
+            null
+        );
+        
+        assertFalse(info.isExpired());
+        
+        // Wait for expiration
+        Thread.sleep(1500);
+        assertTrue(info.isExpired());
+        
+        // Persistent handles don't expire
+        HandleInfo persistent = new HandleInfo(
+            "/test/file2.txt",
+            new HandleGuid(),
+            new byte[16],
+            HandleType.PERSISTENT,
+            0,
+            null
+        );
+        
+        Thread.sleep(100);
+        assertFalse(persistent.isExpired());
+    }
+    
+    @Test
+    public void testHandleManagerPersistence() throws Exception {
+        CIFSContext context = new BaseContext(new PropertyConfiguration());
+        PersistentHandleManager manager = new PersistentHandleManager(context);
+        
+        // Create persistent handle
+        HandleGuid guid = manager.requestDurableHandle(
+            "/test/file.txt",
+            HandleType.PERSISTENT,
+            0,
+            null
+        );
+        
+        byte[] fileId = new byte[16];
+        Arrays.fill(fileId, (byte)0x42);
+        manager.updateHandleFileId(guid, fileId);
+        
+        // Shutdown and recreate manager
+        manager.shutdown();
+        
+        PersistentHandleManager manager2 = new PersistentHandleManager(context);
+        HandleInfo recovered = manager2.getHandleForReconnect("/test/file.txt");
+        
+        assertNotNull(recovered);
+        assertEquals(HandleType.PERSISTENT, recovered.type);
+        assertArrayEquals(fileId, recovered.fileId);
+    }
+}
+```
+
+### 8.2 Integration Tests
+```java
+@Test
+public void testDurableHandleReconnection() throws Exception {
+    CIFSContext context = getTestContext();
+    context.getConfig().setProperty("jcifs.smb.client.useDurableHandles", "true");
+    
+    SmbFile file = new SmbFile("smb://server/share/test.txt", context);
+    file.createNewFile();
+    
+    // Write some data
+    try (OutputStream os = file.getOutputStream()) {
+        os.write("test data".getBytes());
+    }
+    
+    // Simulate network disconnection
+    file.getTree().getSession().getTransport().disconnect();
+    
+    // Try to read - should trigger reconnection
+    try (InputStream is = file.getInputStream()) {
+        byte[] buffer = new byte[9];
+        is.read(buffer);
+        assertEquals("test data", new String(buffer));
+    }
+}
+
+@Test
+public void testPersistentHandleSurvivesReboot() throws Exception {
+    // This test requires special setup with server reboot capability
+    CIFSContext context = getTestContext();
+    context.getConfig().setProperty("jcifs.smb.client.usePersistentHandles", "true");
+    
+    SmbFile file = new SmbFile("smb://server/share/persistent.txt", context);
+    file.createNewFile();
+    
+    // Get handle info
+    PersistentHandleManager manager = file.getTree().getSession().getHandleManager();
+    HandleInfo handle = manager.getHandleForReconnect(file.getPath());
+    assertNotNull(handle);
+    assertEquals(HandleType.PERSISTENT, handle.type);
+    
+    // Simulate server reboot
+    // ... server reboot logic ...
+    
+    // Reconnect should succeed
+    SmbFile file2 = new SmbFile("smb://server/share/persistent.txt", context);
+    assertTrue(file2.exists());  // Should reconnect with persistent handle
+}
+```
+
+## 9. Error Handling and Recovery
+
+### 9.1 Handle Break Scenarios
+```java
+public enum HandleBreakReason {
+    NETWORK_FAILURE,      // Network connection lost
+    SESSION_EXPIRED,      // Session timeout
+    SERVER_REBOOT,        // Server restart
+    HANDLE_EXPIRED,       // Handle timeout reached
+    LEASE_BREAK,         // Associated lease broken
+    EXPLICIT_CLOSE       // User closed handle
+}
+
+public class HandleBreakHandler {
+    public void handleBreak(HandleInfo handle, HandleBreakReason reason) {
+        switch (reason) {
+            case NETWORK_FAILURE:
+            case SESSION_EXPIRED:
+                // Attempt immediate reconnection
+                scheduleReconnect(handle, 0);
+                break;
+                
+            case SERVER_REBOOT:
+                // Wait before reconnecting
+                scheduleReconnect(handle, 5000);
+                break;
+                
+            case HANDLE_EXPIRED:
+            case LEASE_BREAK:
+                // Release handle, create new one
+                releaseAndRecreate(handle);
+                break;
+                
+            case EXPLICIT_CLOSE:
+                // Clean release
+                releaseHandle(handle);
+                break;
+        }
+    }
+}
+```
+
+## 10. Performance Considerations
+
+### 10.1 Handle Caching Strategy
+```java
+public class HandleCache {
+    private final int maxHandles = 1000;
+    private final LinkedHashMap<String, HandleInfo> lruCache;
+    
+    public HandleCache() {
+        this.lruCache = new LinkedHashMap<String, HandleInfo>(maxHandles, 0.75f, true) {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<String, HandleInfo> eldest) {
+                if (size() > maxHandles) {
+                    // Release least recently used non-persistent handle
+                    if (eldest.getValue().type != HandleType.PERSISTENT) {
+                        releaseHandle(eldest.getValue());
+                        return true;
+                    }
+                }
+                return false;
+            }
+        };
+    }
+}
+```
+
+### 10.2 Batch Handle Operations
+```java
+public class BatchHandleOperations {
+    public void reconnectMultipleHandles(List<HandleInfo> handles) {
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        
+        for (HandleInfo handle : handles) {
+            futures.add(CompletableFuture.runAsync(() -> {
+                try {
+                    reconnectHandle(handle);
+                } catch (Exception e) {
+                    log.error("Failed to reconnect handle: " + handle.path, e);
+                }
+            }));
+        }
+        
+        // Wait for all reconnections
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+    }
+}
+```
+
+## 11. Monitoring and Metrics
+
+### 11.1 Handle Statistics
+```java
+public class HandleStatistics {
+    private final AtomicLong handlesRequested = new AtomicLong();
+    private final AtomicLong handlesGranted = new AtomicLong();
+    private final AtomicLong reconnectAttempts = new AtomicLong();
+    private final AtomicLong reconnectSuccesses = new AtomicLong();
+    private final AtomicLong handleExpirations = new AtomicLong();
+    
+    public double getReconnectSuccessRate() {
+        long attempts = reconnectAttempts.get();
+        if (attempts == 0) return 0.0;
+        return (double) reconnectSuccesses.get() / attempts;
+    }
+}
+```
+
+## 12. Security Considerations
+
+### 12.1 Handle State Encryption
+```java
+public class SecureHandleStorage {
+    private final SecretKey encryptionKey;
+    
+    public void saveEncrypted(HandleInfo handle, Path file) throws Exception {
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        cipher.init(Cipher.ENCRYPT_MODE, encryptionKey);
+        
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (CipherOutputStream cos = new CipherOutputStream(baos, cipher);
+             ObjectOutputStream oos = new ObjectOutputStream(cos)) {
+            oos.writeObject(handle);
+        }
+        
+        Files.write(file, baos.toByteArray());
+    }
+}
+```

--- a/docs/smb3-features/03-multi-channel-design.md
+++ b/docs/smb3-features/03-multi-channel-design.md
@@ -1,0 +1,1164 @@
+# Multi-Channel Feature - Detailed Design Document
+
+## 1. Overview
+
+SMB3 Multi-Channel enables the use of multiple network connections between client and server, providing increased throughput, network fault tolerance, and automatic failover capabilities. This feature aggregates bandwidth across multiple NICs and provides seamless failover when network paths fail.
+
+## 2. Protocol Specification Reference
+
+- **MS-SMB2 Section 3.2.4.23**: FSCTL_QUERY_NETWORK_INTERFACE_INFO
+- **MS-SMB2 Section 3.2.5.14.8**: Sending an SMB2 IOCTL Request for FSCTL_QUERY_NETWORK_INTERFACE_INFO
+- **MS-SMB2 Section 3.1.5.3**: Receiving an SMB_COM_NEGOTIATE
+- **MS-SMB2 Section 3.2.4.1.6**: Alternative Channel Creation
+- **MS-SMB2 Section 3.3.5.15.12**: Channel Binding
+
+## 3. Multi-Channel Architecture
+
+### 3.1 Channel States
+```java
+public enum ChannelState {
+    DISCONNECTED(0),     // Not connected
+    CONNECTING(1),       // Connection in progress
+    AUTHENTICATING(2),   // Authentication in progress
+    ESTABLISHED(3),      // Ready for use
+    BINDING(4),         // Channel binding in progress
+    ACTIVE(5),          // Actively transferring data
+    FAILED(6),          // Connection failed
+    CLOSING(7);         // Closing connection
+    
+    private final int value;
+    
+    ChannelState(int value) {
+        this.value = value;
+    }
+}
+```
+
+### 3.2 Channel Capabilities
+```java
+public class Smb2ChannelCapabilities {
+    // Multi-channel specific capabilities
+    public static final int SMB2_GLOBAL_CAP_MULTI_CHANNEL = 0x00000008;
+    
+    // Channel binding policies
+    public static final int CHANNEL_BINDING_DISABLED = 0;
+    public static final int CHANNEL_BINDING_PREFERRED = 1;
+    public static final int CHANNEL_BINDING_REQUIRED = 2;
+    
+    // Maximum channels per session
+    public static final int DEFAULT_MAX_CHANNELS = 4;
+    public static final int ABSOLUTE_MAX_CHANNELS = 32;
+}
+```
+
+## 4. Data Structures
+
+### 4.1 Network Interface Information
+```java
+package jcifs.internal.smb2.multichannel;
+
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.util.ArrayList;
+import java.util.List;
+
+public class NetworkInterfaceInfo {
+    private int interfaceIndex;
+    private int capability;
+    private int linkSpeed;  // In units of 1 Mbps
+    private byte[] sockaddrStorage;  // Socket address
+    private InetAddress address;
+    private boolean ipv6;
+    private boolean rssCapable;  // Receive Side Scaling
+    private boolean rdmaCapable;
+    
+    // Capability flags
+    public static final int NETWORK_INTERFACE_CAP_RSS = 0x00000001;
+    public static final int NETWORK_INTERFACE_CAP_RDMA = 0x00000002;
+    
+    public NetworkInterfaceInfo(InetAddress address, int linkSpeed) {
+        this.address = address;
+        this.linkSpeed = linkSpeed;
+        this.ipv6 = address.getAddress().length == 16;
+        this.capability = 0;
+        
+        // Check for RSS capability (simplified - would need OS-specific checks)
+        this.rssCapable = checkRSSCapability();
+        if (rssCapable) {
+            this.capability |= NETWORK_INTERFACE_CAP_RSS;
+        }
+    }
+    
+    public boolean isUsableForChannel() {
+        return address != null && !address.isLoopbackAddress() 
+            && !address.isLinkLocalAddress();
+    }
+    
+    public int getScore() {
+        // Score interface for selection (higher is better)
+        int score = linkSpeed;  // Base score is link speed
+        
+        if (rssCapable) score += 1000;   // Prefer RSS-capable
+        if (rdmaCapable) score += 2000;  // Prefer RDMA-capable
+        if (!ipv6) score += 100;         // Slight preference for IPv4
+        
+        return score;
+    }
+    
+    private boolean checkRSSCapability() {
+        // Platform-specific RSS detection
+        // Simplified implementation
+        try {
+            NetworkInterface ni = NetworkInterface.getByInetAddress(address);
+            return ni != null && ni.supportsMulticast();
+        } catch (Exception e) {
+            return false;
+        }
+    }
+    
+    public byte[] encode() {
+        // Encode for FSCTL_QUERY_NETWORK_INTERFACE_INFO response
+        byte[] buffer = new byte[152];  // Fixed size structure
+        
+        // InterfaceIndex (4 bytes)
+        writeInt4(buffer, 0, interfaceIndex);
+        
+        // Capability (4 bytes)
+        writeInt4(buffer, 4, capability);
+        
+        // Reserved (4 bytes)
+        writeInt4(buffer, 8, 0);
+        
+        // LinkSpeed (8 bytes)
+        writeInt8(buffer, 12, linkSpeed * 1000000L);  // Convert to bps
+        
+        // SockaddrStorage (128 bytes)
+        encodeSockaddr(buffer, 20);
+        
+        return buffer;
+    }
+    
+    private void encodeSockaddr(byte[] buffer, int offset) {
+        if (ipv6) {
+            // IPv6 sockaddr_in6 structure
+            writeInt2(buffer, offset, 23);  // AF_INET6
+            writeInt2(buffer, offset + 2, 445);  // Port
+            writeInt4(buffer, offset + 4, 0);  // Flow info
+            System.arraycopy(address.getAddress(), 0, buffer, offset + 8, 16);
+            writeInt4(buffer, offset + 24, 0);  // Scope ID
+        } else {
+            // IPv4 sockaddr_in structure
+            writeInt2(buffer, offset, 2);  // AF_INET
+            writeInt2(buffer, offset + 2, 445);  // Port
+            System.arraycopy(address.getAddress(), 0, buffer, offset + 4, 4);
+        }
+    }
+}
+```
+
+### 4.2 Channel Information
+```java
+package jcifs.internal.smb2.multichannel;
+
+import jcifs.smb.SmbTransport;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class ChannelInfo {
+    private final String channelId;
+    private final SmbTransport transport;
+    private final NetworkInterfaceInfo localInterface;
+    private final NetworkInterfaceInfo remoteInterface;
+    private volatile ChannelState state;
+    private final long establishedTime;
+    private volatile long lastActivityTime;
+    
+    // Performance metrics
+    private final AtomicLong bytesSent;
+    private final AtomicLong bytesReceived;
+    private final AtomicLong requestsSent;
+    private final AtomicLong requestsReceived;
+    private final AtomicLong errors;
+    
+    // Channel binding
+    private byte[] bindingHash;
+    private boolean isPrimary;
+    
+    public ChannelInfo(String id, SmbTransport transport, 
+                      NetworkInterfaceInfo local, NetworkInterfaceInfo remote) {
+        this.channelId = id;
+        this.transport = transport;
+        this.localInterface = local;
+        this.remoteInterface = remote;
+        this.state = ChannelState.DISCONNECTED;
+        this.establishedTime = System.currentTimeMillis();
+        this.lastActivityTime = establishedTime;
+        
+        this.bytesSent = new AtomicLong();
+        this.bytesReceived = new AtomicLong();
+        this.requestsSent = new AtomicLong();
+        this.requestsReceived = new AtomicLong();
+        this.errors = new AtomicLong();
+        
+        this.isPrimary = false;
+    }
+    
+    public void updateActivity() {
+        this.lastActivityTime = System.currentTimeMillis();
+    }
+    
+    public long getIdleTime() {
+        return System.currentTimeMillis() - lastActivityTime;
+    }
+    
+    public boolean isHealthy() {
+        return state == ChannelState.ACTIVE || state == ChannelState.ESTABLISHED;
+    }
+    
+    public double getErrorRate() {
+        long total = requestsSent.get();
+        if (total == 0) return 0.0;
+        return (double) errors.get() / total;
+    }
+    
+    public long getThroughput() {
+        long duration = System.currentTimeMillis() - establishedTime;
+        if (duration == 0) return 0;
+        return (bytesSent.get() + bytesReceived.get()) * 1000 / duration;
+    }
+    
+    public int getScore() {
+        // Calculate channel score for load balancing
+        int score = 100;
+        
+        // Adjust based on state
+        if (state == ChannelState.ACTIVE) score -= 20;  // Busy channel
+        if (state != ChannelState.ESTABLISHED && state != ChannelState.ACTIVE) return 0;
+        
+        // Adjust based on error rate
+        double errorRate = getErrorRate();
+        if (errorRate > 0.1) score -= 50;
+        else if (errorRate > 0.01) score -= 20;
+        
+        // Adjust based on interface capabilities
+        score += localInterface.getScore() / 100;
+        score += remoteInterface.getScore() / 100;
+        
+        // Prefer primary channel slightly
+        if (isPrimary) score += 10;
+        
+        return Math.max(0, score);
+    }
+}
+```
+
+### 4.3 Channel Manager
+```java
+package jcifs.internal.smb2.multichannel;
+
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ChannelManager {
+    private final CIFSContext context;
+    private final SmbSession session;
+    private final Map<String, ChannelInfo> channels;
+    private final List<NetworkInterfaceInfo> localInterfaces;
+    private final List<NetworkInterfaceInfo> remoteInterfaces;
+    private final ScheduledExecutorService scheduler;
+    private final ChannelLoadBalancer loadBalancer;
+    private final ChannelFailover failover;
+    
+    private volatile boolean multiChannelEnabled;
+    private final int maxChannels;
+    private final AtomicInteger channelCounter;
+    
+    public ChannelManager(CIFSContext context, SmbSession session) {
+        this.context = context;
+        this.session = session;
+        this.channels = new ConcurrentHashMap<>();
+        this.localInterfaces = new ArrayList<>();
+        this.remoteInterfaces = new ArrayList<>();
+        this.scheduler = Executors.newScheduledThreadPool(2);
+        this.loadBalancer = new ChannelLoadBalancer(this);
+        this.failover = new ChannelFailover(this);
+        
+        Configuration config = context.getConfig();
+        this.maxChannels = config.getMaxChannels();
+        this.channelCounter = new AtomicInteger(0);
+        this.multiChannelEnabled = false;
+        
+        // Schedule periodic health checks
+        scheduler.scheduleAtFixedRate(this::performHealthCheck, 10, 10, TimeUnit.SECONDS);
+        
+        // Schedule interface discovery
+        scheduler.scheduleAtFixedRate(this::discoverInterfaces, 0, 30, TimeUnit.SECONDS);
+    }
+    
+    public void initializeMultiChannel() throws IOException {
+        // Check server capability
+        if (!session.getServer().supportsMultiChannel()) {
+            log.info("Server does not support multi-channel");
+            return;
+        }
+        
+        // Query network interfaces from server
+        queryRemoteInterfaces();
+        
+        // Discover local interfaces
+        discoverLocalInterfaces();
+        
+        // Enable multi-channel if we have multiple usable interfaces
+        if (canEnableMultiChannel()) {
+            multiChannelEnabled = true;
+            establishAdditionalChannels();
+        }
+    }
+    
+    private void queryRemoteInterfaces() throws IOException {
+        // Send FSCTL_QUERY_NETWORK_INTERFACE_INFO
+        Smb2IoctlRequest request = new Smb2IoctlRequest();
+        request.setCtlCode(FSCTL_QUERY_NETWORK_INTERFACE_INFO);
+        request.setFileId(new byte[16]);  // Use session ID
+        request.setMaxOutputResponse(65536);
+        
+        Smb2IoctlResponse response = (Smb2IoctlResponse) session.send(request);
+        
+        if (response.isSuccess()) {
+            parseNetworkInterfaces(response.getOutputData());
+        }
+    }
+    
+    private void parseNetworkInterfaces(byte[] data) {
+        remoteInterfaces.clear();
+        int offset = 0;
+        
+        while (offset < data.length) {
+            // Parse NETWORK_INTERFACE_INFO structure
+            int next = readInt4(data, offset);
+            int ifIndex = readInt4(data, offset + 4);
+            int capability = readInt4(data, offset + 8);
+            long linkSpeed = readInt8(data, offset + 16);
+            
+            // Parse socket address
+            InetAddress addr = parseSockaddr(data, offset + 24);
+            
+            NetworkInterfaceInfo info = new NetworkInterfaceInfo(
+                addr, (int)(linkSpeed / 1000000));
+            info.setInterfaceIndex(ifIndex);
+            info.setCapability(capability);
+            
+            if (info.isUsableForChannel()) {
+                remoteInterfaces.add(info);
+            }
+            
+            if (next == 0) break;
+            offset += next;
+        }
+        
+        // Sort by score (best interfaces first)
+        remoteInterfaces.sort((a, b) -> Integer.compare(b.getScore(), a.getScore()));
+    }
+    
+    private void discoverLocalInterfaces() {
+        localInterfaces.clear();
+        
+        try {
+            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+            
+            while (interfaces.hasMoreElements()) {
+                NetworkInterface ni = interfaces.nextElement();
+                
+                if (!ni.isUp() || ni.isLoopback() || ni.isVirtual()) {
+                    continue;
+                }
+                
+                Enumeration<InetAddress> addresses = ni.getInetAddresses();
+                while (addresses.hasMoreElements()) {
+                    InetAddress addr = addresses.nextElement();
+                    
+                    // Estimate link speed (would need platform-specific code for actual speed)
+                    int linkSpeed = ni.isVirtual() ? 100 : 1000;  // Default 1Gbps
+                    
+                    NetworkInterfaceInfo info = new NetworkInterfaceInfo(addr, linkSpeed);
+                    if (info.isUsableForChannel()) {
+                        localInterfaces.add(info);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.error("Failed to discover local interfaces", e);
+        }
+        
+        // Sort by score
+        localInterfaces.sort((a, b) -> Integer.compare(b.getScore(), a.getScore()));
+    }
+    
+    private boolean canEnableMultiChannel() {
+        return localInterfaces.size() > 0 && remoteInterfaces.size() > 0
+            && (localInterfaces.size() > 1 || remoteInterfaces.size() > 1);
+    }
+    
+    private void establishAdditionalChannels() {
+        int currentChannels = channels.size();
+        int targetChannels = Math.min(maxChannels, 
+            Math.min(localInterfaces.size(), remoteInterfaces.size()));
+        
+        for (int i = currentChannels; i < targetChannels; i++) {
+            try {
+                establishChannel(i);
+            } catch (Exception e) {
+                log.warn("Failed to establish channel {}", i, e);
+            }
+        }
+    }
+    
+    private void establishChannel(int index) throws IOException {
+        // Select interfaces for this channel
+        NetworkInterfaceInfo localIf = selectLocalInterface(index);
+        NetworkInterfaceInfo remoteIf = selectRemoteInterface(index);
+        
+        // Create transport for this channel
+        SmbTransport transport = createTransport(localIf, remoteIf);
+        
+        // Create channel info
+        String channelId = "channel-" + channelCounter.incrementAndGet();
+        ChannelInfo channel = new ChannelInfo(channelId, transport, localIf, remoteIf);
+        
+        // Establish connection
+        channel.setState(ChannelState.CONNECTING);
+        transport.connect();
+        
+        // Perform channel binding
+        performChannelBinding(channel);
+        
+        // Add to active channels
+        channels.put(channelId, channel);
+        channel.setState(ChannelState.ESTABLISHED);
+        
+        log.info("Established channel {} using {}:{} -> {}:{}", 
+            channelId, localIf.getAddress(), remoteIf.getAddress());
+    }
+    
+    private void performChannelBinding(ChannelInfo channel) throws IOException {
+        // Calculate channel binding hash
+        byte[] bindingInfo = calculateBindingInfo(channel);
+        byte[] bindingHash = calculateBindingHash(bindingInfo);
+        channel.setBindingHash(bindingHash);
+        
+        // Send session setup with channel binding
+        Smb2SessionSetupRequest request = new Smb2SessionSetupRequest();
+        request.setSessionId(session.getSessionId());
+        request.setFlags(SMB2_SESSION_FLAG_BINDING);
+        request.setSecurityBuffer(bindingHash);
+        
+        Smb2SessionSetupResponse response = (Smb2SessionSetupResponse) 
+            channel.getTransport().send(request);
+        
+        if (!response.isSuccess()) {
+            throw new IOException("Channel binding failed: " + response.getStatus());
+        }
+    }
+    
+    private byte[] calculateBindingInfo(ChannelInfo channel) {
+        // Combine session key with channel-specific data
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        
+        try {
+            baos.write(session.getSessionKey());
+            baos.write(channel.getLocalInterface().getAddress().getAddress());
+            baos.write(channel.getRemoteInterface().getAddress().getAddress());
+            baos.write(ByteBuffer.allocate(8).putLong(System.currentTimeMillis()).array());
+        } catch (IOException e) {
+            // Should not happen with ByteArrayOutputStream
+        }
+        
+        return baos.toByteArray();
+    }
+    
+    private byte[] calculateBindingHash(byte[] bindingInfo) throws IOException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return digest.digest(bindingInfo);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IOException("SHA-256 not available", e);
+        }
+    }
+    
+    public ChannelInfo selectChannel(SMBMessage message) {
+        return loadBalancer.selectChannel(message);
+    }
+    
+    public void handleChannelFailure(ChannelInfo channel, Exception error) {
+        failover.handleFailure(channel, error);
+    }
+    
+    private void performHealthCheck() {
+        for (ChannelInfo channel : channels.values()) {
+            if (channel.getIdleTime() > 60000) {  // 1 minute idle
+                // Send keep-alive
+                try {
+                    sendKeepAlive(channel);
+                } catch (Exception e) {
+                    log.debug("Keep-alive failed for channel {}", channel.getChannelId());
+                    handleChannelFailure(channel, e);
+                }
+            }
+            
+            // Check error rate
+            if (channel.getErrorRate() > 0.1) {
+                log.warn("High error rate on channel {}: {}", 
+                    channel.getChannelId(), channel.getErrorRate());
+                // Consider removing channel
+            }
+        }
+    }
+    
+    private void discoverInterfaces() {
+        if (!multiChannelEnabled) return;
+        
+        // Periodically rediscover interfaces in case of network changes
+        discoverLocalInterfaces();
+        
+        try {
+            queryRemoteInterfaces();
+        } catch (Exception e) {
+            log.debug("Failed to query remote interfaces", e);
+        }
+        
+        // Check if we should add/remove channels
+        adjustChannelCount();
+    }
+    
+    private void adjustChannelCount() {
+        int currentChannels = channels.size();
+        int targetChannels = Math.min(maxChannels, 
+            Math.min(localInterfaces.size(), remoteInterfaces.size()));
+        
+        if (currentChannels < targetChannels) {
+            // Add more channels
+            establishAdditionalChannels();
+        } else if (currentChannels > targetChannels) {
+            // Remove excess channels
+            removeExcessChannels(currentChannels - targetChannels);
+        }
+    }
+    
+    public void shutdown() {
+        scheduler.shutdown();
+        
+        for (ChannelInfo channel : channels.values()) {
+            try {
+                channel.getTransport().disconnect();
+            } catch (Exception e) {
+                log.debug("Error closing channel", e);
+            }
+        }
+        
+        channels.clear();
+    }
+}
+```
+
+### 4.4 Channel Load Balancer
+```java
+package jcifs.internal.smb2.multichannel;
+
+import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class ChannelLoadBalancer {
+    private final ChannelManager manager;
+    private LoadBalancingStrategy strategy;
+    
+    public enum LoadBalancingStrategy {
+        ROUND_ROBIN,      // Rotate through channels
+        LEAST_LOADED,     // Select least busy channel
+        WEIGHTED_RANDOM,  // Random selection weighted by score
+        AFFINITY_BASED,   // Stick to same channel for related operations
+        ADAPTIVE         // Dynamically adjust based on performance
+    }
+    
+    public ChannelLoadBalancer(ChannelManager manager) {
+        this.manager = manager;
+        this.strategy = LoadBalancingStrategy.ADAPTIVE;
+    }
+    
+    public ChannelInfo selectChannel(SMBMessage message) {
+        Collection<ChannelInfo> availableChannels = manager.getHealthyChannels();
+        
+        if (availableChannels.isEmpty()) {
+            throw new NoAvailableChannelException("No healthy channels available");
+        }
+        
+        if (availableChannels.size() == 1) {
+            return availableChannels.iterator().next();
+        }
+        
+        switch (strategy) {
+            case ROUND_ROBIN:
+                return selectRoundRobin(availableChannels);
+                
+            case LEAST_LOADED:
+                return selectLeastLoaded(availableChannels);
+                
+            case WEIGHTED_RANDOM:
+                return selectWeightedRandom(availableChannels);
+                
+            case AFFINITY_BASED:
+                return selectWithAffinity(message, availableChannels);
+                
+            case ADAPTIVE:
+            default:
+                return selectAdaptive(message, availableChannels);
+        }
+    }
+    
+    private ChannelInfo selectLeastLoaded(Collection<ChannelInfo> channels) {
+        return channels.stream()
+            .min(Comparator.comparingLong(ChannelInfo::getRequestsPending))
+            .orElseThrow();
+    }
+    
+    private ChannelInfo selectWeightedRandom(Collection<ChannelInfo> channels) {
+        // Calculate total weight
+        int totalWeight = channels.stream()
+            .mapToInt(ChannelInfo::getScore)
+            .sum();
+        
+        if (totalWeight == 0) {
+            // All channels have zero score, pick randomly
+            List<ChannelInfo> list = new ArrayList<>(channels);
+            return list.get(ThreadLocalRandom.current().nextInt(list.size()));
+        }
+        
+        // Weighted random selection
+        int random = ThreadLocalRandom.current().nextInt(totalWeight);
+        int currentWeight = 0;
+        
+        for (ChannelInfo channel : channels) {
+            currentWeight += channel.getScore();
+            if (random < currentWeight) {
+                return channel;
+            }
+        }
+        
+        // Should not reach here
+        return channels.iterator().next();
+    }
+    
+    private ChannelInfo selectWithAffinity(SMBMessage message, Collection<ChannelInfo> channels) {
+        // Use file handle or tree ID for affinity
+        long affinityKey = 0;
+        
+        if (message instanceof Smb2ReadRequest) {
+            affinityKey = Arrays.hashCode(((Smb2ReadRequest)message).getFileId());
+        } else if (message instanceof Smb2WriteRequest) {
+            affinityKey = Arrays.hashCode(((Smb2WriteRequest)message).getFileId());
+        }
+        
+        if (affinityKey != 0) {
+            // Select channel based on affinity key
+            List<ChannelInfo> list = new ArrayList<>(channels);
+            int index = Math.abs((int)(affinityKey % list.size()));
+            return list.get(index);
+        }
+        
+        // No affinity, use weighted random
+        return selectWeightedRandom(channels);
+    }
+    
+    private ChannelInfo selectAdaptive(SMBMessage message, Collection<ChannelInfo> channels) {
+        // Adaptive strategy based on message type and size
+        
+        if (isLargeTransfer(message)) {
+            // For large transfers, prefer high-bandwidth channels
+            return channels.stream()
+                .max(Comparator.comparingInt(c -> c.getRemoteInterface().getLinkSpeed()))
+                .orElseThrow();
+        }
+        
+        if (isMetadataOperation(message)) {
+            // For metadata operations, prefer low-latency channels
+            return selectLeastLoaded(channels);
+        }
+        
+        // Default to weighted random for general operations
+        return selectWeightedRandom(channels);
+    }
+    
+    private boolean isLargeTransfer(SMBMessage message) {
+        if (message instanceof Smb2ReadRequest) {
+            return ((Smb2ReadRequest)message).getLength() > 1048576;  // 1MB
+        }
+        if (message instanceof Smb2WriteRequest) {
+            return ((Smb2WriteRequest)message).getLength() > 1048576;
+        }
+        return false;
+    }
+    
+    private boolean isMetadataOperation(SMBMessage message) {
+        return message instanceof Smb2QueryInfoRequest
+            || message instanceof Smb2SetInfoRequest
+            || message instanceof Smb2QueryDirectoryRequest;
+    }
+}
+```
+
+### 4.5 Channel Failover Handler
+```java
+package jcifs.internal.smb2.multichannel;
+
+import java.util.concurrent.*;
+
+public class ChannelFailover {
+    private final ChannelManager manager;
+    private final ExecutorService executor;
+    private final Map<String, FailoverState> failoverStates;
+    
+    public ChannelFailover(ChannelManager manager) {
+        this.manager = manager;
+        this.executor = Executors.newCachedThreadPool();
+        this.failoverStates = new ConcurrentHashMap<>();
+    }
+    
+    public static class FailoverState {
+        private final String channelId;
+        private final long failureTime;
+        private int retryCount;
+        private long nextRetryTime;
+        
+        public FailoverState(String channelId) {
+            this.channelId = channelId;
+            this.failureTime = System.currentTimeMillis();
+            this.retryCount = 0;
+            this.nextRetryTime = failureTime + 1000;  // Initial 1 second delay
+        }
+        
+        public boolean shouldRetry() {
+            return retryCount < 3 && System.currentTimeMillis() >= nextRetryTime;
+        }
+        
+        public void incrementRetry() {
+            retryCount++;
+            // Exponential backoff: 1s, 2s, 4s
+            nextRetryTime = System.currentTimeMillis() + (1000L << retryCount);
+        }
+    }
+    
+    public void handleFailure(ChannelInfo failedChannel, Exception error) {
+        log.warn("Channel {} failed: {}", failedChannel.getChannelId(), error.getMessage());
+        
+        // Mark channel as failed
+        failedChannel.setState(ChannelState.FAILED);
+        
+        // Get or create failover state
+        FailoverState state = failoverStates.computeIfAbsent(
+            failedChannel.getChannelId(), 
+            FailoverState::new
+        );
+        
+        // Redistribute pending operations
+        redistributePendingOperations(failedChannel);
+        
+        // Attempt recovery
+        if (state.shouldRetry()) {
+            scheduleRecovery(failedChannel, state);
+        } else {
+            // Remove channel after max retries
+            removeChannel(failedChannel);
+        }
+    }
+    
+    private void redistributePendingOperations(ChannelInfo failedChannel) {
+        // Get pending operations from failed channel
+        List<SMBMessage> pendingOps = failedChannel.getPendingOperations();
+        
+        if (pendingOps.isEmpty()) {
+            return;
+        }
+        
+        log.info("Redistributing {} pending operations from failed channel", 
+            pendingOps.size());
+        
+        // Redistribute to healthy channels
+        for (SMBMessage op : pendingOps) {
+            try {
+                ChannelInfo alternativeChannel = manager.selectChannel(op);
+                alternativeChannel.getTransport().send(op);
+            } catch (Exception e) {
+                log.error("Failed to redistribute operation", e);
+                // Notify waiting threads of failure
+                op.notifyError(e);
+            }
+        }
+    }
+    
+    private void scheduleRecovery(ChannelInfo channel, FailoverState state) {
+        state.incrementRetry();
+        
+        executor.submit(() -> {
+            try {
+                log.info("Attempting to recover channel {}", channel.getChannelId());
+                
+                // Disconnect existing transport
+                channel.getTransport().disconnect();
+                
+                // Create new transport
+                SmbTransport newTransport = manager.createTransport(
+                    channel.getLocalInterface(),
+                    channel.getRemoteInterface()
+                );
+                
+                // Reconnect
+                channel.setState(ChannelState.CONNECTING);
+                newTransport.connect();
+                
+                // Re-establish channel binding
+                manager.performChannelBinding(channel);
+                
+                // Update channel with new transport
+                channel.setTransport(newTransport);
+                channel.setState(ChannelState.ESTABLISHED);
+                
+                // Clear failover state on success
+                failoverStates.remove(channel.getChannelId());
+                
+                log.info("Successfully recovered channel {}", channel.getChannelId());
+                
+            } catch (Exception e) {
+                log.warn("Failed to recover channel {}: {}", 
+                    channel.getChannelId(), e.getMessage());
+                
+                // Schedule next retry or remove
+                handleFailure(channel, e);
+            }
+        });
+    }
+    
+    private void removeChannel(ChannelInfo channel) {
+        log.info("Removing failed channel {} after max retries", channel.getChannelId());
+        
+        manager.removeChannel(channel);
+        failoverStates.remove(channel.getChannelId());
+        
+        // Try to establish a replacement channel
+        manager.establishReplacementChannel();
+    }
+}
+```
+
+## 5. Integration with Existing Code
+
+### 5.1 Session Integration
+```java
+// In SmbSession.java
+private ChannelManager channelManager;
+private boolean multiChannelSupported;
+
+public void negotiateMultiChannel() throws IOException {
+    // Check if both client and server support multi-channel
+    if (!context.getConfig().isUseMultiChannel()) {
+        return;
+    }
+    
+    if (!serverCapabilities.contains(SMB2_GLOBAL_CAP_MULTI_CHANNEL)) {
+        log.debug("Server does not support multi-channel");
+        return;
+    }
+    
+    multiChannelSupported = true;
+    
+    // Initialize channel manager
+    channelManager = new ChannelManager(context, this);
+    channelManager.initializeMultiChannel();
+}
+
+public SmbTransport selectTransport(SMBMessage message) {
+    if (channelManager != null && channelManager.isMultiChannelEnabled()) {
+        ChannelInfo channel = channelManager.selectChannel(message);
+        return channel.getTransport();
+    }
+    
+    // Fall back to single channel
+    return this.transport;
+}
+
+@Override
+public void send(SMBMessage message) throws IOException {
+    SmbTransport selectedTransport = selectTransport(message);
+    
+    try {
+        selectedTransport.send(message);
+    } catch (IOException e) {
+        if (channelManager != null) {
+            // Handle channel failure
+            ChannelInfo channel = channelManager.getChannelForTransport(selectedTransport);
+            channelManager.handleChannelFailure(channel, e);
+            
+            // Retry on different channel
+            SmbTransport alternativeTransport = selectTransport(message);
+            alternativeTransport.send(message);
+        } else {
+            throw e;
+        }
+    }
+}
+```
+
+### 5.2 Transport Pool Integration
+```java
+// In SmbTransportPool.java
+public SmbTransport getMultiChannelTransport(SmbSession session, 
+                                            NetworkInterfaceInfo localIf,
+                                            NetworkInterfaceInfo remoteIf) {
+    String key = localIf.getAddress() + ":" + remoteIf.getAddress();
+    
+    return transports.computeIfAbsent(key, k -> {
+        try {
+            SmbTransport transport = new SmbTransport(
+                context,
+                remoteIf.getAddress(),
+                remoteIf.getPort(),
+                localIf.getAddress()
+            );
+            
+            transport.connect();
+            return transport;
+            
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create transport", e);
+        }
+    });
+}
+```
+
+### 5.3 Read/Write Operations with Multi-Channel
+```java
+// In SmbFile.java
+public void optimizedLargeRead(byte[] buffer, long offset, int length) throws IOException {
+    if (!session.isMultiChannelEnabled() || length < 1048576) {  // 1MB threshold
+        // Use single channel for small reads
+        normalRead(buffer, offset, length);
+        return;
+    }
+    
+    // Split large read across multiple channels
+    ChannelManager channelManager = session.getChannelManager();
+    List<ChannelInfo> channels = channelManager.getHealthyChannels();
+    int channelCount = Math.min(channels.size(), 4);  // Max 4 parallel reads
+    
+    int chunkSize = length / channelCount;
+    List<CompletableFuture<Void>> futures = new ArrayList<>();
+    
+    for (int i = 0; i < channelCount; i++) {
+        final int chunkOffset = i * chunkSize;
+        final int chunkLength = (i == channelCount - 1) ? 
+            length - chunkOffset : chunkSize;
+        final ChannelInfo channel = channels.get(i);
+        
+        CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
+            try {
+                Smb2ReadRequest request = new Smb2ReadRequest();
+                request.setFileId(this.fileId);
+                request.setOffset(offset + chunkOffset);
+                request.setLength(chunkLength);
+                
+                Smb2ReadResponse response = (Smb2ReadResponse) 
+                    channel.getTransport().send(request);
+                
+                System.arraycopy(response.getData(), 0, buffer, 
+                    chunkOffset, response.getDataLength());
+                    
+            } catch (Exception e) {
+                throw new CompletionException(e);
+            }
+        });
+        
+        futures.add(future);
+    }
+    
+    // Wait for all reads to complete
+    try {
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+            .get(30, TimeUnit.SECONDS);
+    } catch (Exception e) {
+        throw new IOException("Multi-channel read failed", e);
+    }
+}
+```
+
+## 6. Configuration
+
+### 6.1 Configuration Properties
+```java
+// In PropertyConfiguration.java
+public static final String USE_MULTI_CHANNEL = "jcifs.smb.client.useMultiChannel";
+public static final String MAX_CHANNELS = "jcifs.smb.client.maxChannels";
+public static final String CHANNEL_BINDING_POLICY = "jcifs.smb.client.channelBindingPolicy";
+public static final String LOAD_BALANCING_STRATEGY = "jcifs.smb.client.loadBalancingStrategy";
+public static final String CHANNEL_HEALTH_CHECK_INTERVAL = "jcifs.smb.client.channelHealthCheckInterval";
+
+public boolean isUseMultiChannel() {
+    return getBooleanProperty(USE_MULTI_CHANNEL, true);
+}
+
+public int getMaxChannels() {
+    return getIntProperty(MAX_CHANNELS, 4);
+}
+
+public int getChannelBindingPolicy() {
+    String policy = getProperty(CHANNEL_BINDING_POLICY, "preferred");
+    switch (policy.toLowerCase()) {
+        case "disabled": return 0;
+        case "required": return 2;
+        default: return 1;  // preferred
+    }
+}
+
+public LoadBalancingStrategy getLoadBalancingStrategy() {
+    String strategy = getProperty(LOAD_BALANCING_STRATEGY, "adaptive");
+    return LoadBalancingStrategy.valueOf(strategy.toUpperCase());
+}
+```
+
+## 7. Testing Strategy
+
+### 7.1 Unit Tests
+```java
+@Test
+public void testChannelSelection() {
+    ChannelManager manager = new ChannelManager(context, session);
+    
+    // Add test channels
+    ChannelInfo channel1 = createTestChannel("channel1", 1000);  // 1Gbps
+    ChannelInfo channel2 = createTestChannel("channel2", 10000); // 10Gbps
+    
+    manager.addChannel(channel1);
+    manager.addChannel(channel2);
+    
+    // Test load balancer selection
+    ChannelLoadBalancer balancer = new ChannelLoadBalancer(manager);
+    
+    // Large transfer should prefer high-bandwidth channel
+    Smb2ReadRequest largeRead = new Smb2ReadRequest();
+    largeRead.setLength(10485760);  // 10MB
+    
+    ChannelInfo selected = balancer.selectChannel(largeRead);
+    assertEquals(channel2, selected);  // Should select 10Gbps channel
+}
+
+@Test
+public void testChannelFailover() throws Exception {
+    ChannelManager manager = new ChannelManager(context, session);
+    ChannelFailover failover = new ChannelFailover(manager);
+    
+    ChannelInfo channel = createTestChannel("test-channel", 1000);
+    manager.addChannel(channel);
+    
+    // Simulate failure
+    IOException error = new IOException("Network error");
+    failover.handleFailure(channel, error);
+    
+    // Verify channel marked as failed
+    assertEquals(ChannelState.FAILED, channel.getState());
+    
+    // Verify recovery attempted
+    Thread.sleep(2000);
+    assertTrue(channel.getState() == ChannelState.ESTABLISHED 
+        || manager.getChannels().isEmpty());
+}
+```
+
+### 7.2 Integration Tests
+```java
+@Test
+public void testMultiChannelThroughput() throws Exception {
+    // Requires multi-NIC test environment
+    CIFSContext context = getTestContext();
+    context.getConfig().setProperty("jcifs.smb.client.useMultiChannel", "true");
+    context.getConfig().setProperty("jcifs.smb.client.maxChannels", "4");
+    
+    SmbFile file = new SmbFile("smb://server/share/largefile.dat", context);
+    
+    // Measure single channel throughput
+    long singleChannelTime = measureReadTime(file, false);
+    
+    // Measure multi-channel throughput
+    long multiChannelTime = measureReadTime(file, true);
+    
+    // Multi-channel should be faster
+    assertTrue(multiChannelTime < singleChannelTime * 0.7);  // At least 30% improvement
+}
+```
+
+## 8. Performance Metrics
+
+### 8.1 Channel Statistics
+```java
+public class MultiChannelStatistics {
+    private final Map<String, ChannelStatistics> channelStats;
+    
+    public class ChannelStatistics {
+        private final AtomicLong bytesSent = new AtomicLong();
+        private final AtomicLong bytesReceived = new AtomicLong();
+        private final AtomicLong operations = new AtomicLong();
+        private final AtomicLong errors = new AtomicLong();
+        private final AtomicLong latencyTotal = new AtomicLong();
+        
+        public double getAverageLatency() {
+            long ops = operations.get();
+            if (ops == 0) return 0;
+            return (double) latencyTotal.get() / ops;
+        }
+        
+        public long getThroughput() {
+            return bytesSent.get() + bytesReceived.get();
+        }
+    }
+    
+    public void recordOperation(String channelId, long bytes, long latency, boolean success) {
+        ChannelStatistics stats = channelStats.computeIfAbsent(channelId, 
+            k -> new ChannelStatistics());
+            
+        stats.operations.incrementAndGet();
+        stats.latencyTotal.addAndGet(latency);
+        
+        if (success) {
+            stats.bytesReceived.addAndGet(bytes);
+        } else {
+            stats.errors.incrementAndGet();
+        }
+    }
+    
+    public double getAggregatedThroughput() {
+        return channelStats.values().stream()
+            .mapToLong(ChannelStatistics::getThroughput)
+            .sum();
+    }
+}
+```
+
+## 9. Security Considerations
+
+### 9.1 Channel Binding Security
+```java
+public class SecureChannelBinding {
+    private final byte[] sessionKey;
+    
+    public byte[] generateChannelBindingHash(ChannelInfo channel) throws GeneralSecurityException {
+        // Use HMAC-SHA256 for channel binding
+        Mac mac = Mac.getInstance("HmacSHA256");
+        SecretKeySpec keySpec = new SecretKeySpec(sessionKey, "HmacSHA256");
+        mac.init(keySpec);
+        
+        // Include channel-specific data
+        mac.update(channel.getLocalInterface().getAddress().getAddress());
+        mac.update(channel.getRemoteInterface().getAddress().getAddress());
+        mac.update(ByteBuffer.allocate(8)
+            .putLong(channel.getEstablishedTime()).array());
+        
+        return mac.doFinal();
+    }
+}
+```

--- a/docs/smb3-features/04-directory-leasing-design.md
+++ b/docs/smb3-features/04-directory-leasing-design.md
@@ -1,0 +1,1059 @@
+# Directory Leasing Feature - Detailed Design Document
+
+## 1. Overview
+
+Directory leasing extends the SMB3 lease concept to directories, enabling client-side caching of directory metadata and change notifications. This significantly improves performance for applications that frequently enumerate directories or monitor directory changes.
+
+## 2. Protocol Specification Reference
+
+- **MS-SMB2 Section 2.2.13.2.12**: SMB2_CREATE_REQUEST_LEASE_V2 for directories
+- **MS-SMB2 Section 2.2.14.2.12**: SMB2_CREATE_RESPONSE_LEASE_V2 for directories  
+- **MS-SMB2 Section 2.2.35**: SMB2 Change Notify Request
+- **MS-SMB2 Section 2.2.36**: SMB2 Change Notify Response
+- **MS-SMB2 Section 3.3.5.9.11**: Directory Leasing and Caching
+
+## 3. Directory Lease Types
+
+### 3.1 Directory-Specific Lease States
+```java
+public class DirectoryLeaseState extends Smb2LeaseState {
+    // Standard lease states apply, plus directory-specific semantics:
+    
+    // READ_CACHING for directories means:
+    // - Can cache directory enumeration results
+    // - Can cache file existence queries
+    // - Can cache basic file attributes
+    
+    // HANDLE_CACHING for directories means:
+    // - Can keep directory handle open
+    // - Can cache subdirectory handles
+    
+    // WRITE_CACHING for directories means:
+    // - Can cache file creation/deletion notifications
+    // - Can perform optimistic file operations
+    
+    // Directory-specific combinations
+    public static final int DIRECTORY_READ_HANDLE = SMB2_LEASE_READ_CACHING | SMB2_LEASE_HANDLE_CACHING;
+    public static final int DIRECTORY_FULL = SMB2_LEASE_FULL;  // All three
+}
+```
+
+### 3.2 Directory Cache Scopes
+```java
+public enum DirectoryCacheScope {
+    IMMEDIATE_CHILDREN,    // Only direct children
+    RECURSIVE_TREE,        // Entire subtree (if supported)
+    METADATA_ONLY,         // File attributes but not content
+    FULL_ENUMERATION      // Complete directory listing
+}
+```
+
+## 4. Data Structures
+
+### 4.1 Directory Lease Context
+```java
+package jcifs.internal.smb2.lease;
+
+public class DirectoryLeaseContext extends Smb2LeaseContext {
+    public static final String NAME_DIRECTORY_REQUEST = "DLse";
+    public static final String NAME_DIRECTORY_RESPONSE = "DLse";
+    
+    private DirectoryCacheScope cacheScope;
+    private long maxCacheAge;
+    private boolean notificationEnabled;
+    private int notificationFilter;
+    
+    // Directory lease flags
+    public static final int DIRECTORY_LEASE_FLAG_RECURSIVE = 0x00000001;
+    public static final int DIRECTORY_LEASE_FLAG_NOTIFICATIONS = 0x00000002;
+    
+    public DirectoryLeaseContext(Smb2LeaseKey key, int leaseState, DirectoryCacheScope scope) {
+        super();
+        setLeaseKey(key);
+        setLeaseState(leaseState);
+        this.cacheScope = scope;
+        this.maxCacheAge = 30000;  // 30 seconds default
+        this.notificationEnabled = true;
+    }
+    
+    @Override
+    public void encode(byte[] buffer, int offset) {
+        super.encode(buffer, offset);
+        
+        // Add directory-specific data after standard lease context
+        int dataOffset = offset + getStandardLeaseSize();
+        
+        // CacheScope (4 bytes)
+        writeInt4(buffer, dataOffset, cacheScope.ordinal());
+        dataOffset += 4;
+        
+        // MaxCacheAge (8 bytes)
+        writeInt8(buffer, dataOffset, maxCacheAge);
+        dataOffset += 8;
+        
+        // Flags (4 bytes)
+        int flags = 0;
+        if (cacheScope == DirectoryCacheScope.RECURSIVE_TREE) {
+            flags |= DIRECTORY_LEASE_FLAG_RECURSIVE;
+        }
+        if (notificationEnabled) {
+            flags |= DIRECTORY_LEASE_FLAG_NOTIFICATIONS;
+        }
+        writeInt4(buffer, dataOffset, flags);
+        dataOffset += 4;
+        
+        // NotificationFilter (4 bytes)
+        writeInt4(buffer, dataOffset, notificationFilter);
+    }
+    
+    @Override
+    public void decode(byte[] buffer, int offset, int length) {
+        super.decode(buffer, offset, length);
+        
+        if (length > getStandardLeaseSize()) {
+            // Decode directory-specific data
+            int dataOffset = offset + getStandardLeaseSize();
+            
+            int scopeOrdinal = readInt4(buffer, dataOffset);
+            this.cacheScope = DirectoryCacheScope.values()[scopeOrdinal];
+            dataOffset += 4;
+            
+            this.maxCacheAge = readInt8(buffer, dataOffset);
+            dataOffset += 8;
+            
+            int flags = readInt4(buffer, dataOffset);
+            dataOffset += 4;
+            
+            this.notificationFilter = readInt4(buffer, dataOffset);
+        }
+    }
+}
+```
+
+### 4.2 Directory Cache Entry
+```java
+package jcifs.internal.smb2.lease;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+public class DirectoryCacheEntry {
+    private final String directoryPath;
+    private final Smb2LeaseKey leaseKey;
+    private final long createTime;
+    private volatile long lastUpdateTime;
+    private volatile long lastAccessTime;
+    
+    // Cached directory contents
+    private final ConcurrentHashMap<String, FileInfo> children;
+    private final ReadWriteLock lock;
+    
+    // Cache metadata
+    private volatile boolean isComplete;  // True if full enumeration cached
+    private volatile boolean hasChanges;  // True if changes detected
+    private DirectoryCacheScope scope;
+    private long maxAge;
+    
+    public DirectoryCacheEntry(String path, Smb2LeaseKey key, DirectoryCacheScope scope) {
+        this.directoryPath = path;
+        this.leaseKey = key;
+        this.scope = scope;
+        this.createTime = System.currentTimeMillis();
+        this.lastUpdateTime = createTime;
+        this.lastAccessTime = createTime;
+        this.maxAge = 30000;  // 30 seconds default
+        
+        this.children = new ConcurrentHashMap<>();
+        this.lock = new ReentrantReadWriteLock();
+        this.isComplete = false;
+        this.hasChanges = false;
+    }
+    
+    public static class FileInfo {
+        private final String name;
+        private final long size;
+        private final long lastModified;
+        private final boolean isDirectory;
+        private final long attributes;
+        private final long creationTime;
+        private final long lastAccessTime;
+        
+        public FileInfo(String name, SmbFileAttributes attrs) {
+            this.name = name;
+            this.size = attrs.getSize();
+            this.lastModified = attrs.getLastWriteTime();
+            this.isDirectory = attrs.isDirectory();
+            this.attributes = attrs.getAttributes();
+            this.creationTime = attrs.getCreateTime();
+            this.lastAccessTime = attrs.getLastAccessTime();
+        }
+        
+        public boolean matches(SmbFileAttributes attrs) {
+            return size == attrs.getSize() 
+                && lastModified == attrs.getLastWriteTime()
+                && attributes == attrs.getAttributes();
+        }
+    }
+    
+    public void updateChild(String childName, SmbFileAttributes attrs) {
+        lock.writeLock().lock();
+        try {
+            FileInfo existing = children.get(childName);
+            FileInfo newInfo = new FileInfo(childName, attrs);
+            
+            if (existing == null || !existing.matches(attrs)) {
+                children.put(childName, newInfo);
+                hasChanges = true;
+                lastUpdateTime = System.currentTimeMillis();
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+    
+    public void removeChild(String childName) {
+        lock.writeLock().lock();
+        try {
+            if (children.remove(childName) != null) {
+                hasChanges = true;
+                lastUpdateTime = System.currentTimeMillis();
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+    
+    public List<FileInfo> getChildren() {
+        lock.readLock().lock();
+        try {
+            lastAccessTime = System.currentTimeMillis();
+            return new ArrayList<>(children.values());
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+    
+    public FileInfo getChild(String name) {
+        lock.readLock().lock();
+        try {
+            lastAccessTime = System.currentTimeMillis();
+            return children.get(name);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+    
+    public boolean hasChild(String name) {
+        lock.readLock().lock();
+        try {
+            lastAccessTime = System.currentTimeMillis();
+            return children.containsKey(name);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+    
+    public boolean isExpired() {
+        return System.currentTimeMillis() - lastUpdateTime > maxAge;
+    }
+    
+    public boolean needsRefresh() {
+        return isExpired() || hasChanges;
+    }
+    
+    public void markComplete() {
+        lock.writeLock().lock();
+        try {
+            this.isComplete = true;
+            this.hasChanges = false;
+            this.lastUpdateTime = System.currentTimeMillis();
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+    
+    public void invalidate() {
+        lock.writeLock().lock();
+        try {
+            children.clear();
+            isComplete = false;
+            hasChanges = true;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+}
+```
+
+### 4.3 Directory Lease Manager
+```java
+package jcifs.internal.smb2.lease;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public class DirectoryLeaseManager {
+    private final CIFSContext context;
+    private final LeaseManager baseLeaseManager;  // Reuse existing lease manager
+    private final ConcurrentHashMap<String, DirectoryCacheEntry> directoryCache;
+    private final ConcurrentHashMap<Smb2LeaseKey, String> leaseToPath;
+    private final ScheduledExecutorService scheduler;
+    
+    // Change notification integration
+    private final DirectoryChangeNotifier changeNotifier;
+    
+    public DirectoryLeaseManager(CIFSContext context, LeaseManager leaseManager) {
+        this.context = context;
+        this.baseLeaseManager = leaseManager;
+        this.directoryCache = new ConcurrentHashMap<>();
+        this.leaseToPath = new ConcurrentHashMap<>();
+        this.scheduler = Executors.newScheduledThreadPool(1);
+        this.changeNotifier = new DirectoryChangeNotifier(this);
+        
+        // Schedule periodic cache cleanup
+        scheduler.scheduleAtFixedRate(this::cleanupExpiredEntries, 60, 60, TimeUnit.SECONDS);
+    }
+    
+    public Smb2LeaseKey requestDirectoryLease(String directoryPath, 
+                                             int requestedState, 
+                                             DirectoryCacheScope scope) {
+        // Request base lease
+        Smb2LeaseKey leaseKey = baseLeaseManager.requestLease(directoryPath, requestedState);
+        
+        // Create directory cache entry
+        DirectoryCacheEntry cacheEntry = new DirectoryCacheEntry(directoryPath, leaseKey, scope);
+        directoryCache.put(directoryPath, cacheEntry);
+        leaseToPath.put(leaseKey, directoryPath);
+        
+        // Start change notification if enabled
+        if (context.getConfig().isDirectoryNotificationsEnabled()) {
+            changeNotifier.startWatching(directoryPath, leaseKey);
+        }
+        
+        return leaseKey;
+    }
+    
+    public DirectoryCacheEntry getCacheEntry(String directoryPath) {
+        DirectoryCacheEntry entry = directoryCache.get(directoryPath);
+        
+        // Check if cache entry is valid
+        if (entry != null && entry.needsRefresh()) {
+            // Check if lease is still valid
+            LeaseEntry leaseEntry = baseLeaseManager.getLease(entry.getLeaseKey());
+            if (leaseEntry == null || !leaseEntry.hasReadCache()) {
+                // Lease lost, remove cache entry
+                directoryCache.remove(directoryPath);
+                return null;
+            }
+        }
+        
+        return entry;
+    }
+    
+    public boolean canCacheDirectoryListing(String directoryPath) {
+        DirectoryCacheEntry entry = getCacheEntry(directoryPath);
+        if (entry == null) return false;
+        
+        LeaseEntry leaseEntry = baseLeaseManager.getLease(entry.getLeaseKey());
+        return leaseEntry != null && leaseEntry.hasReadCache();
+    }
+    
+    public List<SmbFile> getCachedDirectoryListing(String directoryPath) {
+        DirectoryCacheEntry entry = getCacheEntry(directoryPath);
+        if (entry == null || !entry.isComplete()) {
+            return null;  // No cached listing available
+        }
+        
+        List<SmbFile> files = new ArrayList<>();
+        for (DirectoryCacheEntry.FileInfo fileInfo : entry.getChildren()) {
+            // Create SmbFile objects from cached info
+            SmbFile file = createSmbFileFromCache(directoryPath, fileInfo);
+            files.add(file);
+        }
+        
+        return files;
+    }
+    
+    public void updateDirectoryCache(String directoryPath, List<SmbFile> files) {
+        DirectoryCacheEntry entry = getCacheEntry(directoryPath);
+        if (entry == null) return;
+        
+        // Update cache with new directory listing
+        for (SmbFile file : files) {
+            SmbFileAttributes attrs = file.getAttributes();
+            entry.updateChild(file.getName(), attrs);
+        }
+        
+        entry.markComplete();
+    }
+    
+    public void handleDirectoryChange(String directoryPath, String childName, 
+                                    DirectoryChangeType changeType) {
+        DirectoryCacheEntry entry = directoryCache.get(directoryPath);
+        if (entry == null) return;
+        
+        switch (changeType) {
+            case FILE_ADDED:
+                // Invalidate cache - we need to fetch new file info
+                entry.invalidate();
+                break;
+                
+            case FILE_REMOVED:
+                entry.removeChild(childName);
+                break;
+                
+            case FILE_MODIFIED:
+                // Remove from cache to force refresh
+                entry.removeChild(childName);
+                break;
+                
+            case DIRECTORY_RENAMED:
+                // Full invalidation needed
+                entry.invalidate();
+                break;
+        }
+    }
+    
+    public void handleDirectoryLeaseBreak(Smb2LeaseKey leaseKey, int newState) {
+        String directoryPath = leaseToPath.get(leaseKey);
+        if (directoryPath == null) return;
+        
+        DirectoryCacheEntry entry = directoryCache.get(directoryPath);
+        if (entry == null) return;
+        
+        // Handle lease break by updating cache behavior
+        if ((newState & Smb2LeaseState.SMB2_LEASE_READ_CACHING) == 0) {
+            // Lost read cache - invalidate directory cache
+            entry.invalidate();
+        }
+        
+        if ((newState & Smb2LeaseState.SMB2_LEASE_HANDLE_CACHING) == 0) {
+            // Lost handle cache - may need to close directory handle
+            changeNotifier.stopWatching(directoryPath);
+        }
+        
+        // Forward to base lease manager
+        baseLeaseManager.handleLeaseBreak(leaseKey, newState);
+    }
+    
+    public void releaseDirectoryLease(String directoryPath) {
+        DirectoryCacheEntry entry = directoryCache.remove(directoryPath);
+        if (entry != null) {
+            leaseToPath.remove(entry.getLeaseKey());
+            changeNotifier.stopWatching(directoryPath);
+            baseLeaseManager.releaseLease(entry.getLeaseKey());
+        }
+    }
+    
+    private void cleanupExpiredEntries() {
+        List<String> expiredPaths = new ArrayList<>();
+        
+        for (Map.Entry<String, DirectoryCacheEntry> entry : directoryCache.entrySet()) {
+            if (entry.getValue().isExpired()) {
+                expiredPaths.add(entry.getKey());
+            }
+        }
+        
+        for (String path : expiredPaths) {
+            releaseDirectoryLease(path);
+        }
+    }
+    
+    private SmbFile createSmbFileFromCache(String directoryPath, 
+                                          DirectoryCacheEntry.FileInfo fileInfo) {
+        String filePath = directoryPath + "/" + fileInfo.getName();
+        
+        // Create SmbFile with cached attributes
+        SmbFile file = new SmbFile(filePath, context);
+        file.setCachedAttributes(new SmbFileAttributes() {
+            @Override
+            public long getSize() { return fileInfo.getSize(); }
+            @Override
+            public long getLastWriteTime() { return fileInfo.getLastModified(); }
+            @Override
+            public boolean isDirectory() { return fileInfo.isDirectory(); }
+            // ... other attribute methods
+        });
+        
+        return file;
+    }
+}
+```
+
+### 4.4 Directory Change Notifier
+```java
+package jcifs.internal.smb2.lease;
+
+import jcifs.internal.smb2.ServerMessageBlock2;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class DirectoryChangeNotifier {
+    private final DirectoryLeaseManager leaseManager;
+    private final ConcurrentHashMap<String, ChangeNotificationHandle> activeWatchers;
+    
+    public enum DirectoryChangeType {
+        FILE_ADDED,
+        FILE_REMOVED,
+        FILE_MODIFIED,
+        DIRECTORY_RENAMED,
+        ATTRIBUTES_CHANGED
+    }
+    
+    public static class ChangeNotificationHandle {
+        private final String directoryPath;
+        private final Smb2LeaseKey leaseKey;
+        private final SmbFile directoryFile;
+        private volatile boolean active;
+        
+        public ChangeNotificationHandle(String path, Smb2LeaseKey key, SmbFile dir) {
+            this.directoryPath = path;
+            this.leaseKey = key;
+            this.directoryFile = dir;
+            this.active = true;
+        }
+    }
+    
+    public DirectoryChangeNotifier(DirectoryLeaseManager manager) {
+        this.leaseManager = manager;
+        this.activeWatchers = new ConcurrentHashMap<>();
+    }
+    
+    public void startWatching(String directoryPath, Smb2LeaseKey leaseKey) {
+        if (activeWatchers.containsKey(directoryPath)) {
+            return;  // Already watching
+        }
+        
+        try {
+            SmbFile directory = new SmbFile(directoryPath, leaseManager.getContext());
+            ChangeNotificationHandle handle = new ChangeNotificationHandle(
+                directoryPath, leaseKey, directory);
+            
+            activeWatchers.put(directoryPath, handle);
+            
+            // Start async change notification
+            startAsyncNotification(handle);
+            
+        } catch (Exception e) {
+            log.error("Failed to start directory watching for: " + directoryPath, e);
+        }
+    }
+    
+    public void stopWatching(String directoryPath) {
+        ChangeNotificationHandle handle = activeWatchers.remove(directoryPath);
+        if (handle != null) {
+            handle.active = false;
+            // Cancel any pending notifications
+            cancelNotification(handle);
+        }
+    }
+    
+    private void startAsyncNotification(ChangeNotificationHandle handle) {
+        CompletableFuture.runAsync(() -> {
+            while (handle.active) {
+                try {
+                    // Send SMB2 Change Notify request
+                    Smb2ChangeNotifyRequest request = new Smb2ChangeNotifyRequest();
+                    request.setFileId(handle.directoryFile.getFileId());
+                    request.setCompletionFilter(getNotificationFilter());
+                    request.setWatchTree(false);  // Non-recursive for now
+                    
+                    Smb2ChangeNotifyResponse response = (Smb2ChangeNotifyResponse) 
+                        handle.directoryFile.getTree().send(request);
+                    
+                    if (response.isSuccess()) {
+                        processChangeNotification(handle, response);
+                    }
+                    
+                } catch (Exception e) {
+                    if (handle.active) {
+                        log.debug("Change notification failed for: " + handle.directoryPath, e);
+                        // Retry after delay
+                        try {
+                            Thread.sleep(5000);
+                        } catch (InterruptedException ie) {
+                            Thread.currentThread().interrupt();
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+    }
+    
+    private void processChangeNotification(ChangeNotificationHandle handle, 
+                                         Smb2ChangeNotifyResponse response) {
+        // Parse FILE_NOTIFY_INFORMATION structures from response
+        byte[] data = response.getOutputBuffer();
+        int offset = 0;
+        
+        while (offset < data.length) {
+            int nextEntryOffset = readInt4(data, offset);
+            int action = readInt4(data, offset + 4);
+            int fileNameLength = readInt4(data, offset + 8);
+            
+            // Extract filename
+            byte[] fileNameBytes = new byte[fileNameLength];
+            System.arraycopy(data, offset + 12, fileNameBytes, 0, fileNameLength);
+            String fileName = new String(fileNameBytes, StandardCharsets.UTF_16LE);
+            
+            // Convert action to our enum
+            DirectoryChangeType changeType = convertAction(action);
+            
+            // Notify lease manager
+            leaseManager.handleDirectoryChange(handle.directoryPath, fileName, changeType);
+            
+            if (nextEntryOffset == 0) break;
+            offset += nextEntryOffset;
+        }
+    }
+    
+    private DirectoryChangeType convertAction(int action) {
+        switch (action) {
+            case FILE_ACTION_ADDED: return DirectoryChangeType.FILE_ADDED;
+            case FILE_ACTION_REMOVED: return DirectoryChangeType.FILE_REMOVED;
+            case FILE_ACTION_MODIFIED: return DirectoryChangeType.FILE_MODIFIED;
+            case FILE_ACTION_RENAMED_OLD_NAME:
+            case FILE_ACTION_RENAMED_NEW_NAME: return DirectoryChangeType.DIRECTORY_RENAMED;
+            default: return DirectoryChangeType.ATTRIBUTES_CHANGED;
+        }
+    }
+    
+    private int getNotificationFilter() {
+        return FILE_NOTIFY_CHANGE_FILE_NAME
+             | FILE_NOTIFY_CHANGE_DIR_NAME
+             | FILE_NOTIFY_CHANGE_ATTRIBUTES
+             | FILE_NOTIFY_CHANGE_SIZE
+             | FILE_NOTIFY_CHANGE_LAST_WRITE;
+    }
+    
+    // SMB2 Change Notify constants
+    private static final int FILE_ACTION_ADDED = 0x00000001;
+    private static final int FILE_ACTION_REMOVED = 0x00000002;
+    private static final int FILE_ACTION_MODIFIED = 0x00000003;
+    private static final int FILE_ACTION_RENAMED_OLD_NAME = 0x00000004;
+    private static final int FILE_ACTION_RENAMED_NEW_NAME = 0x00000005;
+    
+    private static final int FILE_NOTIFY_CHANGE_FILE_NAME = 0x00000001;
+    private static final int FILE_NOTIFY_CHANGE_DIR_NAME = 0x00000002;
+    private static final int FILE_NOTIFY_CHANGE_ATTRIBUTES = 0x00000004;
+    private static final int FILE_NOTIFY_CHANGE_SIZE = 0x00000008;
+    private static final int FILE_NOTIFY_CHANGE_LAST_WRITE = 0x00000010;
+}
+```
+
+## 5. Integration with Existing Code
+
+### 5.1 SmbFile Directory Operations
+```java
+// In SmbFile.java
+private DirectoryLeaseManager directoryLeaseManager;
+private Smb2LeaseKey directoryLeaseKey;
+
+@Override
+public SmbFile[] listFiles() throws IOException {
+    if (!isDirectory()) {
+        throw new IOException("Not a directory");
+    }
+    
+    // Check if we can use cached directory listing
+    if (directoryLeaseManager != null && 
+        directoryLeaseManager.canCacheDirectoryListing(getPath())) {
+        
+        List<SmbFile> cachedFiles = directoryLeaseManager.getCachedDirectoryListing(getPath());
+        if (cachedFiles != null) {
+            log.debug("Using cached directory listing for: {}", getPath());
+            return cachedFiles.toArray(new SmbFile[0]);
+        }
+    }
+    
+    // Perform actual directory enumeration
+    SmbFile[] files = performDirectoryEnumeration();
+    
+    // Update cache if we have a directory lease
+    if (directoryLeaseManager != null && directoryLeaseKey != null) {
+        directoryLeaseManager.updateDirectoryCache(getPath(), Arrays.asList(files));
+    }
+    
+    return files;
+}
+
+@Override
+public boolean exists() throws IOException {
+    if (isDirectory() && directoryLeaseManager != null) {
+        // Check parent directory cache first
+        String parentPath = getParent();
+        DirectoryCacheEntry parentCache = directoryLeaseManager.getCacheEntry(parentPath);
+        
+        if (parentCache != null && parentCache.isComplete()) {
+            boolean exists = parentCache.hasChild(getName());
+            log.debug("Using cached existence check for: {}", getPath());
+            return exists;
+        }
+    }
+    
+    // Fall back to regular existence check
+    return super.exists();
+}
+
+private void requestDirectoryLease() {
+    if (!isDirectory() || !context.getConfig().isUseDirectoryLeasing()) {
+        return;
+    }
+    
+    if (!tree.getSession().supports(SMB3_0)) {
+        return;  // Directory leasing requires SMB3
+    }
+    
+    directoryLeaseManager = tree.getSession().getDirectoryLeaseManager();
+    if (directoryLeaseManager != null) {
+        DirectoryCacheScope scope = context.getConfig().getDirectoryCacheScope();
+        int requestedState = DirectoryLeaseState.DIRECTORY_READ_HANDLE;
+        
+        directoryLeaseKey = directoryLeaseManager.requestDirectoryLease(
+            getPath(), requestedState, scope);
+        
+        // Add directory lease context to create request
+        if (createRequest != null) {
+            DirectoryLeaseContext leaseCtx = new DirectoryLeaseContext(
+                directoryLeaseKey, requestedState, scope);
+            createRequest.addCreateContext(leaseCtx);
+        }
+    }
+}
+
+@Override
+protected void doConnect() throws IOException {
+    // Request directory lease for directories
+    if (isDirectory()) {
+        requestDirectoryLease();
+    }
+    
+    // Continue with normal connection logic
+    super.doConnect();
+}
+
+@Override
+public void close() throws IOException {
+    try {
+        super.close();
+    } finally {
+        // Don't release directory lease on close - it may be shared
+        // Lease will be cleaned up by the lease manager
+    }
+}
+```
+
+### 5.2 Session Integration
+```java
+// In SmbSession.java
+private DirectoryLeaseManager directoryLeaseManager;
+
+public void initializeDirectoryLeasing() {
+    if (context.getConfig().isUseDirectoryLeasing() && supports(SMB3_0)) {
+        directoryLeaseManager = new DirectoryLeaseManager(context, leaseManager);
+    }
+}
+
+public DirectoryLeaseManager getDirectoryLeaseManager() {
+    return directoryLeaseManager;
+}
+
+@Override
+public void logoff() throws IOException {
+    if (directoryLeaseManager != null) {
+        directoryLeaseManager.shutdown();
+    }
+    super.logoff();
+}
+```
+
+## 6. Configuration
+
+### 6.1 Configuration Properties
+```java
+// In PropertyConfiguration.java
+public static final String USE_DIRECTORY_LEASING = "jcifs.smb.client.useDirectoryLeasing";
+public static final String DIRECTORY_CACHE_SCOPE = "jcifs.smb.client.directoryCacheScope";
+public static final String DIRECTORY_CACHE_TIMEOUT = "jcifs.smb.client.directoryCacheTimeout";
+public static final String DIRECTORY_NOTIFICATIONS_ENABLED = "jcifs.smb.client.directoryNotificationsEnabled";
+public static final String MAX_DIRECTORY_CACHE_ENTRIES = "jcifs.smb.client.maxDirectoryCacheEntries";
+
+public boolean isUseDirectoryLeasing() {
+    return getBooleanProperty(USE_DIRECTORY_LEASING, true);
+}
+
+public DirectoryCacheScope getDirectoryCacheScope() {
+    String scope = getProperty(DIRECTORY_CACHE_SCOPE, "IMMEDIATE_CHILDREN");
+    return DirectoryCacheScope.valueOf(scope);
+}
+
+public long getDirectoryCacheTimeout() {
+    return getLongProperty(DIRECTORY_CACHE_TIMEOUT, 30000);  // 30 seconds
+}
+
+public boolean isDirectoryNotificationsEnabled() {
+    return getBooleanProperty(DIRECTORY_NOTIFICATIONS_ENABLED, true);
+}
+
+public int getMaxDirectoryCacheEntries() {
+    return getIntProperty(MAX_DIRECTORY_CACHE_ENTRIES, 1000);
+}
+```
+
+## 7. Performance Optimizations
+
+### 7.1 Batch Directory Operations
+```java
+public class BatchDirectoryOperations {
+    private final DirectoryLeaseManager leaseManager;
+    
+    public List<SmbFile> batchExists(List<String> paths) {
+        // Group paths by parent directory
+        Map<String, List<String>> pathsByParent = paths.stream()
+            .collect(Collectors.groupingBy(this::getParentPath));
+        
+        List<SmbFile> results = new ArrayList<>();
+        
+        for (Map.Entry<String, List<String>> entry : pathsByParent.entrySet()) {
+            String parentPath = entry.getKey();
+            List<String> childNames = entry.getValue().stream()
+                .map(this::getFileName)
+                .collect(Collectors.toList());
+            
+            // Check if we have cached directory info
+            DirectoryCacheEntry cache = leaseManager.getCacheEntry(parentPath);
+            if (cache != null && cache.isComplete()) {
+                // Use cached data for all children
+                for (String childName : childNames) {
+                    boolean exists = cache.hasChild(childName);
+                    if (exists) {
+                        results.add(new SmbFile(parentPath + "/" + childName, context));
+                    }
+                }
+            } else {
+                // Fall back to individual checks
+                for (String path : entry.getValue()) {
+                    try {
+                        SmbFile file = new SmbFile(path, context);
+                        if (file.exists()) {
+                            results.add(file);
+                        }
+                    } catch (IOException e) {
+                        log.debug("Error checking existence of: " + path, e);
+                    }
+                }
+            }
+        }
+        
+        return results;
+    }
+}
+```
+
+### 7.2 Hierarchical Cache Management
+```java
+public class HierarchicalCacheManager {
+    private final DirectoryLeaseManager leaseManager;
+    private final Map<String, Set<String>> parentChildMap;
+    
+    public void invalidateHierarchy(String path) {
+        // Invalidate all parent directories up to root
+        String currentPath = path;
+        while (currentPath != null && !currentPath.isEmpty()) {
+            DirectoryCacheEntry entry = leaseManager.getCacheEntry(currentPath);
+            if (entry != null) {
+                entry.invalidate();
+            }
+            currentPath = getParentPath(currentPath);
+        }
+        
+        // Invalidate all child directories
+        invalidateChildren(path);
+    }
+    
+    private void invalidateChildren(String parentPath) {
+        Set<String> children = parentChildMap.get(parentPath);
+        if (children != null) {
+            for (String child : children) {
+                DirectoryCacheEntry entry = leaseManager.getCacheEntry(child);
+                if (entry != null) {
+                    entry.invalidate();
+                }
+                invalidateChildren(child);  // Recursive
+            }
+        }
+    }
+}
+```
+
+## 8. Testing Strategy
+
+### 8.1 Unit Tests
+```java
+@Test
+public void testDirectoryCacheEntry() {
+    DirectoryCacheEntry entry = new DirectoryCacheEntry(
+        "/test/dir", new Smb2LeaseKey(), DirectoryCacheScope.IMMEDIATE_CHILDREN);
+    
+    // Test adding children
+    SmbFileAttributes attrs = createMockAttributes("file1.txt", 1000, false);
+    entry.updateChild("file1.txt", attrs);
+    
+    assertTrue(entry.hasChild("file1.txt"));
+    assertEquals(1, entry.getChildren().size());
+    
+    // Test removal
+    entry.removeChild("file1.txt");
+    assertFalse(entry.hasChild("file1.txt"));
+    assertEquals(0, entry.getChildren().size());
+}
+
+@Test
+public void testDirectoryLeaseManager() {
+    CIFSContext context = new BaseContext(new PropertyConfiguration());
+    LeaseManager baseManager = new LeaseManager(context);
+    DirectoryLeaseManager dirManager = new DirectoryLeaseManager(context, baseManager);
+    
+    // Request directory lease
+    Smb2LeaseKey key = dirManager.requestDirectoryLease(
+        "/test/dir", 
+        DirectoryLeaseState.DIRECTORY_READ_HANDLE,
+        DirectoryCacheScope.IMMEDIATE_CHILDREN
+    );
+    
+    assertNotNull(key);
+    assertTrue(dirManager.canCacheDirectoryListing("/test/dir"));
+    
+    // Test cache operations
+    List<SmbFile> files = Arrays.asList(
+        createMockSmbFile("/test/dir/file1.txt"),
+        createMockSmbFile("/test/dir/file2.txt")
+    );
+    
+    dirManager.updateDirectoryCache("/test/dir", files);
+    
+    List<SmbFile> cached = dirManager.getCachedDirectoryListing("/test/dir");
+    assertNotNull(cached);
+    assertEquals(2, cached.size());
+}
+```
+
+### 8.2 Integration Tests
+```java
+@Test
+public void testDirectoryListingCache() throws Exception {
+    CIFSContext context = getTestContext();
+    context.getConfig().setProperty("jcifs.smb.client.useDirectoryLeasing", "true");
+    
+    SmbFile dir = new SmbFile("smb://server/share/testdir/", context);
+    
+    // First listing should hit the server
+    long start1 = System.currentTimeMillis();
+    SmbFile[] files1 = dir.listFiles();
+    long time1 = System.currentTimeMillis() - start1;
+    
+    // Second listing should use cache (much faster)
+    long start2 = System.currentTimeMillis();
+    SmbFile[] files2 = dir.listFiles();
+    long time2 = System.currentTimeMillis() - start2;
+    
+    assertEquals(files1.length, files2.length);
+    assertTrue(time2 < time1 / 2);  // Should be significantly faster
+}
+
+@Test
+public void testDirectoryChangeNotification() throws Exception {
+    CIFSContext context = getTestContext();
+    context.getConfig().setProperty("jcifs.smb.client.directoryNotificationsEnabled", "true");
+    
+    SmbFile dir = new SmbFile("smb://server/share/testdir/", context);
+    SmbFile testFile = new SmbFile("smb://server/share/testdir/newfile.txt", context);
+    
+    // Get initial listing (establishes cache)
+    SmbFile[] initialFiles = dir.listFiles();
+    
+    // Create new file
+    testFile.createNewFile();
+    
+    // Wait for change notification
+    Thread.sleep(2000);
+    
+    // Cache should be invalidated, new listing should include new file
+    SmbFile[] updatedFiles = dir.listFiles();
+    assertEquals(initialFiles.length + 1, updatedFiles.length);
+}
+```
+
+## 9. Error Handling
+
+### 9.1 Cache Consistency
+```java
+public class CacheConsistencyManager {
+    public void handleInconsistency(String directoryPath, String fileName) {
+        log.warn("Cache inconsistency detected for: {}/{}", directoryPath, fileName);
+        
+        // Invalidate affected cache entries
+        DirectoryCacheEntry entry = leaseManager.getCacheEntry(directoryPath);
+        if (entry != null) {
+            entry.removeChild(fileName);
+            
+            // If too many inconsistencies, invalidate entire cache
+            if (entry.getInconsistencyCount() > 5) {
+                entry.invalidate();
+            }
+        }
+    }
+}
+```
+
+### 9.2 Fallback Mechanisms
+```java
+public class DirectoryOperationFallback {
+    public SmbFile[] safeListFiles(SmbFile directory) throws IOException {
+        try {
+            // Try cached listing first
+            if (directoryLeaseManager != null) {
+                List<SmbFile> cached = directoryLeaseManager.getCachedDirectoryListing(
+                    directory.getPath());
+                if (cached != null) {
+                    return cached.toArray(new SmbFile[0]);
+                }
+            }
+        } catch (Exception e) {
+            log.debug("Cached directory listing failed, falling back to direct query", e);
+        }
+        
+        // Fall back to direct server query
+        return directory.performDirectEnumeration();
+    }
+}
+```
+
+## 10. Monitoring and Metrics
+
+### 10.1 Directory Cache Statistics
+```java
+public class DirectoryCacheStatistics {
+    private final AtomicLong cacheHits = new AtomicLong();
+    private final AtomicLong cacheMisses = new AtomicLong();
+    private final AtomicLong cacheInvalidations = new AtomicLong();
+    private final AtomicLong changeNotifications = new AtomicLong();
+    
+    public double getCacheHitRatio() {
+        long hits = cacheHits.get();
+        long misses = cacheMisses.get();
+        long total = hits + misses;
+        
+        if (total == 0) return 0.0;
+        return (double) hits / total;
+    }
+    
+    public void recordCacheHit() { cacheHits.incrementAndGet(); }
+    public void recordCacheMiss() { cacheMisses.incrementAndGet(); }
+    public void recordInvalidation() { cacheInvalidations.incrementAndGet(); }
+    public void recordChangeNotification() { changeNotifications.incrementAndGet(); }
+}
+```

--- a/docs/smb3-features/05-rdma-smb-direct-design.md
+++ b/docs/smb3-features/05-rdma-smb-direct-design.md
@@ -1,0 +1,1122 @@
+# RDMA (SMB Direct) Feature - Detailed Design Document
+
+## 1. Overview
+
+SMB Direct enables high-performance data transfer using Remote Direct Memory Access (RDMA) technology. This provides ultra-low latency and high bandwidth data transfer by bypassing the traditional TCP/IP stack and allowing direct memory-to-memory transfers between client and server.
+
+## 2. Protocol Specification Reference
+
+- **MS-SMBD**: SMB2 Remote Direct Memory Access (RDMA) Transport Protocol
+- **MS-SMB2 Section 2.2.3.1.1**: SMB2 Negotiate Protocol Request with RDMA
+- **MS-SMB2 Section 3.1.5.2**: RDMA Transport Connection
+- **RFC 5040**: A Remote Direct Memory Access Protocol Specification
+- **RFC 5041**: Direct Data Placement over Reliable Transports
+
+## 3. RDMA Architecture
+
+### 3.1 RDMA Capabilities
+```java
+public enum RdmaCapability {
+    RDMA_READ,           // Remote direct read operations
+    RDMA_WRITE,          // Remote direct write operations  
+    RDMA_SEND_RECEIVE,   // Traditional send/receive with RDMA
+    MEMORY_REGISTRATION, // Dynamic memory registration
+    FAST_REGISTRATION   // Fast memory region registration
+}
+
+public class RdmaCapabilities {
+    // RDMA transform capabilities
+    public static final int SMB_DIRECT_RESPONSE_REQUESTED = 0x00000001;
+    
+    // Default RDMA settings
+    public static final int DEFAULT_RDMA_READ_WRITE_SIZE = 1048576;  // 1MB
+    public static final int DEFAULT_RECEIVE_CREDIT_MAX = 255;
+    public static final int DEFAULT_SEND_CREDIT_TARGET = 32;
+    public static final int DEFAULT_MAX_RECEIVE_SIZE = 8192;
+    public static final int DEFAULT_MAX_FRAGMENTED_SIZE = 131072;    // 128KB
+    public static final int DEFAULT_MAX_READ_WRITE_SIZE = 1048576;   // 1MB
+}
+```
+
+### 3.2 RDMA Provider Interface
+```java
+package jcifs.internal.smb2.rdma;
+
+public interface RdmaProvider {
+    /**
+     * Check if RDMA is available on this system
+     */
+    boolean isAvailable();
+    
+    /**
+     * Get supported RDMA capabilities
+     */
+    Set<RdmaCapability> getSupportedCapabilities();
+    
+    /**
+     * Create RDMA connection to remote endpoint
+     */
+    RdmaConnection createConnection(InetSocketAddress remote, 
+                                   InetSocketAddress local) throws IOException;
+    
+    /**
+     * Register memory region for RDMA operations
+     */
+    RdmaMemoryRegion registerMemory(ByteBuffer buffer, 
+                                   EnumSet<RdmaAccess> access) throws IOException;
+    
+    /**
+     * Get provider name (e.g., "InfiniBand", "iWARP", "RoCE")
+     */
+    String getProviderName();
+    
+    /**
+     * Get maximum message size supported
+     */
+    int getMaxMessageSize();
+    
+    /**
+     * Clean up provider resources
+     */
+    void shutdown();
+}
+
+public enum RdmaAccess {
+    LOCAL_READ,
+    LOCAL_WRITE,
+    REMOTE_READ,
+    REMOTE_WRITE,
+    MEMORY_BIND
+}
+```
+
+## 4. Data Structures
+
+### 4.1 RDMA Connection
+```java
+package jcifs.internal.smb2.rdma;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public abstract class RdmaConnection implements AutoCloseable {
+    protected final InetSocketAddress remoteAddress;
+    protected final InetSocketAddress localAddress;
+    protected final AtomicInteger sendCredits;
+    protected final AtomicInteger receiveCredits;
+    protected final BlockingQueue<RdmaWorkRequest> pendingRequests;
+    
+    // Connection state
+    protected volatile RdmaConnectionState state;
+    protected RdmaCredits credits;
+    protected int maxFragmentedSize;
+    protected int maxReadWriteSize;
+    
+    public enum RdmaConnectionState {
+        DISCONNECTED,
+        CONNECTING,
+        CONNECTED,
+        ESTABLISHED,
+        ERROR,
+        CLOSING,
+        CLOSED
+    }
+    
+    public RdmaConnection(InetSocketAddress remote, InetSocketAddress local) {
+        this.remoteAddress = remote;
+        this.localAddress = local;
+        this.sendCredits = new AtomicInteger(0);
+        this.receiveCredits = new AtomicInteger(RdmaCapabilities.DEFAULT_RECEIVE_CREDIT_MAX);
+        this.pendingRequests = new LinkedBlockingQueue<>();
+        this.state = RdmaConnectionState.DISCONNECTED;
+        this.maxFragmentedSize = RdmaCapabilities.DEFAULT_MAX_FRAGMENTED_SIZE;
+        this.maxReadWriteSize = RdmaCapabilities.DEFAULT_MAX_READ_WRITE_SIZE;
+    }
+    
+    /**
+     * Establish RDMA connection
+     */
+    public abstract void connect() throws IOException;
+    
+    /**
+     * Send data using RDMA
+     */
+    public abstract void send(ByteBuffer data, RdmaMemoryRegion region) throws IOException;
+    
+    /**
+     * Receive data using RDMA  
+     */
+    public abstract ByteBuffer receive(int timeout) throws IOException;
+    
+    /**
+     * Perform RDMA read operation
+     */
+    public abstract void rdmaRead(RdmaMemoryRegion localRegion, 
+                                 long remoteAddress, 
+                                 int remoteKey,
+                                 int length) throws IOException;
+    
+    /**
+     * Perform RDMA write operation
+     */
+    public abstract void rdmaWrite(RdmaMemoryRegion localRegion,
+                                  long remoteAddress,
+                                  int remoteKey,
+                                  int length) throws IOException;
+    
+    /**
+     * Negotiate RDMA parameters
+     */
+    public abstract RdmaNegotiateResponse negotiate(RdmaNegotiateRequest request) throws IOException;
+    
+    public boolean canSend() {
+        return sendCredits.get() > 0 && state == RdmaConnectionState.ESTABLISHED;
+    }
+    
+    public void consumeSendCredit() {
+        sendCredits.decrementAndGet();
+    }
+    
+    public void grantSendCredit() {
+        sendCredits.incrementAndGet();
+    }
+    
+    public void grantReceiveCredit() {
+        receiveCredits.incrementAndGet();
+    }
+    
+    public int getAvailableSendCredits() {
+        return sendCredits.get();
+    }
+    
+    public int getAvailableReceiveCredits() {
+        return receiveCredits.get();
+    }
+}
+```
+
+### 4.2 RDMA Memory Region
+```java
+package jcifs.internal.smb2.rdma;
+
+public abstract class RdmaMemoryRegion implements AutoCloseable {
+    protected final ByteBuffer buffer;
+    protected final EnumSet<RdmaAccess> accessFlags;
+    protected final int localKey;
+    protected final int remoteKey;
+    protected final long address;
+    protected volatile boolean valid;
+    
+    public RdmaMemoryRegion(ByteBuffer buffer, EnumSet<RdmaAccess> access) {
+        this.buffer = buffer;
+        this.accessFlags = access;
+        this.localKey = generateLocalKey();
+        this.remoteKey = generateRemoteKey();
+        this.address = getBufferAddress(buffer);
+        this.valid = true;
+    }
+    
+    public ByteBuffer getBuffer() {
+        if (!valid) throw new IllegalStateException("Memory region invalidated");
+        return buffer;
+    }
+    
+    public int getLocalKey() { return localKey; }
+    public int getRemoteKey() { return remoteKey; }
+    public long getAddress() { return address; }
+    public int getSize() { return buffer.remaining(); }
+    
+    public boolean hasAccess(RdmaAccess access) {
+        return accessFlags.contains(access);
+    }
+    
+    /**
+     * Invalidate this memory region
+     */
+    public abstract void invalidate();
+    
+    protected abstract int generateLocalKey();
+    protected abstract int generateRemoteKey();
+    protected abstract long getBufferAddress(ByteBuffer buffer);
+    
+    @Override
+    public void close() {
+        invalidate();
+        valid = false;
+    }
+}
+```
+
+### 4.3 RDMA Transport
+```java
+package jcifs.internal.smb2.rdma;
+
+import jcifs.smb.SmbTransport;
+import jcifs.internal.smb2.ServerMessageBlock2;
+
+public class RdmaTransport extends SmbTransport {
+    private final RdmaConnection rdmaConnection;
+    private final RdmaProvider provider;
+    private final RdmaBufferManager bufferManager;
+    private final RdmaCredits credits;
+    
+    // RDMA-specific settings
+    private int maxReadWriteSize;
+    private int maxReceiveSize;
+    private boolean rdmaReadWriteEnabled;
+    
+    public RdmaTransport(CIFSContext context, 
+                        InetSocketAddress address,
+                        RdmaProvider provider) throws IOException {
+        super(context, address.getAddress(), address.getPort());
+        
+        this.provider = provider;
+        this.rdmaConnection = provider.createConnection(address, getLocalAddress());
+        this.bufferManager = new RdmaBufferManager(provider);
+        this.credits = new RdmaCredits();
+        
+        // Initialize RDMA parameters
+        this.maxReadWriteSize = RdmaCapabilities.DEFAULT_MAX_READ_WRITE_SIZE;
+        this.maxReceiveSize = RdmaCapabilities.DEFAULT_MAX_RECEIVE_SIZE;
+        this.rdmaReadWriteEnabled = true;
+    }
+    
+    @Override
+    public void connect() throws IOException {
+        // Establish RDMA connection
+        rdmaConnection.connect();
+        
+        // Perform RDMA negotiate
+        performRdmaNegotiation();
+        
+        // Continue with SMB negotiate over RDMA
+        super.connect();
+    }
+    
+    private void performRdmaNegotiation() throws IOException {
+        RdmaNegotiateRequest request = new RdmaNegotiateRequest();
+        request.setMinVersion(0x0100);
+        request.setMaxVersion(0x0100);
+        request.setCreditsRequested(credits.getInitialCredits());
+        request.setPreferredSendSize(maxReceiveSize);
+        request.setMaxReceiveSize(maxReceiveSize);
+        request.setMaxFragmentedSize(rdmaConnection.maxFragmentedSize);
+        
+        RdmaNegotiateResponse response = rdmaConnection.negotiate(request);
+        
+        if (!response.isSuccess()) {
+            throw new IOException("RDMA negotiation failed: " + response.getStatus());
+        }
+        
+        // Update connection parameters based on negotiation
+        credits.setCreditsGranted(response.getCreditsGranted());
+        maxReadWriteSize = Math.min(maxReadWriteSize, response.getMaxReadWriteSize());
+        maxReceiveSize = Math.min(maxReceiveSize, response.getMaxReceiveSize());
+    }
+    
+    @Override
+    protected void doSend(ServerMessageBlock2 request) throws IOException {
+        if (shouldUseRdmaReadWrite(request)) {
+            sendWithRdmaReadWrite(request);
+        } else {
+            sendWithRdmaSendReceive(request);
+        }
+    }
+    
+    private boolean shouldUseRdmaReadWrite(ServerMessageBlock2 request) {
+        if (!rdmaReadWriteEnabled) return false;
+        
+        int dataSize = getDataSize(request);
+        return dataSize > 8192 && dataSize <= maxReadWriteSize;  // Use RDMA for large transfers
+    }
+    
+    private void sendWithRdmaReadWrite(ServerMessageBlock2 request) throws IOException {
+        // For large data transfers, use RDMA read/write
+        
+        if (request instanceof Smb2ReadRequest) {
+            handleRdmaRead((Smb2ReadRequest) request);
+        } else if (request instanceof Smb2WriteRequest) {
+            handleRdmaWrite((Smb2WriteRequest) request);
+        } else {
+            // Fall back to send/receive for non-data operations
+            sendWithRdmaSendReceive(request);
+        }
+    }
+    
+    private void handleRdmaRead(Smb2ReadRequest request) throws IOException {
+        // Allocate buffer for read data
+        ByteBuffer readBuffer = bufferManager.allocateBuffer(request.getLength());
+        RdmaMemoryRegion readRegion = provider.registerMemory(readBuffer, 
+            EnumSet.of(RdmaAccess.LOCAL_WRITE, RdmaAccess.REMOTE_WRITE));
+        
+        try {
+            // Create SMB2 Read request with RDMA read channel info
+            request.addRdmaChannelInfo(readRegion.getRemoteKey(), 
+                                     readRegion.getAddress(),
+                                     readRegion.getSize());
+            
+            // Send request header via RDMA send
+            sendWithRdmaSendReceive(request);
+            
+            // Wait for server to write data directly to our buffer via RDMA
+            // No additional receive needed - data written directly to memory
+            
+            // Create response with data from RDMA buffer
+            Smb2ReadResponse response = new Smb2ReadResponse();
+            response.setData(readBuffer.array(), 0, request.getLength());
+            
+            // Notify waiting thread
+            request.setResponse(response);
+            
+        } finally {
+            readRegion.close();
+            bufferManager.releaseBuffer(readBuffer);
+        }
+    }
+    
+    private void handleRdmaWrite(Smb2WriteRequest request) throws IOException {
+        // Register write data buffer for RDMA
+        ByteBuffer writeBuffer = ByteBuffer.wrap(request.getData());
+        RdmaMemoryRegion writeRegion = provider.registerMemory(writeBuffer,
+            EnumSet.of(RdmaAccess.LOCAL_READ, RdmaAccess.REMOTE_READ));
+        
+        try {
+            // Add RDMA read channel info to request
+            request.addRdmaChannelInfo(writeRegion.getRemoteKey(),
+                                     writeRegion.getAddress(),
+                                     writeRegion.getSize());
+            
+            // Send request header (server will read data directly via RDMA)
+            sendWithRdmaSendReceive(request);
+            
+        } finally {
+            writeRegion.close();
+        }
+    }
+    
+    private void sendWithRdmaSendReceive(ServerMessageBlock2 request) throws IOException {
+        // Traditional send/receive over RDMA
+        
+        // Wait for send credit
+        if (!rdmaConnection.canSend()) {
+            waitForSendCredit();
+        }
+        
+        // Serialize request
+        ByteBuffer requestBuffer = serializeRequest(request);
+        
+        // Register buffer if needed
+        RdmaMemoryRegion sendRegion = bufferManager.getSendRegion(requestBuffer.remaining());
+        sendRegion.getBuffer().put(requestBuffer);
+        sendRegion.getBuffer().flip();
+        
+        try {
+            // Send via RDMA
+            rdmaConnection.send(sendRegion.getBuffer(), sendRegion);
+            rdmaConnection.consumeSendCredit();
+            
+            // Receive response
+            ByteBuffer responseBuffer = rdmaConnection.receive(getResponseTimeout());
+            
+            // Parse response
+            ServerMessageBlock2 response = parseResponse(responseBuffer);
+            request.setResponse(response);
+            
+        } finally {
+            bufferManager.releaseSendRegion(sendRegion);
+        }
+    }
+    
+    private void waitForSendCredit() throws IOException {
+        long deadline = System.currentTimeMillis() + 5000;  // 5 second timeout
+        
+        while (!rdmaConnection.canSend() && System.currentTimeMillis() < deadline) {
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted waiting for send credit", e);
+            }
+        }
+        
+        if (!rdmaConnection.canSend()) {
+            throw new IOException("Timeout waiting for RDMA send credit");
+        }
+    }
+    
+    @Override
+    public void disconnect() throws IOException {
+        try {
+            rdmaConnection.close();
+        } finally {
+            bufferManager.cleanup();
+            super.disconnect();
+        }
+    }
+    
+    public RdmaProvider getProvider() {
+        return provider;
+    }
+    
+    public RdmaConnection getConnection() {
+        return rdmaConnection;
+    }
+}
+```
+
+### 4.4 RDMA Buffer Manager
+```java
+package jcifs.internal.smb2.rdma;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class RdmaBufferManager {
+    private final RdmaProvider provider;
+    private final ConcurrentLinkedQueue<RdmaMemoryRegion> availableSendRegions;
+    private final ConcurrentLinkedQueue<RdmaMemoryRegion> availableReceiveRegions;
+    private final AtomicLong totalAllocated;
+    private final AtomicLong totalReleased;
+    
+    // Buffer pool configuration
+    private final int initialSendBuffers = 32;
+    private final int initialReceiveBuffers = 64;
+    private final int sendBufferSize = 65536;      // 64KB
+    private final int receiveBufferSize = 65536;   // 64KB
+    
+    public RdmaBufferManager(RdmaProvider provider) {
+        this.provider = provider;
+        this.availableSendRegions = new ConcurrentLinkedQueue<>();
+        this.availableReceiveRegions = new ConcurrentLinkedQueue<>();
+        this.totalAllocated = new AtomicLong();
+        this.totalReleased = new AtomicLong();
+        
+        // Pre-allocate buffer pool
+        initializeBufferPool();
+    }
+    
+    private void initializeBufferPool() {
+        // Allocate send buffers
+        for (int i = 0; i < initialSendBuffers; i++) {
+            try {
+                ByteBuffer buffer = ByteBuffer.allocateDirect(sendBufferSize);
+                RdmaMemoryRegion region = provider.registerMemory(buffer,
+                    EnumSet.of(RdmaAccess.LOCAL_READ, RdmaAccess.REMOTE_READ));
+                availableSendRegions.offer(region);
+                totalAllocated.incrementAndGet();
+            } catch (IOException e) {
+                log.warn("Failed to pre-allocate send buffer", e);
+            }
+        }
+        
+        // Allocate receive buffers
+        for (int i = 0; i < initialReceiveBuffers; i++) {
+            try {
+                ByteBuffer buffer = ByteBuffer.allocateDirect(receiveBufferSize);
+                RdmaMemoryRegion region = provider.registerMemory(buffer,
+                    EnumSet.of(RdmaAccess.LOCAL_WRITE, RdmaAccess.REMOTE_WRITE));
+                availableReceiveRegions.offer(region);
+                totalAllocated.incrementAndGet();
+            } catch (IOException e) {
+                log.warn("Failed to pre-allocate receive buffer", e);
+            }
+        }
+    }
+    
+    public RdmaMemoryRegion getSendRegion(int minSize) throws IOException {
+        if (minSize <= sendBufferSize) {
+            RdmaMemoryRegion region = availableSendRegions.poll();
+            if (region != null) {
+                region.getBuffer().clear();
+                return region;
+            }
+        }
+        
+        // Allocate new buffer
+        ByteBuffer buffer = ByteBuffer.allocateDirect(Math.max(minSize, sendBufferSize));
+        RdmaMemoryRegion region = provider.registerMemory(buffer,
+            EnumSet.of(RdmaAccess.LOCAL_READ, RdmaAccess.REMOTE_READ));
+        totalAllocated.incrementAndGet();
+        return region;
+    }
+    
+    public void releaseSendRegion(RdmaMemoryRegion region) {
+        if (region.getSize() == sendBufferSize && availableSendRegions.size() < initialSendBuffers * 2) {
+            availableSendRegions.offer(region);
+        } else {
+            region.close();
+            totalReleased.incrementAndGet();
+        }
+    }
+    
+    public RdmaMemoryRegion getReceiveRegion() throws IOException {
+        RdmaMemoryRegion region = availableReceiveRegions.poll();
+        if (region != null) {
+            region.getBuffer().clear();
+            return region;
+        }
+        
+        // Allocate new buffer
+        ByteBuffer buffer = ByteBuffer.allocateDirect(receiveBufferSize);
+        RdmaMemoryRegion region = provider.registerMemory(buffer,
+            EnumSet.of(RdmaAccess.LOCAL_WRITE, RdmaAccess.REMOTE_WRITE));
+        totalAllocated.incrementAndGet();
+        return region;
+    }
+    
+    public void releaseReceiveRegion(RdmaMemoryRegion region) {
+        if (availableReceiveRegions.size() < initialReceiveBuffers * 2) {
+            availableReceiveRegions.offer(region);
+        } else {
+            region.close();
+            totalReleased.incrementAndGet();
+        }
+    }
+    
+    public ByteBuffer allocateBuffer(int size) {
+        return ByteBuffer.allocateDirect(size);
+    }
+    
+    public void releaseBuffer(ByteBuffer buffer) {
+        // For direct buffers, we rely on GC
+        // Could implement a more sophisticated buffer pool here
+    }
+    
+    public void cleanup() {
+        // Clean up all pooled regions
+        RdmaMemoryRegion region;
+        
+        while ((region = availableSendRegions.poll()) != null) {
+            region.close();
+            totalReleased.incrementAndGet();
+        }
+        
+        while ((region = availableReceiveRegions.poll()) != null) {
+            region.close();
+            totalReleased.incrementAndGet();
+        }
+    }
+    
+    public long getTotalAllocated() { return totalAllocated.get(); }
+    public long getTotalReleased() { return totalReleased.get(); }
+    public long getActiveRegions() { return totalAllocated.get() - totalReleased.get(); }
+}
+```
+
+### 4.5 RDMA Provider Implementations
+
+#### 4.5.1 DiSNI Provider (InfiniBand/RoCE)
+```java
+package jcifs.internal.smb2.rdma.disni;
+
+import com.ibm.disni.*;
+import com.ibm.disni.verbs.*;
+
+public class DisniRdmaProvider implements RdmaProvider {
+    private RdmaActiveEndpointGroup<DisniRdmaEndpoint> endpointGroup;
+    private RdmaActiveEndpoint endpoint;
+    private boolean initialized = false;
+    
+    @Override
+    public boolean isAvailable() {
+        try {
+            // Check if DiSNI is available
+            Class.forName("com.ibm.disni.RdmaActiveEndpointGroup");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+    
+    @Override
+    public Set<RdmaCapability> getSupportedCapabilities() {
+        return EnumSet.allOf(RdmaCapability.class);
+    }
+    
+    @Override
+    public RdmaConnection createConnection(InetSocketAddress remote, 
+                                          InetSocketAddress local) throws IOException {
+        ensureInitialized();
+        return new DisniRdmaConnection(remote, local, endpointGroup);
+    }
+    
+    @Override
+    public RdmaMemoryRegion registerMemory(ByteBuffer buffer, 
+                                          EnumSet<RdmaAccess> access) throws IOException {
+        ensureInitialized();
+        return new DisniMemoryRegion(buffer, access, endpoint);
+    }
+    
+    private void ensureInitialized() throws IOException {
+        if (!initialized) {
+            try {
+                // Initialize DiSNI
+                endpointGroup = new RdmaActiveEndpointGroup<DisniRdmaEndpoint>(
+                    1000, false, 128, 4, 128);
+                endpointGroup.init(new DisniRdmaEndpointFactory());
+                initialized = true;
+            } catch (Exception e) {
+                throw new IOException("Failed to initialize DiSNI", e);
+            }
+        }
+    }
+    
+    @Override
+    public String getProviderName() {
+        return "DiSNI (InfiniBand/RoCE)";
+    }
+    
+    @Override
+    public int getMaxMessageSize() {
+        return 2147483647;  // 2GB - DiSNI limit
+    }
+    
+    @Override
+    public void shutdown() {
+        if (endpointGroup != null) {
+            try {
+                endpointGroup.close();
+            } catch (Exception e) {
+                log.error("Error shutting down DiSNI", e);
+            }
+        }
+        initialized = false;
+    }
+}
+
+class DisniRdmaConnection extends RdmaConnection {
+    private final RdmaActiveEndpoint endpoint;
+    private final RdmaActiveEndpointGroup<DisniRdmaEndpoint> group;
+    
+    public DisniRdmaConnection(InetSocketAddress remote, InetSocketAddress local,
+                              RdmaActiveEndpointGroup<DisniRdmaEndpoint> group) throws IOException {
+        super(remote, local);
+        this.group = group;
+        this.endpoint = group.createEndpoint();
+    }
+    
+    @Override
+    public void connect() throws IOException {
+        try {
+            endpoint.connect(remoteAddress, 1000);  // 1 second timeout
+            state = RdmaConnectionState.CONNECTED;
+        } catch (Exception e) {
+            throw new IOException("RDMA connection failed", e);
+        }
+    }
+    
+    @Override
+    public void send(ByteBuffer data, RdmaMemoryRegion region) throws IOException {
+        try {
+            DisniMemoryRegion disniRegion = (DisniMemoryRegion) region;
+            IbvSendWR sendWR = new IbvSendWR();
+            sendWR.setWr_id(System.nanoTime());
+            sendWR.setOpcode(IbvSendWR.IbvWrOpcode.IBV_WR_SEND.ordinal());
+            sendWR.setSend_flags(IbvSendWR.IBV_SEND_SIGNALED);
+            
+            LinkedList<IbvSge> sgeList = new LinkedList<>();
+            IbvSge sge = new IbvSge();
+            sge.setAddr(disniRegion.getAddress());
+            sge.setLength(data.remaining());
+            sge.setLkey(disniRegion.getLocalKey());
+            sgeList.add(sge);
+            
+            sendWR.setSg_list(sgeList);
+            endpoint.postSend(Arrays.asList(sendWR)).execute().free();
+            
+        } catch (Exception e) {
+            throw new IOException("RDMA send failed", e);
+        }
+    }
+    
+    @Override
+    public ByteBuffer receive(int timeout) throws IOException {
+        try {
+            RdmaCompletionEvent event = endpoint.getCqProcessor().getCqEvent(timeout);
+            if (event != null) {
+                return event.getBuffer();
+            }
+            return null;
+        } catch (Exception e) {
+            throw new IOException("RDMA receive failed", e);
+        }
+    }
+    
+    // ... other RDMA operation implementations
+}
+```
+
+#### 4.5.2 Fallback TCP Provider
+```java
+package jcifs.internal.smb2.rdma.tcp;
+
+public class TcpRdmaProvider implements RdmaProvider {
+    @Override
+    public boolean isAvailable() {
+        return true;  // TCP is always available
+    }
+    
+    @Override
+    public Set<RdmaCapability> getSupportedCapabilities() {
+        // TCP fallback only supports send/receive
+        return EnumSet.of(RdmaCapability.RDMA_SEND_RECEIVE);
+    }
+    
+    @Override
+    public RdmaConnection createConnection(InetSocketAddress remote, 
+                                          InetSocketAddress local) throws IOException {
+        return new TcpRdmaConnection(remote, local);
+    }
+    
+    @Override
+    public RdmaMemoryRegion registerMemory(ByteBuffer buffer, 
+                                          EnumSet<RdmaAccess> access) throws IOException {
+        // TCP doesn't need real memory registration
+        return new TcpMemoryRegion(buffer, access);
+    }
+    
+    @Override
+    public String getProviderName() {
+        return "TCP Fallback";
+    }
+    
+    @Override
+    public int getMaxMessageSize() {
+        return 65536;  // 64KB for TCP
+    }
+    
+    @Override
+    public void shutdown() {
+        // Nothing to clean up for TCP
+    }
+}
+```
+
+## 5. Integration with Existing Code
+
+### 5.1 Transport Selection
+```java
+// In SmbTransportPool.java
+public SmbTransport createTransport(CIFSContext context, 
+                                   InetSocketAddress address) throws IOException {
+    Configuration config = context.getConfig();
+    
+    if (config.isUseRDMA()) {
+        RdmaProvider provider = selectRdmaProvider();
+        if (provider != null && provider.isAvailable()) {
+            try {
+                return new RdmaTransport(context, address, provider);
+            } catch (IOException e) {
+                log.warn("Failed to create RDMA transport, falling back to TCP", e);
+            }
+        }
+    }
+    
+    // Fall back to TCP
+    return new SmbTransport(context, address.getAddress(), address.getPort());
+}
+
+private RdmaProvider selectRdmaProvider() {
+    // Try providers in order of preference
+    List<RdmaProvider> providers = Arrays.asList(
+        new DisniRdmaProvider(),      // InfiniBand/RoCE
+        new JxioRdmaProvider(),       // Alternative RDMA library
+        new TcpRdmaProvider()         // TCP fallback
+    );
+    
+    for (RdmaProvider provider : providers) {
+        if (provider.isAvailable()) {
+            log.info("Selected RDMA provider: {}", provider.getProviderName());
+            return provider;
+        }
+    }
+    
+    return null;
+}
+```
+
+### 5.2 SMB2 Read/Write with RDMA
+```java
+// In Smb2ReadRequest.java
+private RdmaChannelInfo rdmaChannelInfo;
+
+public void addRdmaChannelInfo(int remoteKey, long address, int length) {
+    this.rdmaChannelInfo = new RdmaChannelInfo(remoteKey, address, length);
+}
+
+@Override
+protected int writePayload(byte[] dst, int dstIndex) {
+    int written = super.writePayload(dst, dstIndex);
+    
+    if (rdmaChannelInfo != null) {
+        // Add RDMA read channel info
+        writeInt4(dst, dstIndex + written, rdmaChannelInfo.getRemoteKey());
+        written += 4;
+        writeInt8(dst, dstIndex + written, rdmaChannelInfo.getAddress());
+        written += 8;
+        writeInt4(dst, dstIndex + written, rdmaChannelInfo.getLength());
+        written += 4;
+    }
+    
+    return written;
+}
+
+public static class RdmaChannelInfo {
+    private final int remoteKey;
+    private final long address;
+    private final int length;
+    
+    public RdmaChannelInfo(int key, long addr, int len) {
+        this.remoteKey = key;
+        this.address = addr;
+        this.length = len;
+    }
+    
+    // Getters...
+}
+```
+
+## 6. Configuration
+
+### 6.1 Configuration Properties
+```java
+// In PropertyConfiguration.java
+public static final String USE_RDMA = "jcifs.smb.client.useRDMA";
+public static final String RDMA_PROVIDER = "jcifs.smb.client.rdmaProvider";
+public static final String RDMA_READ_WRITE_THRESHOLD = "jcifs.smb.client.rdmaReadWriteThreshold";
+public static final String RDMA_MAX_SEND_SIZE = "jcifs.smb.client.rdmaMaxSendSize";
+public static final String RDMA_MAX_RECEIVE_SIZE = "jcifs.smb.client.rdmaMaxReceiveSize";
+public static final String RDMA_CREDITS = "jcifs.smb.client.rdmaCredits";
+
+public boolean isUseRDMA() {
+    String value = getProperty(USE_RDMA, "auto");
+    return "true".equals(value) || ("auto".equals(value) && isRdmaAvailable());
+}
+
+public String getRdmaProvider() {
+    return getProperty(RDMA_PROVIDER, "auto");  // auto, disni, jxio, tcp
+}
+
+public int getRdmaReadWriteThreshold() {
+    return getIntProperty(RDMA_READ_WRITE_THRESHOLD, 8192);  // 8KB
+}
+
+public int getRdmaMaxSendSize() {
+    return getIntProperty(RDMA_MAX_SEND_SIZE, 65536);  // 64KB
+}
+
+public int getRdmaMaxReceiveSize() {
+    return getIntProperty(RDMA_MAX_RECEIVE_SIZE, 65536);  // 64KB
+}
+
+public int getRdmaCredits() {
+    return getIntProperty(RDMA_CREDITS, 255);
+}
+
+private boolean isRdmaAvailable() {
+    return new DisniRdmaProvider().isAvailable() || 
+           new JxioRdmaProvider().isAvailable();
+}
+```
+
+## 7. Testing Strategy
+
+### 7.1 Unit Tests
+```java
+@Test
+public void testRdmaProviderSelection() {
+    RdmaProvider provider = RdmaProviderFactory.createProvider("auto");
+    assertNotNull(provider);
+    assertTrue(provider.isAvailable());
+}
+
+@Test
+public void testRdmaMemoryRegistration() throws Exception {
+    RdmaProvider provider = new DisniRdmaProvider();
+    assumeTrue(provider.isAvailable());
+    
+    ByteBuffer buffer = ByteBuffer.allocateDirect(4096);
+    RdmaMemoryRegion region = provider.registerMemory(buffer, 
+        EnumSet.of(RdmaAccess.LOCAL_READ, RdmaAccess.REMOTE_READ));
+    
+    assertNotNull(region);
+    assertEquals(4096, region.getSize());
+    assertTrue(region.hasAccess(RdmaAccess.LOCAL_READ));
+    
+    region.close();
+}
+
+@Test
+public void testRdmaBufferManager() throws Exception {
+    RdmaProvider provider = new TcpRdmaProvider();  // Use TCP for testing
+    RdmaBufferManager manager = new RdmaBufferManager(provider);
+    
+    // Test buffer allocation
+    RdmaMemoryRegion region = manager.getSendRegion(1024);
+    assertNotNull(region);
+    assertTrue(region.getSize() >= 1024);
+    
+    // Test buffer release
+    manager.releaseSendRegion(region);
+    
+    // Test reuse
+    RdmaMemoryRegion region2 = manager.getSendRegion(1024);
+    assertNotNull(region2);
+    
+    manager.cleanup();
+}
+```
+
+### 7.2 Integration Tests
+```java
+@Test
+@EnabledIfSystemProperty(named = "rdma.test.enabled", matches = "true")
+public void testRdmaLargeFileTransfer() throws Exception {
+    CIFSContext context = getTestContext();
+    context.getConfig().setProperty("jcifs.smb.client.useRDMA", "true");
+    
+    SmbFile file = new SmbFile("smb://server/share/largefile.dat", context);
+    
+    // Measure RDMA transfer performance
+    byte[] data = new byte[10485760];  // 10MB
+    Arrays.fill(data, (byte)0x42);
+    
+    long start = System.currentTimeMillis();
+    
+    try (OutputStream os = file.getOutputStream()) {
+        os.write(data);
+    }
+    
+    long writeTime = System.currentTimeMillis() - start;
+    
+    // Read back
+    start = System.currentTimeMillis();
+    byte[] readData = new byte[data.length];
+    
+    try (InputStream is = file.getInputStream()) {
+        is.read(readData);
+    }
+    
+    long readTime = System.currentTimeMillis() - start;
+    
+    assertArrayEquals(data, readData);
+    
+    // RDMA should be faster than TCP for large transfers
+    log.info("RDMA Write: {}ms, Read: {}ms", writeTime, readTime);
+}
+
+@Test
+public void testRdmaFallbackToTcp() throws Exception {
+    // Test that we properly fall back to TCP when RDMA is not available
+    CIFSContext context = getTestContext();
+    context.getConfig().setProperty("jcifs.smb.client.useRDMA", "true");
+    context.getConfig().setProperty("jcifs.smb.client.rdmaProvider", "nonexistent");
+    
+    SmbFile file = new SmbFile("smb://server/share/test.txt", context);
+    
+    // Should work even if RDMA provider is not available
+    file.createNewFile();
+    assertTrue(file.exists());
+}
+```
+
+## 8. Performance Monitoring
+
+### 8.1 RDMA Statistics
+```java
+public class RdmaStatistics {
+    private final AtomicLong rdmaReads = new AtomicLong();
+    private final AtomicLong rdmaWrites = new AtomicLong();
+    private final AtomicLong rdmaSends = new AtomicLong();
+    private final AtomicLong rdmaReceives = new AtomicLong();
+    private final AtomicLong bytesTransferred = new AtomicLong();
+    private final AtomicLong operationErrors = new AtomicLong();
+    
+    public void recordRdmaRead(int bytes) {
+        rdmaReads.incrementAndGet();
+        bytesTransferred.addAndGet(bytes);
+    }
+    
+    public void recordRdmaWrite(int bytes) {
+        rdmaWrites.incrementAndGet();
+        bytesTransferred.addAndGet(bytes);
+    }
+    
+    public void recordError() {
+        operationErrors.incrementAndGet();
+    }
+    
+    public double getErrorRate() {
+        long total = rdmaReads.get() + rdmaWrites.get() + rdmaSends.get() + rdmaReceives.get();
+        if (total == 0) return 0.0;
+        return (double) operationErrors.get() / total;
+    }
+    
+    // Getters for all statistics...
+}
+```
+
+## 9. Error Handling and Fallback
+
+### 9.1 RDMA Error Recovery
+```java
+public class RdmaErrorHandler {
+    public void handleRdmaError(RdmaConnection connection, Exception error) {
+        log.warn("RDMA error occurred: {}", error.getMessage());
+        
+        if (isRecoverableError(error)) {
+            // Attempt to recover connection
+            try {
+                connection.reset();
+                log.info("RDMA connection recovered");
+            } catch (Exception e) {
+                log.error("Failed to recover RDMA connection", e);
+                fallbackToTcp(connection);
+            }
+        } else {
+            // Non-recoverable error, fall back to TCP
+            fallbackToTcp(connection);
+        }
+    }
+    
+    private boolean isRecoverableError(Exception error) {
+        // Check if error is recoverable (temporary network issue, etc.)
+        return error instanceof SocketTimeoutException
+            || error.getMessage().contains("retry");
+    }
+    
+    private void fallbackToTcp(RdmaConnection connection) {
+        log.info("Falling back to TCP transport");
+        // Switch transport to TCP
+        // This would require transport factory modification
+    }
+}
+```
+
+## 10. Security Considerations
+
+### 10.1 RDMA Security
+```java
+public class RdmaSecurityManager {
+    public void validateMemoryAccess(RdmaMemoryRegion region, RdmaAccess requestedAccess) {
+        if (!region.hasAccess(requestedAccess)) {
+            throw new SecurityException("Insufficient RDMA memory access rights");
+        }
+    }
+    
+    public void validateRemoteAccess(long remoteAddress, int length, int remoteKey) {
+        // Validate that remote memory access is authorized
+        // This would integrate with SMB3 encryption/signing
+        if (!isAuthorizedAccess(remoteAddress, length, remoteKey)) {
+            throw new SecurityException("Unauthorized RDMA remote access");
+        }
+    }
+    
+    private boolean isAuthorizedAccess(long address, int length, int key) {
+        // Implementation would check against established security context
+        return true;  // Simplified
+    }
+}
+```

--- a/docs/smb3-features/06-witness-protocol-design.md
+++ b/docs/smb3-features/06-witness-protocol-design.md
@@ -1,0 +1,1225 @@
+# Witness Protocol Feature - Detailed Design Document
+
+## 1. Overview
+
+The SMB Witness Protocol enables rapid notification of resource changes in a clustered file server environment. It provides fast failover capabilities by allowing clients to register for notifications about server node availability, share movement, and other critical cluster events.
+
+## 2. Protocol Specification Reference
+
+- **MS-SWN**: Service Witness Protocol Specification
+- **MS-SMB2 Section 3.2.4.24**: FSCTL_SRV_REQUEST_RESUME_KEY
+- **MS-SMB2 Section 3.3.5.15.12**: Cluster Reconnect
+- **MS-RRP**: Windows Remote Registry Protocol (for witness service discovery)
+
+## 3. Witness Architecture
+
+### 3.1 Witness Service Types
+```java
+public enum WitnessServiceType {
+    CLUSTER_WITNESS,     // Cluster-aware witness service
+    FILE_SERVER_WITNESS, // Individual file server witness
+    SCALE_OUT_WITNESS,   // Scale-out file server witness
+    DFS_WITNESS         // DFS namespace witness
+}
+
+public enum WitnessVersion {
+    VERSION_1(0x00010001),  // Windows Server 2012
+    VERSION_2(0x00020000);  // Windows Server 2012 R2+
+    
+    private final int version;
+    
+    WitnessVersion(int version) {
+        this.version = version;
+    }
+    
+    public int getValue() { return version; }
+}
+```
+
+### 3.2 Witness Event Types
+```java
+public enum WitnessEventType {
+    RESOURCE_CHANGE(1),        // Resource state changed
+    CLIENT_MOVE(2),           // Client should move to different node
+    SHARE_MOVE(3),            // Share moved to different node
+    IP_CHANGE(4),             // IP address changed
+    SHARE_DELETE(5),          // Share deleted
+    NODE_UNAVAILABLE(6),      // Cluster node unavailable
+    NODE_AVAILABLE(7);        // Cluster node available
+    
+    private final int value;
+    
+    WitnessEventType(int value) {
+        this.value = value;
+    }
+    
+    public int getValue() { return value; }
+}
+```
+
+## 4. Data Structures
+
+### 4.1 Witness Registration
+```java
+package jcifs.internal.witness;
+
+import java.net.InetAddress;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class WitnessRegistration {
+    private final String registrationId;
+    private final String shareName;
+    private final InetAddress serverAddress;
+    private final WitnessServiceType serviceType;
+    private final WitnessVersion version;
+    private final long registrationTime;
+    private final AtomicLong sequenceNumber;
+    
+    // Registration flags
+    public static final int WITNESS_REGISTER_NONE = 0x00000000;
+    public static final int WITNESS_REGISTER_IP_NOTIFICATION = 0x00000001;
+    
+    // Registration state
+    private volatile WitnessRegistrationState state;
+    private volatile long lastHeartbeat;
+    private int flags;
+    
+    public enum WitnessRegistrationState {
+        REGISTERING,
+        REGISTERED,
+        UNREGISTERING,
+        FAILED,
+        EXPIRED
+    }
+    
+    public WitnessRegistration(String shareName, InetAddress serverAddress, 
+                              WitnessServiceType serviceType) {
+        this.registrationId = generateRegistrationId();
+        this.shareName = shareName;
+        this.serverAddress = serverAddress;
+        this.serviceType = serviceType;
+        this.version = WitnessVersion.VERSION_2;  // Use latest by default
+        this.registrationTime = System.currentTimeMillis();
+        this.sequenceNumber = new AtomicLong(0);
+        this.state = WitnessRegistrationState.REGISTERING;
+        this.lastHeartbeat = registrationTime;
+        this.flags = WITNESS_REGISTER_IP_NOTIFICATION;
+    }
+    
+    private String generateRegistrationId() {
+        return "REG-" + System.currentTimeMillis() + "-" + 
+               Integer.toHexString(System.identityHashCode(this));
+    }
+    
+    public long getNextSequenceNumber() {
+        return sequenceNumber.incrementAndGet();
+    }
+    
+    public void updateHeartbeat() {
+        this.lastHeartbeat = System.currentTimeMillis();
+    }
+    
+    public boolean isExpired(long timeoutMs) {
+        return System.currentTimeMillis() - lastHeartbeat > timeoutMs;
+    }
+    
+    // Getters and setters...
+    public String getRegistrationId() { return registrationId; }
+    public String getShareName() { return shareName; }
+    public InetAddress getServerAddress() { return serverAddress; }
+    public WitnessServiceType getServiceType() { return serviceType; }
+    public WitnessRegistrationState getState() { return state; }
+    public void setState(WitnessRegistrationState state) { this.state = state; }
+}
+```
+
+### 4.2 Witness Notification
+```java
+package jcifs.internal.witness;
+
+import java.util.List;
+import java.util.ArrayList;
+
+public class WitnessNotification {
+    private final WitnessEventType eventType;
+    private final long timestamp;
+    private final String resourceName;
+    private final List<WitnessIPAddress> newIPAddresses;
+    private final List<WitnessIPAddress> oldIPAddresses;
+    private final String clientAccessPoint;
+    private final int flags;
+    
+    // Notification flags
+    public static final int WITNESS_RESOURCE_STATE_UNKNOWN = 0x00000000;
+    public static final int WITNESS_RESOURCE_STATE_AVAILABLE = 0x00000001;
+    public static final int WITNESS_RESOURCE_STATE_UNAVAILABLE = 0x000000FF;
+    
+    public WitnessNotification(WitnessEventType eventType, String resourceName) {
+        this.eventType = eventType;
+        this.resourceName = resourceName;
+        this.timestamp = System.currentTimeMillis();
+        this.newIPAddresses = new ArrayList<>();
+        this.oldIPAddresses = new ArrayList<>();
+        this.clientAccessPoint = null;
+        this.flags = WITNESS_RESOURCE_STATE_UNKNOWN;
+    }
+    
+    public static class WitnessIPAddress {
+        private final InetAddress address;
+        private final int flags;
+        
+        public static final int IPV4 = 0x01;
+        public static final int IPV6 = 0x02;
+        
+        public WitnessIPAddress(InetAddress address) {
+            this.address = address;
+            this.flags = address.getAddress().length == 4 ? IPV4 : IPV6;
+        }
+        
+        public InetAddress getAddress() { return address; }
+        public int getFlags() { return flags; }
+        public boolean isIPv4() { return (flags & IPV4) != 0; }
+        public boolean isIPv6() { return (flags & IPV6) != 0; }
+    }
+    
+    public void addNewIPAddress(InetAddress address) {
+        newIPAddresses.add(new WitnessIPAddress(address));
+    }
+    
+    public void addOldIPAddress(InetAddress address) {
+        oldIPAddresses.add(new WitnessIPAddress(address));
+    }
+    
+    // Getters...
+    public WitnessEventType getEventType() { return eventType; }
+    public String getResourceName() { return resourceName; }
+    public long getTimestamp() { return timestamp; }
+    public List<WitnessIPAddress> getNewIPAddresses() { return newIPAddresses; }
+    public List<WitnessIPAddress> getOldIPAddresses() { return oldIPAddresses; }
+}
+```
+
+### 4.3 Witness Client
+```java
+package jcifs.internal.witness;
+
+import jcifs.dcerpc.*;
+import jcifs.dcerpc.rpc.*;
+import java.util.concurrent.*;
+
+public class WitnessClient implements AutoCloseable {
+    private final InetAddress witnessServer;
+    private final int port;
+    private final CIFSContext context;
+    private final ConcurrentHashMap<String, WitnessRegistration> registrations;
+    private final ConcurrentHashMap<String, WitnessNotificationListener> listeners;
+    private final ScheduledExecutorService scheduler;
+    private final WitnessRpcClient rpcClient;
+    
+    // Witness service endpoint
+    private static final String WITNESS_SERVICE_UUID = "ccd8c074-d0e5-4a40-92b4-d074faa6ba28";
+    private static final int DEFAULT_WITNESS_PORT = 135;  // RPC endpoint mapper
+    
+    public interface WitnessNotificationListener {
+        void onWitnessNotification(WitnessNotification notification);
+        void onRegistrationFailed(WitnessRegistration registration, Exception error);
+        void onRegistrationExpired(WitnessRegistration registration);
+    }
+    
+    public WitnessClient(InetAddress witnessServer, CIFSContext context) {
+        this.witnessServer = witnessServer;
+        this.port = DEFAULT_WITNESS_PORT;
+        this.context = context;
+        this.registrations = new ConcurrentHashMap<>();
+        this.listeners = new ConcurrentHashMap<>();
+        this.scheduler = Executors.newScheduledThreadPool(2);
+        this.rpcClient = new WitnessRpcClient(witnessServer, context);
+        
+        // Schedule periodic tasks
+        schedulePeriodicTasks();
+    }
+    
+    private void schedulePeriodicTasks() {
+        // Heartbeat monitoring
+        scheduler.scheduleAtFixedRate(this::checkHeartbeats, 30, 30, TimeUnit.SECONDS);
+        
+        // Registration monitoring
+        scheduler.scheduleAtFixedRate(this::monitorRegistrations, 10, 10, TimeUnit.SECONDS);
+    }
+    
+    public CompletableFuture<WitnessRegistration> registerForNotifications(
+            String shareName, 
+            InetAddress serverAddress,
+            WitnessNotificationListener listener) {
+        
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                // Create registration
+                WitnessRegistration registration = new WitnessRegistration(
+                    shareName, serverAddress, WitnessServiceType.FILE_SERVER_WITNESS);
+                
+                // Perform RPC registration
+                WitnessRegisterRequest request = new WitnessRegisterRequest();
+                request.setVersion(registration.getVersion().getValue());
+                request.setShareName(shareName);
+                request.setServerAddress(serverAddress.getHostAddress());
+                request.setFlags(registration.getFlags());
+                
+                WitnessRegisterResponse response = rpcClient.register(request);
+                
+                if (response.isSuccess()) {
+                    registration.setState(WitnessRegistrationState.REGISTERED);
+                    registrations.put(registration.getRegistrationId(), registration);
+                    listeners.put(registration.getRegistrationId(), listener);
+                    
+                    log.info("Successfully registered for witness notifications: {}", 
+                        registration.getRegistrationId());
+                    
+                    return registration;
+                } else {
+                    throw new IOException("Witness registration failed: " + response.getError());
+                }
+                
+            } catch (Exception e) {
+                log.error("Failed to register for witness notifications", e);
+                throw new RuntimeException(e);
+            }
+        });
+    }
+    
+    public CompletableFuture<Void> unregister(WitnessRegistration registration) {
+        return CompletableFuture.runAsync(() -> {
+            try {
+                registration.setState(WitnessRegistrationState.UNREGISTERING);
+                
+                WitnessUnregisterRequest request = new WitnessUnregisterRequest();
+                request.setRegistrationId(registration.getRegistrationId());
+                
+                WitnessUnregisterResponse response = rpcClient.unregister(request);
+                
+                if (response.isSuccess()) {
+                    registrations.remove(registration.getRegistrationId());
+                    listeners.remove(registration.getRegistrationId());
+                    
+                    log.info("Successfully unregistered witness: {}", 
+                        registration.getRegistrationId());
+                } else {
+                    log.warn("Failed to unregister witness: {}", response.getError());
+                }
+                
+            } catch (Exception e) {
+                log.error("Error during witness unregistration", e);
+            }
+        });
+    }
+    
+    public void processNotification(WitnessNotification notification) {
+        log.info("Received witness notification: {} for resource: {}", 
+            notification.getEventType(), notification.getResourceName());
+        
+        // Find registrations that match this notification
+        for (Map.Entry<String, WitnessRegistration> entry : registrations.entrySet()) {
+            WitnessRegistration registration = entry.getValue();
+            
+            if (shouldDeliverNotification(registration, notification)) {
+                WitnessNotificationListener listener = listeners.get(entry.getKey());
+                if (listener != null) {
+                    try {
+                        listener.onWitnessNotification(notification);
+                    } catch (Exception e) {
+                        log.error("Error in witness notification listener", e);
+                    }
+                }
+            }
+        }
+    }
+    
+    private boolean shouldDeliverNotification(WitnessRegistration registration, 
+                                            WitnessNotification notification) {
+        // Check if notification is relevant to this registration
+        String resourceName = notification.getResourceName();
+        String shareName = registration.getShareName();
+        
+        // Match by share name or server address
+        return resourceName.equalsIgnoreCase(shareName) ||
+               resourceName.equals(registration.getServerAddress().getHostAddress());
+    }
+    
+    private void checkHeartbeats() {
+        long timeout = context.getConfig().getWitnessHeartbeatTimeout();
+        
+        for (WitnessRegistration registration : registrations.values()) {
+            if (registration.isExpired(timeout)) {
+                log.warn("Witness registration expired: {}", registration.getRegistrationId());
+                
+                registration.setState(WitnessRegistrationState.EXPIRED);
+                WitnessNotificationListener listener = listeners.get(registration.getRegistrationId());
+                
+                if (listener != null) {
+                    listener.onRegistrationExpired(registration);
+                }
+                
+                // Clean up expired registration
+                registrations.remove(registration.getRegistrationId());
+                listeners.remove(registration.getRegistrationId());
+            }
+        }
+    }
+    
+    private void monitorRegistrations() {
+        for (WitnessRegistration registration : registrations.values()) {
+            if (registration.getState() == WitnessRegistrationState.REGISTERED) {
+                // Send periodic heartbeat
+                sendHeartbeat(registration);
+            }
+        }
+    }
+    
+    private void sendHeartbeat(WitnessRegistration registration) {
+        try {
+            WitnessHeartbeatRequest request = new WitnessHeartbeatRequest();
+            request.setRegistrationId(registration.getRegistrationId());
+            request.setSequenceNumber(registration.getNextSequenceNumber());
+            
+            WitnessHeartbeatResponse response = rpcClient.heartbeat(request);
+            
+            if (response.isSuccess()) {
+                registration.updateHeartbeat();
+            } else {
+                log.warn("Witness heartbeat failed for: {}", registration.getRegistrationId());
+            }
+            
+        } catch (Exception e) {
+            log.debug("Heartbeat error for registration: {}", 
+                registration.getRegistrationId(), e);
+        }
+    }
+    
+    @Override
+    public void close() {
+        // Unregister all active registrations
+        List<CompletableFuture<Void>> unregisterFutures = new ArrayList<>();
+        
+        for (WitnessRegistration registration : registrations.values()) {
+            unregisterFutures.add(unregister(registration));
+        }
+        
+        // Wait for all unregistrations to complete
+        try {
+            CompletableFuture.allOf(unregisterFutures.toArray(new CompletableFuture[0]))
+                .get(10, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            log.warn("Error during witness client shutdown", e);
+        }
+        
+        // Shutdown scheduler
+        scheduler.shutdown();
+        
+        // Close RPC client
+        if (rpcClient != null) {
+            rpcClient.close();
+        }
+    }
+}
+```
+
+### 4.4 Witness RPC Client
+```java
+package jcifs.internal.witness;
+
+import jcifs.dcerpc.*;
+import jcifs.dcerpc.rpc.*;
+
+public class WitnessRpcClient implements AutoCloseable {
+    private final DcerpcHandle handle;
+    private final InetAddress serverAddress;
+    private final CIFSContext context;
+    
+    // Witness RPC interface
+    private static final String WITNESS_INTERFACE_UUID = "ccd8c074-d0e5-4a40-92b4-d074faa6ba28";
+    private static final int WITNESS_INTERFACE_VERSION = 1;
+    
+    // RPC operation numbers
+    private static final int WITNESS_REGISTER = 0;
+    private static final int WITNESS_UNREGISTER = 1;
+    private static final int WITNESS_ASYNC_NOTIFY = 2;
+    private static final int WITNESS_HEARTBEAT = 3;
+    
+    public WitnessRpcClient(InetAddress serverAddress, CIFSContext context) throws IOException {
+        this.serverAddress = serverAddress;
+        this.context = context;
+        
+        try {
+            // Create RPC handle to witness service
+            this.handle = DcerpcHandle.getHandle(
+                "ncacn_ip_tcp:" + serverAddress.getHostAddress() + "[135]",
+                WITNESS_INTERFACE_UUID,
+                WITNESS_INTERFACE_VERSION,
+                context
+            );
+            
+            // Bind to witness interface
+            handle.bind();
+            
+        } catch (Exception e) {
+            throw new IOException("Failed to connect to witness service", e);
+        }
+    }
+    
+    public WitnessRegisterResponse register(WitnessRegisterRequest request) throws IOException {
+        try {
+            WitnessRegisterStub stub = new WitnessRegisterStub(request);
+            handle.sendrecv(stub);
+            return stub.getResponse();
+        } catch (Exception e) {
+            throw new IOException("Witness register RPC failed", e);
+        }
+    }
+    
+    public WitnessUnregisterResponse unregister(WitnessUnregisterRequest request) throws IOException {
+        try {
+            WitnessUnregisterStub stub = new WitnessUnregisterStub(request);
+            handle.sendrecv(stub);
+            return stub.getResponse();
+        } catch (Exception e) {
+            throw new IOException("Witness unregister RPC failed", e);
+        }
+    }
+    
+    public WitnessHeartbeatResponse heartbeat(WitnessHeartbeatRequest request) throws IOException {
+        try {
+            WitnessHeartbeatStub stub = new WitnessHeartbeatStub(request);
+            handle.sendrecv(stub);
+            return stub.getResponse();
+        } catch (Exception e) {
+            throw new IOException("Witness heartbeat RPC failed", e);
+        }
+    }
+    
+    @Override
+    public void close() {
+        if (handle != null) {
+            try {
+                handle.close();
+            } catch (Exception e) {
+                log.error("Error closing witness RPC handle", e);
+            }
+        }
+    }
+    
+    // RPC Stub classes for witness operations
+    private static class WitnessRegisterStub extends DcerpcMessage {
+        private final WitnessRegisterRequest request;
+        private WitnessRegisterResponse response;
+        
+        public WitnessRegisterStub(WitnessRegisterRequest request) {
+            this.request = request;
+            this.ptype = 0;
+            this.flags = DCERPC_FIRST_FRAG | DCERPC_LAST_FRAG;
+        }
+        
+        @Override
+        public int getOpnum() { return WITNESS_REGISTER; }
+        
+        @Override
+        public void encode_in(NdrBuffer buffer) throws NdrException {
+            // Encode WitnessRegister request parameters
+            buffer.enc_ndr_long(request.getVersion());
+            buffer.enc_ndr_string(request.getShareName());
+            buffer.enc_ndr_string(request.getServerAddress());
+            buffer.enc_ndr_long(request.getFlags());
+        }
+        
+        @Override
+        public void decode_out(NdrBuffer buffer) throws NdrException {
+            // Decode WitnessRegister response
+            response = new WitnessRegisterResponse();
+            response.setRegistrationId(buffer.dec_ndr_string());
+            response.setReturnCode(buffer.dec_ndr_long());
+        }
+        
+        public WitnessRegisterResponse getResponse() { return response; }
+    }
+    
+    private static class WitnessUnregisterStub extends DcerpcMessage {
+        private final WitnessUnregisterRequest request;
+        private WitnessUnregisterResponse response;
+        
+        public WitnessUnregisterStub(WitnessUnregisterRequest request) {
+            this.request = request;
+            this.ptype = 0;
+            this.flags = DCERPC_FIRST_FRAG | DCERPC_LAST_FRAG;
+        }
+        
+        @Override
+        public int getOpnum() { return WITNESS_UNREGISTER; }
+        
+        @Override
+        public void encode_in(NdrBuffer buffer) throws NdrException {
+            buffer.enc_ndr_string(request.getRegistrationId());
+        }
+        
+        @Override
+        public void decode_out(NdrBuffer buffer) throws NdrException {
+            response = new WitnessUnregisterResponse();
+            response.setReturnCode(buffer.dec_ndr_long());
+        }
+        
+        public WitnessUnregisterResponse getResponse() { return response; }
+    }
+    
+    private static class WitnessHeartbeatStub extends DcerpcMessage {
+        private final WitnessHeartbeatRequest request;
+        private WitnessHeartbeatResponse response;
+        
+        public WitnessHeartbeatStub(WitnessHeartbeatRequest request) {
+            this.request = request;
+            this.ptype = 0;
+            this.flags = DCERPC_FIRST_FRAG | DCERPC_LAST_FRAG;
+        }
+        
+        @Override
+        public int getOpnum() { return WITNESS_HEARTBEAT; }
+        
+        @Override
+        public void encode_in(NdrBuffer buffer) throws NdrException {
+            buffer.enc_ndr_string(request.getRegistrationId());
+            buffer.enc_ndr_long(request.getSequenceNumber());
+        }
+        
+        @Override
+        public void decode_out(NdrBuffer buffer) throws NdrException {
+            response = new WitnessHeartbeatResponse();
+            response.setSequenceNumber(buffer.dec_ndr_long());
+            response.setReturnCode(buffer.dec_ndr_long());
+        }
+        
+        public WitnessHeartbeatResponse getResponse() { return response; }
+    }
+}
+
+// Request/Response classes
+class WitnessRegisterRequest {
+    private int version;
+    private String shareName;
+    private String serverAddress;
+    private int flags;
+    
+    // Getters and setters...
+}
+
+class WitnessRegisterResponse {
+    private String registrationId;
+    private int returnCode;
+    
+    public boolean isSuccess() { return returnCode == 0; }
+    public String getError() { return "Error code: " + returnCode; }
+    // Getters and setters...
+}
+
+class WitnessUnregisterRequest {
+    private String registrationId;
+    // Getters and setters...
+}
+
+class WitnessUnregisterResponse {
+    private int returnCode;
+    
+    public boolean isSuccess() { return returnCode == 0; }
+    public String getError() { return "Error code: " + returnCode; }
+}
+
+class WitnessHeartbeatRequest {
+    private String registrationId;
+    private long sequenceNumber;
+    // Getters and setters...
+}
+
+class WitnessHeartbeatResponse {
+    private long sequenceNumber;
+    private int returnCode;
+    
+    public boolean isSuccess() { return returnCode == 0; }
+    // Getters and setters...
+}
+```
+
+## 5. Integration with Existing Code
+
+### 5.1 Session Integration
+```java
+// In SmbSession.java
+private WitnessClient witnessClient;
+private boolean witnessEnabled;
+
+public void initializeWitnessSupport() {
+    Configuration config = context.getConfig();
+    
+    if (!config.isUseWitness()) {
+        return;
+    }
+    
+    try {
+        // Discover witness service
+        InetAddress witnessServer = discoverWitnessService();
+        if (witnessServer != null) {
+            witnessClient = new WitnessClient(witnessServer, context);
+            witnessEnabled = true;
+            
+            log.info("Initialized witness support with server: {}", witnessServer);
+        }
+    } catch (Exception e) {
+        log.warn("Failed to initialize witness support", e);
+    }
+}
+
+private InetAddress discoverWitnessService() throws IOException {
+    // Try the same server first
+    InetAddress serverAddress = transport.getRemoteAddress();
+    
+    if (isWitnessServiceAvailable(serverAddress)) {
+        return serverAddress;
+    }
+    
+    // Query for cluster witness service via DNS
+    try {
+        String clusterName = getClusterName(serverAddress);
+        if (clusterName != null) {
+            return InetAddress.getByName(clusterName + "-witness");
+        }
+    } catch (Exception e) {
+        log.debug("Failed to discover cluster witness via DNS", e);
+    }
+    
+    return null;  // No witness service found
+}
+
+private boolean isWitnessServiceAvailable(InetAddress address) {
+    try (Socket socket = new Socket()) {
+        socket.connect(new InetSocketAddress(address, 135), 5000);  // RPC endpoint
+        return true;
+    } catch (IOException e) {
+        return false;
+    }
+}
+
+public void registerForWitnessNotifications(String shareName) {
+    if (!witnessEnabled || witnessClient == null) {
+        return;
+    }
+    
+    try {
+        InetAddress serverAddress = transport.getRemoteAddress();
+        
+        witnessClient.registerForNotifications(shareName, serverAddress, 
+            new WitnessNotificationHandler())
+            .thenAccept(registration -> {
+                log.info("Registered for witness notifications: share={}, id={}", 
+                    shareName, registration.getRegistrationId());
+            })
+            .exceptionally(error -> {
+                log.error("Failed to register for witness notifications", error);
+                return null;
+            });
+            
+    } catch (Exception e) {
+        log.error("Error registering for witness notifications", e);
+    }
+}
+
+private class WitnessNotificationHandler implements WitnessClient.WitnessNotificationListener {
+    @Override
+    public void onWitnessNotification(WitnessNotification notification) {
+        handleWitnessEvent(notification);
+    }
+    
+    @Override
+    public void onRegistrationFailed(WitnessRegistration registration, Exception error) {
+        log.error("Witness registration failed: {}", registration.getRegistrationId(), error);
+    }
+    
+    @Override
+    public void onRegistrationExpired(WitnessRegistration registration) {
+        log.warn("Witness registration expired: {}", registration.getRegistrationId());
+        // Could attempt re-registration here
+    }
+}
+
+private void handleWitnessEvent(WitnessNotification notification) {
+    log.info("Handling witness event: {} for resource: {}", 
+        notification.getEventType(), notification.getResourceName());
+    
+    switch (notification.getEventType()) {
+        case RESOURCE_CHANGE:
+            handleResourceChange(notification);
+            break;
+            
+        case CLIENT_MOVE:
+            handleClientMove(notification);
+            break;
+            
+        case SHARE_MOVE:
+            handleShareMove(notification);
+            break;
+            
+        case IP_CHANGE:
+            handleIPChange(notification);
+            break;
+            
+        case NODE_UNAVAILABLE:
+            handleNodeUnavailable(notification);
+            break;
+            
+        case NODE_AVAILABLE:
+            handleNodeAvailable(notification);
+            break;
+    }
+}
+
+private void handleResourceChange(WitnessNotification notification) {
+    // Resource state changed - may need to reconnect
+    log.info("Resource change detected for: {}", notification.getResourceName());
+    
+    // Schedule reconnection attempt
+    scheduleReconnection(1000);  // 1 second delay
+}
+
+private void handleClientMove(WitnessNotification notification) {
+    // Server is asking client to move to different node
+    log.info("Client move requested for resource: {}", notification.getResourceName());
+    
+    List<WitnessNotification.WitnessIPAddress> newAddresses = notification.getNewIPAddresses();
+    if (!newAddresses.isEmpty()) {
+        // Attempt to connect to new address
+        InetAddress newAddress = newAddresses.get(0).getAddress();
+        scheduleAddressChange(newAddress);
+    }
+}
+
+private void handleShareMove(WitnessNotification notification) {
+    // Share moved to different server node
+    log.info("Share move detected for: {}", notification.getResourceName());
+    
+    // Similar to client move - try new addresses
+    handleClientMove(notification);
+}
+
+private void handleIPChange(WitnessNotification notification) {
+    // Server IP address changed
+    log.info("IP change detected for resource: {}", notification.getResourceName());
+    
+    List<WitnessNotification.WitnessIPAddress> newAddresses = notification.getNewIPAddresses();
+    if (!newAddresses.isEmpty()) {
+        InetAddress newAddress = newAddresses.get(0).getAddress();
+        scheduleAddressChange(newAddress);
+    }
+}
+
+private void scheduleReconnection(long delayMs) {
+    CompletableFuture.delayedExecutor(delayMs, TimeUnit.MILLISECONDS)
+        .execute(() -> {
+            try {
+                transport.disconnect();
+                transport.connect();  // Reconnect
+                log.info("Successfully reconnected after witness notification");
+            } catch (Exception e) {
+                log.error("Failed to reconnect after witness notification", e);
+            }
+        });
+}
+
+private void scheduleAddressChange(InetAddress newAddress) {
+    CompletableFuture.runAsync(() -> {
+        try {
+            // Create new transport to new address
+            SmbTransport newTransport = new SmbTransport(context, newAddress, transport.getPort());
+            
+            // Disconnect old transport
+            transport.disconnect();
+            
+            // Replace with new transport
+            this.transport = newTransport;
+            newTransport.connect();
+            
+            log.info("Successfully moved to new server address: {}", newAddress);
+            
+        } catch (Exception e) {
+            log.error("Failed to move to new server address: {}", newAddress, e);
+            // Could fall back to original address
+        }
+    });
+}
+
+@Override
+public void logoff() throws IOException {
+    if (witnessClient != null) {
+        witnessClient.close();
+    }
+    super.logoff();
+}
+```
+
+### 5.2 Tree Connection Integration
+```java
+// In SmbTree.java
+public void connectWithWitnessSupport() throws IOException {
+    // Perform normal tree connection
+    super.connect();
+    
+    // Register for witness notifications for this share
+    if (session.isWitnessEnabled()) {
+        String shareName = getPath();  // e.g., "\\server\share"
+        session.registerForWitnessNotifications(shareName);
+    }
+}
+```
+
+### 5.3 File Handle Integration
+```java
+// In SmbFile.java
+@Override
+protected void handleConnectionLoss(IOException error) {
+    if (tree.getSession().isWitnessEnabled()) {
+        log.info("Connection lost, waiting for witness notification before retry");
+        
+        // Wait briefly for witness notification before retrying
+        try {
+            Thread.sleep(2000);  // 2 second grace period
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+    
+    // Proceed with normal error handling/retry
+    super.handleConnectionLoss(error);
+}
+```
+
+## 6. Configuration
+
+### 6.1 Configuration Properties
+```java
+// In PropertyConfiguration.java
+public static final String USE_WITNESS = "jcifs.smb.client.useWitness";
+public static final String WITNESS_HEARTBEAT_TIMEOUT = "jcifs.smb.client.witnessHeartbeatTimeout";
+public static final String WITNESS_REGISTRATION_TIMEOUT = "jcifs.smb.client.witnessRegistrationTimeout";
+public static final String WITNESS_RECONNECT_DELAY = "jcifs.smb.client.witnessReconnectDelay";
+public static final String WITNESS_SERVICE_DISCOVERY = "jcifs.smb.client.witnessServiceDiscovery";
+
+public boolean isUseWitness() {
+    return getBooleanProperty(USE_WITNESS, false);  // Disabled by default
+}
+
+public long getWitnessHeartbeatTimeout() {
+    return getLongProperty(WITNESS_HEARTBEAT_TIMEOUT, 120000);  // 2 minutes
+}
+
+public long getWitnessRegistrationTimeout() {
+    return getLongProperty(WITNESS_REGISTRATION_TIMEOUT, 300000);  // 5 minutes
+}
+
+public long getWitnessReconnectDelay() {
+    return getLongProperty(WITNESS_RECONNECT_DELAY, 1000);  // 1 second
+}
+
+public boolean isWitnessServiceDiscovery() {
+    return getBooleanProperty(WITNESS_SERVICE_DISCOVERY, true);
+}
+```
+
+## 7. Testing Strategy
+
+### 7.1 Unit Tests
+```java
+@Test
+public void testWitnessRegistration() {
+    WitnessRegistration registration = new WitnessRegistration(
+        "\\\\server\\share", 
+        InetAddress.getByName("192.168.1.100"),
+        WitnessServiceType.FILE_SERVER_WITNESS
+    );
+    
+    assertNotNull(registration.getRegistrationId());
+    assertEquals(WitnessRegistrationState.REGISTERING, registration.getState());
+    assertFalse(registration.isExpired(60000));
+    
+    // Test sequence numbers
+    long seq1 = registration.getNextSequenceNumber();
+    long seq2 = registration.getNextSequenceNumber();
+    assertEquals(seq1 + 1, seq2);
+}
+
+@Test
+public void testWitnessNotification() {
+    WitnessNotification notification = new WitnessNotification(
+        WitnessEventType.CLIENT_MOVE, "TestResource");
+    
+    notification.addNewIPAddress(InetAddress.getByName("192.168.1.101"));
+    
+    assertEquals(WitnessEventType.CLIENT_MOVE, notification.getEventType());
+    assertEquals("TestResource", notification.getResourceName());
+    assertEquals(1, notification.getNewIPAddresses().size());
+}
+
+@Test
+public void testWitnessClientMock() throws Exception {
+    // Mock witness service for testing
+    MockWitnessService mockService = new MockWitnessService();
+    mockService.start();
+    
+    try {
+        WitnessClient client = new WitnessClient(mockService.getAddress(), context);
+        
+        CompletableFuture<WitnessRegistration> future = client.registerForNotifications(
+            "\\\\test\\share",
+            InetAddress.getByName("192.168.1.100"),
+            new TestWitnessListener()
+        );
+        
+        WitnessRegistration registration = future.get(5, TimeUnit.SECONDS);
+        assertNotNull(registration);
+        assertEquals(WitnessRegistrationState.REGISTERED, registration.getState());
+        
+        client.close();
+    } finally {
+        mockService.stop();
+    }
+}
+```
+
+### 7.2 Integration Tests
+```java
+@Test
+@EnabledIfSystemProperty(named = "witness.test.enabled", matches = "true")
+public void testWitnessFailover() throws Exception {
+    // Requires cluster environment for testing
+    CIFSContext context = getTestContext();
+    context.getConfig().setProperty("jcifs.smb.client.useWitness", "true");
+    
+    SmbFile file = new SmbFile("smb://cluster-server/share/test.txt", context);
+    file.createNewFile();
+    
+    // Monitor for witness notifications
+    TestWitnessListener listener = new TestWitnessListener();
+    
+    // Simulate cluster failover (would require test environment setup)
+    // ... trigger server failover ...
+    
+    // Verify that witness notification was received and handled
+    assertTrue(listener.waitForNotification(30000));  // 30 second timeout
+    
+    // Verify file is still accessible after failover
+    assertTrue(file.exists());
+}
+
+@Test
+public void testWitnessServiceDiscovery() throws Exception {
+    CIFSContext context = getTestContext();
+    context.getConfig().setProperty("jcifs.smb.client.useWitness", "true");
+    context.getConfig().setProperty("jcifs.smb.client.witnessServiceDiscovery", "true");
+    
+    SmbSession session = new SmbSession(context, transport);
+    session.initializeWitnessSupport();
+    
+    // Should either find witness service or gracefully handle absence
+    // No exception should be thrown
+}
+
+private static class TestWitnessListener implements WitnessClient.WitnessNotificationListener {
+    private volatile boolean notificationReceived = false;
+    private final CountDownLatch latch = new CountDownLatch(1);
+    
+    @Override
+    public void onWitnessNotification(WitnessNotification notification) {
+        notificationReceived = true;
+        latch.countDown();
+    }
+    
+    @Override
+    public void onRegistrationFailed(WitnessRegistration registration, Exception error) {
+        // Test implementation
+    }
+    
+    @Override
+    public void onRegistrationExpired(WitnessRegistration registration) {
+        // Test implementation
+    }
+    
+    public boolean waitForNotification(long timeoutMs) throws InterruptedException {
+        return latch.await(timeoutMs, TimeUnit.MILLISECONDS);
+    }
+    
+    public boolean isNotificationReceived() {
+        return notificationReceived;
+    }
+}
+```
+
+## 8. Error Handling and Reliability
+
+### 8.1 Witness Service Unavailability
+```java
+public class WitnessServiceErrorHandler {
+    private final WitnessClient client;
+    private final ScheduledExecutorService scheduler;
+    private volatile boolean serviceAvailable = true;
+    
+    public void handleServiceUnavailable(Exception error) {
+        log.warn("Witness service unavailable: {}", error.getMessage());
+        serviceAvailable = false;
+        
+        // Schedule retry
+        scheduleServiceRetry();
+    }
+    
+    private void scheduleServiceRetry() {
+        scheduler.schedule(() -> {
+            try {
+                // Test if service is back online
+                if (testWitnessService()) {
+                    serviceAvailable = true;
+                    log.info("Witness service is back online");
+                    
+                    // Re-register for notifications
+                    reregisterNotifications();
+                } else {
+                    // Schedule another retry
+                    scheduleServiceRetry();
+                }
+            } catch (Exception e) {
+                log.debug("Witness service retry failed", e);
+                scheduleServiceRetry();
+            }
+        }, 30, TimeUnit.SECONDS);
+    }
+    
+    private boolean testWitnessService() {
+        // Simple connectivity test
+        return client != null && client.isConnected();
+    }
+    
+    private void reregisterNotifications() {
+        // Re-register all previous registrations
+        // Implementation would store registration details for recovery
+    }
+}
+```
+
+### 8.2 Network Partition Handling
+```java
+public class WitnessNetworkPartitionHandler {
+    public void handleNetworkPartition() {
+        log.warn("Network partition detected - witness notifications may be delayed");
+        
+        // Switch to more aggressive connection retry
+        // Increase heartbeat frequency
+        // Consider fallback mechanisms
+    }
+    
+    public void handlePartitionRecovery() {
+        log.info("Network partition recovered - resuming normal witness operations");
+        
+        // Restore normal operation parameters
+        // Verify all registrations are still valid
+    }
+}
+```
+
+## 9. Performance and Optimization
+
+### 9.1 Witness Event Batching
+```java
+public class WitnessEventBatcher {
+    private final Queue<WitnessNotification> pendingNotifications;
+    private final ScheduledExecutorService scheduler;
+    private final int batchSize = 10;
+    private final long batchTimeout = 100;  // 100ms
+    
+    public void addNotification(WitnessNotification notification) {
+        synchronized (pendingNotifications) {
+            pendingNotifications.offer(notification);
+            
+            if (pendingNotifications.size() >= batchSize) {
+                processBatch();
+            }
+        }
+    }
+    
+    private void processBatch() {
+        List<WitnessNotification> batch = new ArrayList<>();
+        
+        synchronized (pendingNotifications) {
+            while (!pendingNotifications.isEmpty() && batch.size() < batchSize) {
+                batch.add(pendingNotifications.poll());
+            }
+        }
+        
+        if (!batch.isEmpty()) {
+            processNotificationBatch(batch);
+        }
+    }
+    
+    private void processNotificationBatch(List<WitnessNotification> notifications) {
+        // Process multiple notifications together for efficiency
+        for (WitnessNotification notification : notifications) {
+            // Handle notification
+        }
+    }
+}
+```
+
+## 10. Security Considerations
+
+### 10.1 Witness Authentication
+```java
+public class WitnessSecurityManager {
+    public void authenticateWitnessService(InetAddress witnessServer) throws SecurityException {
+        // Verify witness service is authorized
+        if (!isAuthorizedWitnessServer(witnessServer)) {
+            throw new SecurityException("Unauthorized witness server: " + witnessServer);
+        }
+    }
+    
+    public void validateNotification(WitnessNotification notification) throws SecurityException {
+        // Validate notification authenticity
+        if (!isValidNotificationSource(notification)) {
+            throw new SecurityException("Invalid witness notification source");
+        }
+    }
+    
+    private boolean isAuthorizedWitnessServer(InetAddress server) {
+        // Implementation would check against authorized server list
+        // Could use certificates, Kerberos, etc.
+        return true;  // Simplified
+    }
+    
+    private boolean isValidNotificationSource(WitnessNotification notification) {
+        // Validate notification signature/source
+        return true;  // Simplified
+    }
+}
+```
+
+## 11. Monitoring and Metrics
+
+### 11.1 Witness Statistics
+```java
+public class WitnessStatistics {
+    private final AtomicLong registrationsActive = new AtomicLong();
+    private final AtomicLong notificationsReceived = new AtomicLong();
+    private final AtomicLong failoverEvents = new AtomicLong();
+    private final AtomicLong heartbeatsSent = new AtomicLong();
+    private final AtomicLong registrationFailures = new AtomicLong();
+    
+    public void recordRegistration() { registrationsActive.incrementAndGet(); }
+    public void recordUnregistration() { registrationsActive.decrementAndGet(); }
+    public void recordNotification() { notificationsReceived.incrementAndGet(); }
+    public void recordFailover() { failoverEvents.incrementAndGet(); }
+    public void recordHeartbeat() { heartbeatsSent.incrementAndGet(); }
+    public void recordRegistrationFailure() { registrationFailures.incrementAndGet(); }
+    
+    // Getters for all statistics...
+    public long getActiveRegistrations() { return registrationsActive.get(); }
+    public long getNotificationsReceived() { return notificationsReceived.get(); }
+    public long getFailoverEvents() { return failoverEvents.get(); }
+}


### PR DESCRIPTION
This update enhances the README with comprehensive documentation for JCIFS v3.x. It introduces SMB3 protocol details (encryption, signing, negotiation), updates the Java requirement to version 17, and adds explicit dependency examples for Maven users. The features list has been restructured, known limitations are clarified, and practical code snippets are included for quick start and authentication. Additional sections provide guidance on choosing between JCIFS and jcifs-ng, as well as contribution guidelines.
