### PR TITLE
Add SMB2/SMB3 Lease Support with New Configuration and Create Context Handling

### DIFF
--- a/src/main/java/jcifs/Configuration.java
+++ b/src/main/java/jcifs/Configuration.java
@@ -495,6 +495,38 @@ public interface Configuration {
     boolean isForceExtendedSecurity();
 
     /**
+     * Property {@code jcifs.smb.client.useLease} (boolean, default true)
+     *
+     * @return whether to use SMB2/SMB3 leases for caching
+     * @since 2.2
+     */
+    boolean isUseLease();
+
+    /**
+     * Property {@code jcifs.smb.client.leaseTimeout} (int, default 30000)
+     *
+     * @return lease timeout in milliseconds
+     * @since 2.2
+     */
+    int getLeaseTimeout();
+
+    /**
+     * Property {@code jcifs.smb.client.maxLeases} (int, default 1000)
+     *
+     * @return maximum number of concurrent leases
+     * @since 2.2
+     */
+    int getMaxLeases();
+
+    /**
+     * Property {@code jcifs.smb.client.leaseVersion} (int, default 2)
+     *
+     * @return preferred lease version (1 or 2)
+     * @since 2.2
+     */
+    int getLeaseVersion();
+
+    /**
      *
      *
      * Property {@code jcifs.netbios.lmhosts} (string)

--- a/src/main/java/jcifs/Configuration.java
+++ b/src/main/java/jcifs/Configuration.java
@@ -527,6 +527,14 @@ public interface Configuration {
     int getLeaseVersion();
 
     /**
+     * Property {@code jcifs.smb.client.leaseBreakTimeout} (int, default 60)
+     *
+     * @return lease break timeout in seconds (per MS-SMB2 spec)
+     * @since 2.2
+     */
+    int getLeaseBreakTimeout();
+
+    /**
      *
      *
      * Property {@code jcifs.netbios.lmhosts} (string)

--- a/src/main/java/jcifs/config/BaseConfiguration.java
+++ b/src/main/java/jcifs/config/BaseConfiguration.java
@@ -85,6 +85,8 @@ public class BaseConfiguration implements Configuration {
     protected int maxLeases = 1000;
     /** Preferred lease version (1 or 2) */
     protected int leaseVersion = 2;
+    /** Lease break timeout in seconds (per MS-SMB2 spec) */
+    protected int leaseBreakTimeout = 60;
     /** Whether to use NT status codes instead of DOS error codes */
     protected boolean useNtStatus = true;
     /** Whether to use extended security negotiation */
@@ -577,6 +579,11 @@ public class BaseConfiguration implements Configuration {
     @Override
     public int getLeaseVersion() {
         return this.leaseVersion;
+    }
+
+    @Override
+    public int getLeaseBreakTimeout() {
+        return this.leaseBreakTimeout;
     }
 
     @Override

--- a/src/main/java/jcifs/config/BaseConfiguration.java
+++ b/src/main/java/jcifs/config/BaseConfiguration.java
@@ -77,6 +77,14 @@ public class BaseConfiguration implements Configuration {
     protected boolean ipcSigningEnforced = true;
     /** Whether SMB3 encryption is enabled */
     protected boolean encryptionEnabled = false;
+    /** Whether to use SMB2/SMB3 leases for caching */
+    protected boolean useLease = true;
+    /** Lease timeout in milliseconds */
+    protected int leaseTimeout = 30000;
+    /** Maximum number of concurrent leases */
+    protected int maxLeases = 1000;
+    /** Preferred lease version (1 or 2) */
+    protected int leaseVersion = 2;
     /** Whether to use NT status codes instead of DOS error codes */
     protected boolean useNtStatus = true;
     /** Whether to use extended security negotiation */
@@ -549,6 +557,26 @@ public class BaseConfiguration implements Configuration {
     @Override
     public boolean isEncryptionEnabled() {
         return this.encryptionEnabled;
+    }
+
+    @Override
+    public boolean isUseLease() {
+        return this.useLease;
+    }
+
+    @Override
+    public int getLeaseTimeout() {
+        return this.leaseTimeout;
+    }
+
+    @Override
+    public int getMaxLeases() {
+        return this.maxLeases;
+    }
+
+    @Override
+    public int getLeaseVersion() {
+        return this.leaseVersion;
     }
 
     @Override

--- a/src/main/java/jcifs/config/DelegatingConfiguration.java
+++ b/src/main/java/jcifs/config/DelegatingConfiguration.java
@@ -386,6 +386,26 @@ public class DelegatingConfiguration implements Configuration {
         return this.delegate.isForceExtendedSecurity();
     }
 
+    @Override
+    public boolean isUseLease() {
+        return this.delegate.isUseLease();
+    }
+
+    @Override
+    public int getLeaseTimeout() {
+        return this.delegate.getLeaseTimeout();
+    }
+
+    @Override
+    public int getMaxLeases() {
+        return this.delegate.getMaxLeases();
+    }
+
+    @Override
+    public int getLeaseVersion() {
+        return this.delegate.getLeaseVersion();
+    }
+
     /**
      * {@inheritDoc}
      *

--- a/src/main/java/jcifs/config/DelegatingConfiguration.java
+++ b/src/main/java/jcifs/config/DelegatingConfiguration.java
@@ -406,6 +406,11 @@ public class DelegatingConfiguration implements Configuration {
         return this.delegate.getLeaseVersion();
     }
 
+    @Override
+    public int getLeaseBreakTimeout() {
+        return this.delegate.getLeaseBreakTimeout();
+    }
+
     /**
      * {@inheritDoc}
      *

--- a/src/main/java/jcifs/internal/smb2/create/LeaseV1CreateContextRequest.java
+++ b/src/main/java/jcifs/internal/smb2/create/LeaseV1CreateContextRequest.java
@@ -1,5 +1,5 @@
 /*
- * © 2017 AgNO3 Gmbh & Co. KG
+ * © 2025 CodeLibs, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/jcifs/internal/smb2/create/LeaseV1CreateContextRequest.java
+++ b/src/main/java/jcifs/internal/smb2/create/LeaseV1CreateContextRequest.java
@@ -1,0 +1,163 @@
+/*
+ * © 2017 AgNO3 Gmbh & Co. KG
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package jcifs.internal.smb2.create;
+
+import jcifs.internal.smb2.lease.Smb2LeaseKey;
+import jcifs.internal.util.SMBUtil;
+
+/**
+ * SMB2 Lease V1 Create Context Request
+ *
+ * MS-SMB2 2.2.13.2.8
+ */
+public class LeaseV1CreateContextRequest implements CreateContextRequest {
+
+    /**
+     * Context name for lease request
+     */
+    public static final String CONTEXT_NAME = "RqLs";
+
+    private static final byte[] CONTEXT_NAME_BYTES = CONTEXT_NAME.getBytes();
+
+    private Smb2LeaseKey leaseKey;
+    private int leaseState;
+    private int leaseFlags;
+
+    /**
+     * Create a new lease V1 context request
+     */
+    public LeaseV1CreateContextRequest() {
+        this.leaseKey = new Smb2LeaseKey();
+        this.leaseState = 0;
+        this.leaseFlags = 0;
+    }
+
+    /**
+     * Create a new lease V1 context request with specified parameters
+     *
+     * @param leaseKey the lease key
+     * @param leaseState requested lease state
+     */
+    public LeaseV1CreateContextRequest(Smb2LeaseKey leaseKey, int leaseState) {
+        this.leaseKey = leaseKey;
+        this.leaseState = leaseState;
+        this.leaseFlags = 0;
+    }
+
+    @Override
+    public byte[] getName() {
+        return CONTEXT_NAME_BYTES;
+    }
+
+    /**
+     * @return the lease key
+     */
+    public Smb2LeaseKey getLeaseKey() {
+        return leaseKey;
+    }
+
+    /**
+     * @param leaseKey the lease key to set
+     */
+    public void setLeaseKey(Smb2LeaseKey leaseKey) {
+        this.leaseKey = leaseKey;
+    }
+
+    /**
+     * @return the requested lease state
+     */
+    public int getLeaseState() {
+        return leaseState;
+    }
+
+    /**
+     * @param leaseState the lease state to set
+     */
+    public void setLeaseState(int leaseState) {
+        this.leaseState = leaseState;
+    }
+
+    /**
+     * @return the lease flags
+     */
+    public int getLeaseFlags() {
+        return leaseFlags;
+    }
+
+    /**
+     * @param leaseFlags the lease flags to set
+     */
+    public void setLeaseFlags(int leaseFlags) {
+        this.leaseFlags = leaseFlags;
+    }
+
+    @Override
+    public int size() {
+        // Context header: 16 bytes
+        // Name: 4 bytes ("RqLs")
+        // Padding: 4 bytes (to align data to 8-byte boundary)
+        // Data: 32 bytes (lease V1 structure)
+        return 16 + 4 + 4 + 32;
+    }
+
+    @Override
+    public int encode(byte[] dst, int dstIndex) {
+        int start = dstIndex;
+
+        // Write context header
+        SMBUtil.writeInt4(0, dst, dstIndex); // Next (offset to next context, 0 for last)
+        dstIndex += 4;
+
+        SMBUtil.writeInt2(16, dst, dstIndex); // NameOffset (from start of context)
+        dstIndex += 2;
+
+        SMBUtil.writeInt2(4, dst, dstIndex); // NameLength
+        dstIndex += 2;
+
+        SMBUtil.writeInt2(0, dst, dstIndex); // Reserved
+        dstIndex += 2;
+
+        SMBUtil.writeInt2(24, dst, dstIndex); // DataOffset (from start of context)
+        dstIndex += 2;
+
+        SMBUtil.writeInt4(32, dst, dstIndex); // DataLength
+        dstIndex += 4;
+
+        // Write context name
+        System.arraycopy(CONTEXT_NAME_BYTES, 0, dst, dstIndex, 4);
+        dstIndex += 4;
+
+        // Padding to align data to 8-byte boundary
+        dstIndex += 4;
+
+        // Write lease V1 data (32 bytes total)
+        leaseKey.encode(dst, dstIndex); // LeaseKey (16 bytes)
+        dstIndex += 16;
+
+        SMBUtil.writeInt4(leaseState, dst, dstIndex); // LeaseState (4 bytes)
+        dstIndex += 4;
+
+        SMBUtil.writeInt4(leaseFlags, dst, dstIndex); // LeaseFlags (4 bytes)
+        dstIndex += 4;
+
+        SMBUtil.writeInt8(0, dst, dstIndex); // LeaseDuration (8 bytes) - reserved, must be zero
+        dstIndex += 8;
+
+        return dstIndex - start;
+    }
+}

--- a/src/main/java/jcifs/internal/smb2/create/LeaseV1CreateContextResponse.java
+++ b/src/main/java/jcifs/internal/smb2/create/LeaseV1CreateContextResponse.java
@@ -1,5 +1,5 @@
 /*
- * © 2017 AgNO3 Gmbh & Co. KG
+ * © 2025 CodeLibs, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/jcifs/internal/smb2/create/LeaseV1CreateContextResponse.java
+++ b/src/main/java/jcifs/internal/smb2/create/LeaseV1CreateContextResponse.java
@@ -1,0 +1,99 @@
+/*
+ * © 2017 AgNO3 Gmbh & Co. KG
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package jcifs.internal.smb2.create;
+
+import jcifs.internal.SMBProtocolDecodingException;
+import jcifs.internal.smb2.lease.Smb2LeaseKey;
+import jcifs.internal.util.SMBUtil;
+
+/**
+ * SMB2 Lease V1 Create Context Response
+ *
+ * MS-SMB2 2.2.14.2.10
+ */
+public class LeaseV1CreateContextResponse implements CreateContextResponse {
+
+    /**
+     * Context name for lease response
+     */
+    public static final String CONTEXT_NAME = "RqLs";
+
+    private static final byte[] CONTEXT_NAME_BYTES = CONTEXT_NAME.getBytes();
+
+    private Smb2LeaseKey leaseKey;
+    private int leaseState;
+    private int leaseFlags;
+
+    /**
+     * Create a new lease V1 context response
+     */
+    public LeaseV1CreateContextResponse() {
+    }
+
+    @Override
+    public byte[] getName() {
+        return CONTEXT_NAME_BYTES;
+    }
+
+    /**
+     * @return the lease key
+     */
+    public Smb2LeaseKey getLeaseKey() {
+        return leaseKey;
+    }
+
+    /**
+     * @return the granted lease state
+     */
+    public int getLeaseState() {
+        return leaseState;
+    }
+
+    /**
+     * @return the lease flags
+     */
+    public int getLeaseFlags() {
+        return leaseFlags;
+    }
+
+    @Override
+    public int decode(byte[] buffer, int bufferIndex, int len) throws SMBProtocolDecodingException {
+        int start = bufferIndex;
+
+        if (len < 32) {
+            throw new SMBProtocolDecodingException("Lease V1 context data too short: " + len);
+        }
+
+        // Read lease V1 data (32 bytes)
+        byte[] keyBytes = new byte[16];
+        System.arraycopy(buffer, bufferIndex, keyBytes, 0, 16);
+        this.leaseKey = new Smb2LeaseKey(keyBytes);
+        bufferIndex += 16;
+
+        this.leaseState = SMBUtil.readInt4(buffer, bufferIndex);
+        bufferIndex += 4;
+
+        this.leaseFlags = SMBUtil.readInt4(buffer, bufferIndex);
+        bufferIndex += 4;
+
+        // LeaseDuration (8 bytes) - reserved, skip
+        bufferIndex += 8;
+
+        return bufferIndex - start;
+    }
+}

--- a/src/main/java/jcifs/internal/smb2/create/LeaseV2CreateContextRequest.java
+++ b/src/main/java/jcifs/internal/smb2/create/LeaseV2CreateContextRequest.java
@@ -1,0 +1,208 @@
+/*
+ * © 2017 AgNO3 Gmbh & Co. KG
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package jcifs.internal.smb2.create;
+
+import jcifs.internal.smb2.lease.Smb2LeaseKey;
+import jcifs.internal.util.SMBUtil;
+
+/**
+ * SMB2 Lease V2 Create Context Request
+ *
+ * MS-SMB2 2.2.13.2.10
+ */
+public class LeaseV2CreateContextRequest implements CreateContextRequest {
+
+    /**
+     * Context name for lease V2 request
+     */
+    public static final String CONTEXT_NAME = "RqL2";
+
+    private static final byte[] CONTEXT_NAME_BYTES = CONTEXT_NAME.getBytes();
+
+    private Smb2LeaseKey leaseKey;
+    private int leaseState;
+    private int leaseFlags;
+    private Smb2LeaseKey parentLeaseKey;
+    private int epoch;
+
+    /**
+     * Create a new lease V2 context request
+     */
+    public LeaseV2CreateContextRequest() {
+        this.leaseKey = new Smb2LeaseKey();
+        this.parentLeaseKey = new Smb2LeaseKey(new byte[16]); // Zero parent key by default
+        this.leaseState = 0;
+        this.leaseFlags = 0;
+        this.epoch = 1;
+    }
+
+    /**
+     * Create a new lease V2 context request with specified parameters
+     *
+     * @param leaseKey the lease key
+     * @param leaseState requested lease state
+     * @param parentLeaseKey parent lease key (can be null for zero key)
+     * @param epoch lease epoch
+     */
+    public LeaseV2CreateContextRequest(Smb2LeaseKey leaseKey, int leaseState, Smb2LeaseKey parentLeaseKey, int epoch) {
+        this.leaseKey = leaseKey;
+        this.leaseState = leaseState;
+        this.leaseFlags = 0;
+        this.parentLeaseKey = parentLeaseKey != null ? parentLeaseKey : new Smb2LeaseKey(new byte[16]);
+        this.epoch = epoch;
+    }
+
+    @Override
+    public byte[] getName() {
+        return CONTEXT_NAME_BYTES;
+    }
+
+    /**
+     * @return the lease key
+     */
+    public Smb2LeaseKey getLeaseKey() {
+        return leaseKey;
+    }
+
+    /**
+     * @param leaseKey the lease key to set
+     */
+    public void setLeaseKey(Smb2LeaseKey leaseKey) {
+        this.leaseKey = leaseKey;
+    }
+
+    /**
+     * @return the requested lease state
+     */
+    public int getLeaseState() {
+        return leaseState;
+    }
+
+    /**
+     * @param leaseState the lease state to set
+     */
+    public void setLeaseState(int leaseState) {
+        this.leaseState = leaseState;
+    }
+
+    /**
+     * @return the lease flags
+     */
+    public int getLeaseFlags() {
+        return leaseFlags;
+    }
+
+    /**
+     * @param leaseFlags the lease flags to set
+     */
+    public void setLeaseFlags(int leaseFlags) {
+        this.leaseFlags = leaseFlags;
+    }
+
+    /**
+     * @return the parent lease key
+     */
+    public Smb2LeaseKey getParentLeaseKey() {
+        return parentLeaseKey;
+    }
+
+    /**
+     * @param parentLeaseKey the parent lease key to set
+     */
+    public void setParentLeaseKey(Smb2LeaseKey parentLeaseKey) {
+        this.parentLeaseKey = parentLeaseKey != null ? parentLeaseKey : new Smb2LeaseKey(new byte[16]);
+    }
+
+    /**
+     * @return the epoch
+     */
+    public int getEpoch() {
+        return epoch;
+    }
+
+    /**
+     * @param epoch the epoch to set
+     */
+    public void setEpoch(int epoch) {
+        this.epoch = epoch;
+    }
+
+    @Override
+    public int size() {
+        // Context header: 16 bytes
+        // Name: 4 bytes ("RqL2")
+        // Padding: 4 bytes (to align data to 8-byte boundary)
+        // Data: 52 bytes (lease V2 structure)
+        return 16 + 4 + 4 + 52;
+    }
+
+    @Override
+    public int encode(byte[] dst, int dstIndex) {
+        int start = dstIndex;
+
+        // Write context header
+        SMBUtil.writeInt4(16, dst, dstIndex); // Next (offset to next context, 0 for last)
+        dstIndex += 4;
+
+        SMBUtil.writeInt2(4, dst, dstIndex); // NameOffset (from start of context)
+        dstIndex += 2;
+
+        SMBUtil.writeInt2(4, dst, dstIndex); // NameLength
+        dstIndex += 2;
+
+        SMBUtil.writeInt2(0, dst, dstIndex); // Reserved
+        dstIndex += 2;
+
+        SMBUtil.writeInt2(24, dst, dstIndex); // DataOffset (from start of context)
+        dstIndex += 2;
+
+        SMBUtil.writeInt4(52, dst, dstIndex); // DataLength
+        dstIndex += 4;
+
+        // Write context name
+        System.arraycopy(CONTEXT_NAME_BYTES, 0, dst, dstIndex, 4);
+        dstIndex += 4;
+
+        // Padding to align data to 8-byte boundary
+        dstIndex += 4;
+
+        // Write lease V2 data (52 bytes total)
+        leaseKey.encode(dst, dstIndex); // LeaseKey (16 bytes)
+        dstIndex += 16;
+
+        SMBUtil.writeInt4(leaseState, dst, dstIndex); // LeaseState (4 bytes)
+        dstIndex += 4;
+
+        SMBUtil.writeInt4(leaseFlags, dst, dstIndex); // LeaseFlags (4 bytes)
+        dstIndex += 4;
+
+        SMBUtil.writeInt8(0, dst, dstIndex); // LeaseDuration (8 bytes) - reserved, must be zero
+        dstIndex += 8;
+
+        parentLeaseKey.encode(dst, dstIndex); // ParentLeaseKey (16 bytes)
+        dstIndex += 16;
+
+        SMBUtil.writeInt2(epoch, dst, dstIndex); // Epoch (2 bytes)
+        dstIndex += 2;
+
+        SMBUtil.writeInt2(0, dst, dstIndex); // Reserved (2 bytes)
+        dstIndex += 2;
+
+        return dstIndex - start;
+    }
+}

--- a/src/main/java/jcifs/internal/smb2/create/LeaseV2CreateContextRequest.java
+++ b/src/main/java/jcifs/internal/smb2/create/LeaseV2CreateContextRequest.java
@@ -1,5 +1,5 @@
 /*
- * © 2017 AgNO3 Gmbh & Co. KG
+ * © 2025 CodeLibs, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/jcifs/internal/smb2/create/LeaseV2CreateContextResponse.java
+++ b/src/main/java/jcifs/internal/smb2/create/LeaseV2CreateContextResponse.java
@@ -1,0 +1,126 @@
+/*
+ * © 2017 AgNO3 Gmbh & Co. KG
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package jcifs.internal.smb2.create;
+
+import jcifs.internal.SMBProtocolDecodingException;
+import jcifs.internal.smb2.lease.Smb2LeaseKey;
+import jcifs.internal.util.SMBUtil;
+
+/**
+ * SMB2 Lease V2 Create Context Response
+ *
+ * MS-SMB2 2.2.14.2.11
+ */
+public class LeaseV2CreateContextResponse implements CreateContextResponse {
+
+    /**
+     * Context name for lease V2 response
+     */
+    public static final String CONTEXT_NAME = "RqL2";
+
+    private static final byte[] CONTEXT_NAME_BYTES = CONTEXT_NAME.getBytes();
+
+    private Smb2LeaseKey leaseKey;
+    private int leaseState;
+    private int leaseFlags;
+    private Smb2LeaseKey parentLeaseKey;
+    private int epoch;
+
+    /**
+     * Create a new lease V2 context response
+     */
+    public LeaseV2CreateContextResponse() {
+    }
+
+    @Override
+    public byte[] getName() {
+        return CONTEXT_NAME_BYTES;
+    }
+
+    /**
+     * @return the lease key
+     */
+    public Smb2LeaseKey getLeaseKey() {
+        return leaseKey;
+    }
+
+    /**
+     * @return the granted lease state
+     */
+    public int getLeaseState() {
+        return leaseState;
+    }
+
+    /**
+     * @return the lease flags
+     */
+    public int getLeaseFlags() {
+        return leaseFlags;
+    }
+
+    /**
+     * @return the parent lease key
+     */
+    public Smb2LeaseKey getParentLeaseKey() {
+        return parentLeaseKey;
+    }
+
+    /**
+     * @return the epoch
+     */
+    public int getEpoch() {
+        return epoch;
+    }
+
+    @Override
+    public int decode(byte[] buffer, int bufferIndex, int len) throws SMBProtocolDecodingException {
+        int start = bufferIndex;
+
+        if (len < 52) {
+            throw new SMBProtocolDecodingException("Lease V2 context data too short: " + len);
+        }
+
+        // Read lease V2 data (52 bytes)
+        byte[] keyBytes = new byte[16];
+        System.arraycopy(buffer, bufferIndex, keyBytes, 0, 16);
+        this.leaseKey = new Smb2LeaseKey(keyBytes);
+        bufferIndex += 16;
+
+        this.leaseState = SMBUtil.readInt4(buffer, bufferIndex);
+        bufferIndex += 4;
+
+        this.leaseFlags = SMBUtil.readInt4(buffer, bufferIndex);
+        bufferIndex += 4;
+
+        // LeaseDuration (8 bytes) - reserved, skip
+        bufferIndex += 8;
+
+        byte[] parentKeyBytes = new byte[16];
+        System.arraycopy(buffer, bufferIndex, parentKeyBytes, 0, 16);
+        this.parentLeaseKey = new Smb2LeaseKey(parentKeyBytes);
+        bufferIndex += 16;
+
+        this.epoch = SMBUtil.readInt2(buffer, bufferIndex);
+        bufferIndex += 2;
+
+        // Reserved (2 bytes) - skip
+        bufferIndex += 2;
+
+        return bufferIndex - start;
+    }
+}

--- a/src/main/java/jcifs/internal/smb2/create/LeaseV2CreateContextResponse.java
+++ b/src/main/java/jcifs/internal/smb2/create/LeaseV2CreateContextResponse.java
@@ -1,5 +1,5 @@
 /*
- * © 2017 AgNO3 Gmbh & Co. KG
+ * © 2025 CodeLibs, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/jcifs/internal/smb2/create/Smb2CreateRequest.java
+++ b/src/main/java/jcifs/internal/smb2/create/Smb2CreateRequest.java
@@ -27,6 +27,8 @@ import jcifs.Configuration;
 import jcifs.internal.RequestWithPath;
 import jcifs.internal.smb2.ServerMessageBlock2Request;
 import jcifs.internal.smb2.Smb2Constants;
+import jcifs.internal.smb2.lease.Smb2LeaseKey;
+import jcifs.internal.smb2.lease.Smb2LeaseState;
 import jcifs.internal.util.SMBUtil;
 import jcifs.util.Hexdump;
 
@@ -403,6 +405,56 @@ public class Smb2CreateRequest extends ServerMessageBlock2Request<Smb2CreateResp
      */
     public void setCreateOptions(final int createOptions) {
         this.createOptions = createOptions;
+    }
+
+    /**
+     * Set the create contexts for this request
+     * @param contexts the create contexts to set
+     */
+    public void setCreateContexts(CreateContextRequest[] contexts) {
+        this.createContexts = contexts;
+    }
+
+    /**
+     * Add a create context to this request
+     * @param context the create context to add
+     */
+    public void addCreateContext(CreateContextRequest context) {
+        if (context == null) {
+            return;
+        }
+        if (this.createContexts == null) {
+            this.createContexts = new CreateContextRequest[] { context };
+        } else {
+            CreateContextRequest[] newContexts = new CreateContextRequest[this.createContexts.length + 1];
+            System.arraycopy(this.createContexts, 0, newContexts, 0, this.createContexts.length);
+            newContexts[this.createContexts.length] = context;
+            this.createContexts = newContexts;
+        }
+    }
+
+    /**
+     * Add a lease V1 context to this request
+     * @param leaseKey the lease key
+     * @param requestedState the requested lease state
+     */
+    public void addLeaseV1Context(Smb2LeaseKey leaseKey, int requestedState) {
+        LeaseV1CreateContextRequest leaseContext = new LeaseV1CreateContextRequest(leaseKey, requestedState);
+        addCreateContext(leaseContext);
+        setRequestedOplockLevel(SMB2_OPLOCK_LEVEL_LEASE);
+    }
+
+    /**
+     * Add a lease V2 context to this request
+     * @param leaseKey the lease key
+     * @param requestedState the requested lease state
+     * @param parentLeaseKey the parent lease key (can be null)
+     * @param epoch the lease epoch
+     */
+    public void addLeaseV2Context(Smb2LeaseKey leaseKey, int requestedState, Smb2LeaseKey parentLeaseKey, int epoch) {
+        LeaseV2CreateContextRequest leaseContext = new LeaseV2CreateContextRequest(leaseKey, requestedState, parentLeaseKey, epoch);
+        addCreateContext(leaseContext);
+        setRequestedOplockLevel(SMB2_OPLOCK_LEVEL_LEASE);
     }
 
     /**

--- a/src/main/java/jcifs/internal/smb2/lease/LeaseManager.java
+++ b/src/main/java/jcifs/internal/smb2/lease/LeaseManager.java
@@ -1,0 +1,392 @@
+/*
+ * © 2017 AgNO3 Gmbh & Co. KG
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package jcifs.internal.smb2.lease;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jcifs.CIFSContext;
+
+/**
+ * SMB2/SMB3 Lease Manager
+ *
+ * Manages lease state for SMB2/SMB3 connections
+ */
+public class LeaseManager {
+
+    private static final Logger log = LoggerFactory.getLogger(LeaseManager.class);
+
+    private final ConcurrentHashMap<Smb2LeaseKey, LeaseEntry> leases;
+    private final ConcurrentHashMap<String, Smb2LeaseKey> pathToLease;
+    private final ReadWriteLock lock;
+    private final CIFSContext context;
+
+    /**
+     * Create a new lease manager
+     *
+     * @param context CIFS context
+     */
+    public LeaseManager(CIFSContext context) {
+        this.context = context;
+        this.leases = new ConcurrentHashMap<>();
+        this.pathToLease = new ConcurrentHashMap<>();
+        this.lock = new ReentrantReadWriteLock();
+    }
+
+    /**
+     * Lease entry containing lease state information
+     */
+    public static class LeaseEntry {
+        private final Smb2LeaseKey leaseKey;
+        private volatile int leaseState;
+        private volatile int epoch;
+        private final long createTime;
+        private volatile long lastAccessTime;
+        private final String path;
+        private volatile boolean breaking;
+
+        /**
+         * Create a new lease entry
+         *
+         * @param key lease key
+         * @param path file path
+         * @param state initial lease state
+         */
+        public LeaseEntry(Smb2LeaseKey key, String path, int state) {
+            this.leaseKey = key;
+            this.path = path;
+            this.leaseState = state;
+            this.createTime = System.currentTimeMillis();
+            this.lastAccessTime = createTime;
+            this.epoch = 1;
+            this.breaking = false;
+        }
+
+        /**
+         * Update the lease state
+         *
+         * @param newState new lease state
+         */
+        public synchronized void updateState(int newState) {
+            this.leaseState = newState;
+            this.lastAccessTime = System.currentTimeMillis();
+        }
+
+        /**
+         * Increment the epoch value
+         */
+        public synchronized void incrementEpoch() {
+            this.epoch++;
+        }
+
+        /**
+         * Check if lease has read caching
+         *
+         * @return true if read caching is enabled
+         */
+        public boolean hasReadCache() {
+            return Smb2LeaseState.hasReadCaching(leaseState);
+        }
+
+        /**
+         * Check if lease has write caching
+         *
+         * @return true if write caching is enabled
+         */
+        public boolean hasWriteCache() {
+            return Smb2LeaseState.hasWriteCaching(leaseState);
+        }
+
+        /**
+         * Check if lease has handle caching
+         *
+         * @return true if handle caching is enabled
+         */
+        public boolean hasHandleCache() {
+            return Smb2LeaseState.hasHandleCaching(leaseState);
+        }
+
+        /**
+         * @return the lease key
+         */
+        public Smb2LeaseKey getLeaseKey() {
+            return leaseKey;
+        }
+
+        /**
+         * @return the current lease state
+         */
+        public int getLeaseState() {
+            return leaseState;
+        }
+
+        /**
+         * @return the current epoch
+         */
+        public int getEpoch() {
+            return epoch;
+        }
+
+        /**
+         * @return the file path
+         */
+        public String getPath() {
+            return path;
+        }
+
+        /**
+         * @return true if lease is currently breaking
+         */
+        public boolean isBreaking() {
+            return breaking;
+        }
+
+        /**
+         * @param breaking set breaking state
+         */
+        public void setBreaking(boolean breaking) {
+            this.breaking = breaking;
+        }
+
+        /**
+         * @return last access time in milliseconds
+         */
+        public long getLastAccessTime() {
+            return lastAccessTime;
+        }
+    }
+
+    /**
+     * Request a lease for a file path
+     *
+     * @param path file path
+     * @param requestedState requested lease state
+     * @return lease key for the request
+     */
+    public Smb2LeaseKey requestLease(String path, int requestedState) {
+        lock.writeLock().lock();
+        try {
+            // Check if we already have a lease for this path
+            Smb2LeaseKey existingKey = pathToLease.get(path);
+            if (existingKey != null) {
+                LeaseEntry entry = leases.get(existingKey);
+                if (entry != null && !entry.breaking) {
+                    entry.lastAccessTime = System.currentTimeMillis();
+                    log.debug("Reusing existing lease for path: {}", path);
+                    return existingKey;
+                }
+            }
+
+            // Create new lease
+            Smb2LeaseKey newKey = new Smb2LeaseKey();
+            LeaseEntry newEntry = new LeaseEntry(newKey, path, requestedState);
+            leases.put(newKey, newEntry);
+            pathToLease.put(path, newKey);
+
+            log.debug("Created new lease for path: {} with key: {}", path, newKey);
+            return newKey;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Update lease state after receiving response
+     *
+     * @param key lease key
+     * @param grantedState granted lease state
+     */
+    public void updateLease(Smb2LeaseKey key, int grantedState) {
+        LeaseEntry entry = leases.get(key);
+        if (entry != null) {
+            entry.updateState(grantedState);
+            log.debug("Updated lease {} to state: 0x{}", key, Integer.toHexString(grantedState));
+        } else {
+            log.warn("Attempted to update non-existent lease: {}", key);
+        }
+    }
+
+    /**
+     * Get lease entry by key
+     *
+     * @param key lease key
+     * @return lease entry or null if not found
+     */
+    public LeaseEntry getLease(Smb2LeaseKey key) {
+        return leases.get(key);
+    }
+
+    /**
+     * Get lease entry by path
+     *
+     * @param path file path
+     * @return lease entry or null if not found
+     */
+    public LeaseEntry getLeaseByPath(String path) {
+        Smb2LeaseKey key = pathToLease.get(path);
+        return key != null ? leases.get(key) : null;
+    }
+
+    /**
+     * Handle a lease break notification
+     *
+     * @param key lease key
+     * @param newState new lease state
+     */
+    public void handleLeaseBreak(Smb2LeaseKey key, int newState) {
+        LeaseEntry entry = leases.get(key);
+        if (entry != null) {
+            log.info("Handling lease break for {} from state 0x{} to 0x{}", key, Integer.toHexString(entry.getLeaseState()),
+                    Integer.toHexString(newState));
+
+            entry.setBreaking(true);
+            int oldState = entry.getLeaseState();
+            entry.updateState(newState);
+
+            // Flush any cached data if losing write cache
+            if (Smb2LeaseState.hasWriteCaching(oldState) && !Smb2LeaseState.hasWriteCaching(newState)) {
+                flushCachedWrites(entry.getPath());
+            }
+
+            // Invalidate cached data if losing read cache
+            if (Smb2LeaseState.hasReadCaching(oldState) && !Smb2LeaseState.hasReadCaching(newState)) {
+                invalidateReadCache(entry.getPath());
+            }
+
+            entry.incrementEpoch();
+            entry.setBreaking(false);
+        } else {
+            log.warn("Received lease break for unknown lease: {}", key);
+        }
+    }
+
+    /**
+     * Handle a lease break with timeout
+     *
+     * @param key lease key
+     * @param newState new lease state
+     * @param timeoutSeconds timeout in seconds
+     */
+    public void handleLeaseBreakWithTimeout(Smb2LeaseKey key, int newState, int timeoutSeconds) {
+        CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
+            handleLeaseBreak(key, newState);
+        });
+
+        try {
+            future.get(timeoutSeconds, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            // Force lease release if break handling times out
+            releaseLease(key);
+            log.warn("Lease break timeout for key: {}", key);
+        } catch (Exception e) {
+            log.error("Error handling lease break for key: " + key, e);
+        }
+    }
+
+    /**
+     * Release a lease
+     *
+     * @param key lease key
+     */
+    public void releaseLease(Smb2LeaseKey key) {
+        lock.writeLock().lock();
+        try {
+            LeaseEntry entry = leases.remove(key);
+            if (entry != null) {
+                pathToLease.remove(entry.getPath());
+                log.debug("Released lease for path: {} with key: {}", entry.getPath(), key);
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Release all leases
+     */
+    public void releaseAll() {
+        lock.writeLock().lock();
+        try {
+            log.info("Releasing all {} leases", leases.size());
+            leases.clear();
+            pathToLease.clear();
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Get all active leases
+     *
+     * @return map of lease keys to lease entries
+     */
+    public Map<Smb2LeaseKey, LeaseEntry> getAllLeases() {
+        return new ConcurrentHashMap<>(leases);
+    }
+
+    /**
+     * Clean up expired leases
+     *
+     * @param maxAgeMillis maximum age in milliseconds
+     * @return number of leases cleaned up
+     */
+    public int cleanupExpiredLeases(long maxAgeMillis) {
+        lock.writeLock().lock();
+        try {
+            long now = System.currentTimeMillis();
+            int cleaned = 0;
+
+            for (Map.Entry<Smb2LeaseKey, LeaseEntry> entry : leases.entrySet()) {
+                if (now - entry.getValue().getLastAccessTime() > maxAgeMillis) {
+                    leases.remove(entry.getKey());
+                    pathToLease.remove(entry.getValue().getPath());
+                    cleaned++;
+                    log.debug("Cleaned up expired lease: {}", entry.getKey());
+                }
+            }
+
+            if (cleaned > 0) {
+                log.info("Cleaned up {} expired leases", cleaned);
+            }
+
+            return cleaned;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    private void flushCachedWrites(String path) {
+        // Implementation would flush cached writes for the path
+        // This is a placeholder for actual cache flushing logic
+        log.debug("Flushing cached writes for path: {}", path);
+    }
+
+    private void invalidateReadCache(String path) {
+        // Implementation would invalidate read cache for the path
+        // This is a placeholder for actual cache invalidation logic
+        log.debug("Invalidating read cache for path: {}", path);
+    }
+}

--- a/src/main/java/jcifs/internal/smb2/lease/LeaseManager.java
+++ b/src/main/java/jcifs/internal/smb2/lease/LeaseManager.java
@@ -1,5 +1,5 @@
 /*
- * © 2017 AgNO3 Gmbh & Co. KG
+ * © 2025 CodeLibs, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/jcifs/internal/smb2/lease/Smb2LeaseKey.java
+++ b/src/main/java/jcifs/internal/smb2/lease/Smb2LeaseKey.java
@@ -1,5 +1,5 @@
 /*
- * © 2017 AgNO3 Gmbh & Co. KG
+ * © 2025 CodeLibs, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/jcifs/internal/smb2/lease/Smb2LeaseKey.java
+++ b/src/main/java/jcifs/internal/smb2/lease/Smb2LeaseKey.java
@@ -1,0 +1,121 @@
+/*
+ * © 2017 AgNO3 Gmbh & Co. KG
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package jcifs.internal.smb2.lease;
+
+import java.security.SecureRandom;
+import java.util.Arrays;
+
+/**
+ * SMB2 Lease Key
+ *
+ * Represents a 16-byte lease key used to identify leases in SMB2/SMB3
+ * MS-SMB2 2.2.13.2.8
+ */
+public class Smb2LeaseKey {
+
+    private final byte[] key;
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final int LEASE_KEY_SIZE = 16;
+
+    /**
+     * Create a new random lease key
+     */
+    public Smb2LeaseKey() {
+        this.key = new byte[LEASE_KEY_SIZE];
+        RANDOM.nextBytes(this.key);
+    }
+
+    /**
+     * Create a lease key from existing bytes
+     *
+     * @param key 16-byte array
+     * @throws IllegalArgumentException if key is not 16 bytes
+     */
+    public Smb2LeaseKey(byte[] key) {
+        if (key == null) {
+            throw new IllegalArgumentException("Lease key cannot be null");
+        }
+        if (key.length != LEASE_KEY_SIZE) {
+            throw new IllegalArgumentException("Lease key must be 16 bytes, got " + key.length);
+        }
+        this.key = Arrays.copyOf(key, LEASE_KEY_SIZE);
+    }
+
+    /**
+     * Get the lease key bytes
+     *
+     * @return copy of the 16-byte lease key
+     */
+    public byte[] getKey() {
+        return Arrays.copyOf(key, LEASE_KEY_SIZE);
+    }
+
+    /**
+     * Write the lease key to a buffer
+     *
+     * @param dst destination buffer
+     * @param dstIndex starting index in destination buffer
+     */
+    public void encode(byte[] dst, int dstIndex) {
+        System.arraycopy(key, 0, dst, dstIndex, LEASE_KEY_SIZE);
+    }
+
+    /**
+     * Check if this is a zero key (all bytes are zero)
+     *
+     * @return true if all bytes are zero
+     */
+    public boolean isZero() {
+        for (byte b : key) {
+            if (b != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        Smb2LeaseKey other = (Smb2LeaseKey) obj;
+        return Arrays.equals(key, other.key);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(key);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("LeaseKey[");
+        for (int i = 0; i < key.length; i++) {
+            if (i > 0) {
+                sb.append(' ');
+            }
+            sb.append(String.format("%02X", key[i] & 0xFF));
+        }
+        sb.append(']');
+        return sb.toString();
+    }
+}

--- a/src/main/java/jcifs/internal/smb2/lease/Smb2LeaseState.java
+++ b/src/main/java/jcifs/internal/smb2/lease/Smb2LeaseState.java
@@ -1,5 +1,5 @@
 /*
- * © 2017 AgNO3 Gmbh & Co. KG
+ * © 2025 CodeLibs, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/jcifs/internal/smb2/lease/Smb2LeaseState.java
+++ b/src/main/java/jcifs/internal/smb2/lease/Smb2LeaseState.java
@@ -1,0 +1,92 @@
+/*
+ * © 2017 AgNO3 Gmbh & Co. KG
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package jcifs.internal.smb2.lease;
+
+/**
+ * SMB2 Lease State constants
+ *
+ * MS-SMB2 2.2.13.2.8
+ */
+public class Smb2LeaseState {
+
+    /**
+     * No lease caching
+     */
+    public static final int SMB2_LEASE_NONE = 0x00;
+
+    /**
+     * Read caching lease (R)
+     */
+    public static final int SMB2_LEASE_READ_CACHING = 0x01;
+
+    /**
+     * Handle caching lease (H)
+     */
+    public static final int SMB2_LEASE_HANDLE_CACHING = 0x02;
+
+    /**
+     * Write caching lease (W)
+     */
+    public static final int SMB2_LEASE_WRITE_CACHING = 0x04;
+
+    /**
+     * Read and Handle caching (RH)
+     */
+    public static final int SMB2_LEASE_READ_HANDLE = 0x03;
+
+    /**
+     * Read and Write caching (RW)
+     */
+    public static final int SMB2_LEASE_READ_WRITE = 0x05;
+
+    /**
+     * Full caching - Read, Write and Handle (RWH)
+     */
+    public static final int SMB2_LEASE_FULL = 0x07;
+
+    private Smb2LeaseState() {
+        // Utility class
+    }
+
+    /**
+     * Check if state has read caching
+     * @param state lease state
+     * @return true if read caching is enabled
+     */
+    public static boolean hasReadCaching(int state) {
+        return (state & SMB2_LEASE_READ_CACHING) != 0;
+    }
+
+    /**
+     * Check if state has handle caching
+     * @param state lease state
+     * @return true if handle caching is enabled
+     */
+    public static boolean hasHandleCaching(int state) {
+        return (state & SMB2_LEASE_HANDLE_CACHING) != 0;
+    }
+
+    /**
+     * Check if state has write caching
+     * @param state lease state
+     * @return true if write caching is enabled
+     */
+    public static boolean hasWriteCaching(int state) {
+        return (state & SMB2_LEASE_WRITE_CACHING) != 0;
+    }
+}

--- a/src/main/java/jcifs/internal/smb2/lock/Smb2LeaseBreakAcknowledgment.java
+++ b/src/main/java/jcifs/internal/smb2/lock/Smb2LeaseBreakAcknowledgment.java
@@ -1,0 +1,144 @@
+/*
+ * © 2017 AgNO3 Gmbh & Co. KG
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package jcifs.internal.smb2.lock;
+
+import jcifs.CIFSContext;
+import jcifs.Configuration;
+import jcifs.internal.smb2.ServerMessageBlock2Request;
+import jcifs.internal.smb2.Smb2Constants;
+import jcifs.internal.smb2.lease.Smb2LeaseKey;
+import jcifs.internal.util.SMBUtil;
+
+/**
+ * SMB2 Lease Break Acknowledgment
+ *
+ * MS-SMB2 2.2.24
+ */
+public class Smb2LeaseBreakAcknowledgment extends ServerMessageBlock2Request<Smb2LeaseBreakResponse> {
+
+    private static final int STRUCTURE_SIZE = 36;
+
+    private int flags;
+    private Smb2LeaseKey leaseKey;
+    private int leaseState;
+
+    /**
+     * Create a lease break acknowledgment
+     *
+     * @param config configuration
+     * @param leaseKey lease key
+     * @param leaseState acknowledged lease state
+     */
+    public Smb2LeaseBreakAcknowledgment(Configuration config, Smb2LeaseKey leaseKey, int leaseState) {
+        super(config, SMB2_OPLOCK_BREAK);
+        this.leaseKey = leaseKey;
+        this.leaseState = leaseState;
+        this.flags = 0;
+    }
+
+    /**
+     * Create a lease break acknowledgment
+     *
+     * @param context CIFS context
+     * @param leaseKey lease key
+     * @param leaseState acknowledged lease state
+     */
+    public Smb2LeaseBreakAcknowledgment(CIFSContext context, Smb2LeaseKey leaseKey, int leaseState) {
+        this(context.getConfig(), leaseKey, leaseState);
+    }
+
+    /**
+     * @return the lease key
+     */
+    public Smb2LeaseKey getLeaseKey() {
+        return leaseKey;
+    }
+
+    /**
+     * @return the lease state
+     */
+    public int getLeaseState() {
+        return leaseState;
+    }
+
+    /**
+     * @return the lease flags
+     */
+    public int getLeaseFlags() {
+        return flags;
+    }
+
+    /**
+     * @param flags the lease flags to set
+     */
+    public void setLeaseFlags(int flags) {
+        this.flags = flags;
+    }
+
+    @Override
+    protected Smb2LeaseBreakResponse createResponse(CIFSContext tc, ServerMessageBlock2Request<Smb2LeaseBreakResponse> req) {
+        return new Smb2LeaseBreakResponse(tc.getConfig());
+    }
+
+    @Override
+    public int size() {
+        return size8(Smb2Constants.SMB2_HEADER_LENGTH + STRUCTURE_SIZE);
+    }
+
+    @Override
+    protected int writeBytesWireFormat(byte[] dst, int dstIndex) {
+        int start = dstIndex;
+
+        // StructureSize (2 bytes) - must be 36
+        SMBUtil.writeInt2(STRUCTURE_SIZE, dst, dstIndex);
+        dstIndex += 2;
+
+        // Reserved (2 bytes)
+        SMBUtil.writeInt2(0, dst, dstIndex);
+        dstIndex += 2;
+
+        // Flags (4 bytes)
+        SMBUtil.writeInt4(flags, dst, dstIndex);
+        dstIndex += 4;
+
+        // LeaseKey (16 bytes)
+        leaseKey.encode(dst, dstIndex);
+        dstIndex += 16;
+
+        // LeaseState (4 bytes)
+        SMBUtil.writeInt4(leaseState, dst, dstIndex);
+        dstIndex += 4;
+
+        // LeaseDuration (8 bytes) - must be zero for acknowledgment
+        SMBUtil.writeInt8(0, dst, dstIndex);
+        dstIndex += 8;
+
+        return dstIndex - start;
+    }
+
+    @Override
+    protected int readBytesWireFormat(byte[] buffer, int bufferIndex) {
+        // This is a request, not a response, so this method is not used
+        return 0;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Smb2LeaseBreakAcknowledgment[leaseKey=%s,leaseState=0x%x,flags=0x%x]", leaseKey, leaseState, flags);
+    }
+}

--- a/src/main/java/jcifs/internal/smb2/lock/Smb2LeaseBreakAcknowledgment.java
+++ b/src/main/java/jcifs/internal/smb2/lock/Smb2LeaseBreakAcknowledgment.java
@@ -1,5 +1,5 @@
 /*
- * © 2017 AgNO3 Gmbh & Co. KG
+ * © 2025 CodeLibs, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/jcifs/internal/smb2/lock/Smb2LeaseBreakNotification.java
+++ b/src/main/java/jcifs/internal/smb2/lock/Smb2LeaseBreakNotification.java
@@ -1,5 +1,5 @@
 /*
- * © 2017 AgNO3 Gmbh & Co. KG
+ * © 2025 CodeLibs, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/jcifs/internal/smb2/lock/Smb2LeaseBreakNotification.java
+++ b/src/main/java/jcifs/internal/smb2/lock/Smb2LeaseBreakNotification.java
@@ -1,0 +1,158 @@
+/*
+ * © 2017 AgNO3 Gmbh & Co. KG
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package jcifs.internal.smb2.lock;
+
+import jcifs.Configuration;
+import jcifs.internal.SMBProtocolDecodingException;
+import jcifs.internal.smb2.ServerMessageBlock2Response;
+import jcifs.internal.smb2.lease.Smb2LeaseKey;
+import jcifs.internal.util.SMBUtil;
+
+/**
+ * SMB2 Lease Break Notification
+ *
+ * MS-SMB2 2.2.23
+ */
+public class Smb2LeaseBreakNotification extends ServerMessageBlock2Response {
+
+    private int structureSize;
+    private int flags;
+    private Smb2LeaseKey leaseKey;
+    private int currentLeaseState;
+    private int newLeaseState;
+    private int breakReason;
+    private int accessMaskHint;
+    private int shareAccessHint;
+
+    /**
+     * Constructs an SMB2 lease break notification with the given configuration.
+     *
+     * @param config the configuration for this notification
+     */
+    public Smb2LeaseBreakNotification(Configuration config) {
+        super(config);
+    }
+
+    /**
+     * @return the lease key
+     */
+    public Smb2LeaseKey getLeaseKey() {
+        return leaseKey;
+    }
+
+    /**
+     * @return the current lease state
+     */
+    public int getCurrentLeaseState() {
+        return currentLeaseState;
+    }
+
+    /**
+     * @return the new lease state
+     */
+    public int getNewLeaseState() {
+        return newLeaseState;
+    }
+
+    /**
+     * @return the break reason
+     */
+    public int getBreakReason() {
+        return breakReason;
+    }
+
+    /**
+     * @return the lease flags
+     */
+    public int getLeaseFlags() {
+        return flags;
+    }
+
+    /**
+     * @return the access mask hint
+     */
+    public int getAccessMaskHint() {
+        return accessMaskHint;
+    }
+
+    /**
+     * @return the share access hint
+     */
+    public int getShareAccessHint() {
+        return shareAccessHint;
+    }
+
+    @Override
+    protected int writeBytesWireFormat(byte[] dst, int dstIndex) {
+        // Lease break notifications are sent by the server, not written by client
+        return 0;
+    }
+
+    @Override
+    protected int readBytesWireFormat(byte[] buffer, int bufferIndex) throws SMBProtocolDecodingException {
+        int start = bufferIndex;
+
+        // StructureSize (2 bytes) - must be 44
+        this.structureSize = SMBUtil.readInt2(buffer, bufferIndex);
+        if (this.structureSize != 44) {
+            throw new SMBProtocolDecodingException("Invalid lease break structure size: " + this.structureSize);
+        }
+        bufferIndex += 2;
+
+        // Reserved (2 bytes)
+        bufferIndex += 2;
+
+        // Flags (4 bytes)
+        this.flags = SMBUtil.readInt4(buffer, bufferIndex);
+        bufferIndex += 4;
+
+        // LeaseKey (16 bytes)
+        byte[] keyBytes = new byte[16];
+        System.arraycopy(buffer, bufferIndex, keyBytes, 0, 16);
+        this.leaseKey = new Smb2LeaseKey(keyBytes);
+        bufferIndex += 16;
+
+        // CurrentLeaseState (4 bytes)
+        this.currentLeaseState = SMBUtil.readInt4(buffer, bufferIndex);
+        bufferIndex += 4;
+
+        // NewLeaseState (4 bytes)
+        this.newLeaseState = SMBUtil.readInt4(buffer, bufferIndex);
+        bufferIndex += 4;
+
+        // BreakReason (4 bytes)
+        this.breakReason = SMBUtil.readInt4(buffer, bufferIndex);
+        bufferIndex += 4;
+
+        // AccessMaskHint (4 bytes)
+        this.accessMaskHint = SMBUtil.readInt4(buffer, bufferIndex);
+        bufferIndex += 4;
+
+        // ShareAccessHint (4 bytes)
+        this.shareAccessHint = SMBUtil.readInt4(buffer, bufferIndex);
+        bufferIndex += 4;
+
+        return bufferIndex - start;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Smb2LeaseBreakNotification[leaseKey=%s,currentState=0x%x,newState=0x%x,reason=%d]", leaseKey,
+                currentLeaseState, newLeaseState, breakReason);
+    }
+}

--- a/src/main/java/jcifs/internal/smb2/lock/Smb2LeaseBreakResponse.java
+++ b/src/main/java/jcifs/internal/smb2/lock/Smb2LeaseBreakResponse.java
@@ -1,5 +1,5 @@
 /*
- * © 2017 AgNO3 Gmbh & Co. KG
+ * © 2025 CodeLibs, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/jcifs/internal/smb2/lock/Smb2LeaseBreakResponse.java
+++ b/src/main/java/jcifs/internal/smb2/lock/Smb2LeaseBreakResponse.java
@@ -1,0 +1,122 @@
+/*
+ * © 2017 AgNO3 Gmbh & Co. KG
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package jcifs.internal.smb2.lock;
+
+import jcifs.Configuration;
+import jcifs.internal.SMBProtocolDecodingException;
+import jcifs.internal.smb2.ServerMessageBlock2Response;
+import jcifs.internal.smb2.lease.Smb2LeaseKey;
+import jcifs.internal.util.SMBUtil;
+
+/**
+ * SMB2 Lease Break Response
+ *
+ * MS-SMB2 2.2.25
+ */
+public class Smb2LeaseBreakResponse extends ServerMessageBlock2Response {
+
+    private int structureSize;
+    private int flags;
+    private Smb2LeaseKey leaseKey;
+    private int leaseState;
+    private long leaseDuration;
+
+    /**
+     * Constructs an SMB2 lease break response with the given configuration.
+     *
+     * @param config the configuration for this response
+     */
+    public Smb2LeaseBreakResponse(Configuration config) {
+        super(config);
+    }
+
+    /**
+     * @return the lease key
+     */
+    public Smb2LeaseKey getLeaseKey() {
+        return leaseKey;
+    }
+
+    /**
+     * @return the lease state
+     */
+    public int getLeaseState() {
+        return leaseState;
+    }
+
+    /**
+     * @return the lease flags
+     */
+    public int getLeaseFlags() {
+        return flags;
+    }
+
+    /**
+     * @return the lease duration
+     */
+    public long getLeaseDuration() {
+        return leaseDuration;
+    }
+
+    @Override
+    protected int writeBytesWireFormat(byte[] dst, int dstIndex) {
+        // This is a response, not a request, so this method is not used
+        return 0;
+    }
+
+    @Override
+    protected int readBytesWireFormat(byte[] buffer, int bufferIndex) throws SMBProtocolDecodingException {
+        int start = bufferIndex;
+
+        // StructureSize (2 bytes) - must be 36
+        this.structureSize = SMBUtil.readInt2(buffer, bufferIndex);
+        if (this.structureSize != 36) {
+            throw new SMBProtocolDecodingException("Invalid lease break response structure size: " + this.structureSize);
+        }
+        bufferIndex += 2;
+
+        // Reserved (2 bytes)
+        bufferIndex += 2;
+
+        // Flags (4 bytes)
+        this.flags = SMBUtil.readInt4(buffer, bufferIndex);
+        bufferIndex += 4;
+
+        // LeaseKey (16 bytes)
+        byte[] keyBytes = new byte[16];
+        System.arraycopy(buffer, bufferIndex, keyBytes, 0, 16);
+        this.leaseKey = new Smb2LeaseKey(keyBytes);
+        bufferIndex += 16;
+
+        // LeaseState (4 bytes)
+        this.leaseState = SMBUtil.readInt4(buffer, bufferIndex);
+        bufferIndex += 4;
+
+        // LeaseDuration (8 bytes)
+        this.leaseDuration = SMBUtil.readInt8(buffer, bufferIndex);
+        bufferIndex += 8;
+
+        return bufferIndex - start;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Smb2LeaseBreakResponse[leaseKey=%s,leaseState=0x%x,flags=0x%x,duration=%d]", leaseKey, leaseState, flags,
+                leaseDuration);
+    }
+}

--- a/src/test/java/jcifs/internal/smb2/create/LeaseV1CreateContextRequestTest.java
+++ b/src/test/java/jcifs/internal/smb2/create/LeaseV1CreateContextRequestTest.java
@@ -1,0 +1,154 @@
+/*
+ * © 2017 AgNO3 Gmbh & Co. KG
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package jcifs.internal.smb2.create;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import jcifs.internal.smb2.lease.Smb2LeaseKey;
+import jcifs.internal.smb2.lease.Smb2LeaseState;
+import jcifs.internal.util.SMBUtil;
+
+@DisplayName("LeaseV1CreateContextRequest Tests")
+class LeaseV1CreateContextRequestTest {
+
+    private LeaseV1CreateContextRequest leaseContext;
+    private Smb2LeaseKey testKey;
+    private int testState;
+
+    @BeforeEach
+    void setUp() {
+        byte[] keyBytes = new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10 };
+        testKey = new Smb2LeaseKey(keyBytes);
+        testState = Smb2LeaseState.SMB2_LEASE_READ_WRITE;
+        leaseContext = new LeaseV1CreateContextRequest(testKey, testState);
+    }
+
+    @Test
+    @DisplayName("Should have correct context name")
+    void testContextName() {
+        assertArrayEquals("RqLs".getBytes(), leaseContext.getName());
+        assertEquals("RqLs", LeaseV1CreateContextRequest.CONTEXT_NAME);
+    }
+
+    @Test
+    @DisplayName("Should initialize with default values")
+    void testDefaultConstructor() {
+        LeaseV1CreateContextRequest defaultContext = new LeaseV1CreateContextRequest();
+
+        assertNotNull(defaultContext.getLeaseKey());
+        assertEquals(0, defaultContext.getLeaseState());
+        assertEquals(0, defaultContext.getLeaseFlags());
+    }
+
+    @Test
+    @DisplayName("Should initialize with provided values")
+    void testParameterizedConstructor() {
+        assertEquals(testKey, leaseContext.getLeaseKey());
+        assertEquals(testState, leaseContext.getLeaseState());
+        assertEquals(0, leaseContext.getLeaseFlags());
+    }
+
+    @Test
+    @DisplayName("Should calculate correct size")
+    void testSize() {
+        int expectedSize = 16 + 4 + 4 + 32; // header + name + padding + data
+        assertEquals(expectedSize, leaseContext.size());
+    }
+
+    @Test
+    @DisplayName("Should set and get lease key")
+    void testLeaseKeyAccessors() {
+        byte[] newKeyBytes = new byte[] { (byte) 0xFF, (byte) 0xFE, (byte) 0xFD, (byte) 0xFC, (byte) 0xFB, (byte) 0xFA, (byte) 0xF9,
+                (byte) 0xF8, (byte) 0xF7, (byte) 0xF6, (byte) 0xF5, (byte) 0xF4, (byte) 0xF3, (byte) 0xF2, (byte) 0xF1, (byte) 0xF0 };
+        Smb2LeaseKey newKey = new Smb2LeaseKey(newKeyBytes);
+
+        leaseContext.setLeaseKey(newKey);
+        assertEquals(newKey, leaseContext.getLeaseKey());
+    }
+
+    @Test
+    @DisplayName("Should set and get lease state")
+    void testLeaseStateAccessors() {
+        int newState = Smb2LeaseState.SMB2_LEASE_FULL;
+
+        leaseContext.setLeaseState(newState);
+        assertEquals(newState, leaseContext.getLeaseState());
+    }
+
+    @Test
+    @DisplayName("Should set and get lease flags")
+    void testLeaseFlagsAccessors() {
+        int newFlags = 0x12345678;
+
+        leaseContext.setLeaseFlags(newFlags);
+        assertEquals(newFlags, leaseContext.getLeaseFlags());
+    }
+
+    @Test
+    @DisplayName("Should encode context correctly")
+    void testEncode() {
+        byte[] buffer = new byte[leaseContext.size()];
+        int encoded = leaseContext.encode(buffer, 0);
+
+        assertEquals(leaseContext.size(), encoded);
+
+        // Verify context header structure according to MS-SMB2
+        // Next field (4 bytes) - should be 0 for last/single context
+        assertEquals(0, SMBUtil.readInt4(buffer, 0));
+
+        // NameOffset field (2 bytes) - should be 16 (after header)
+        assertEquals(16, SMBUtil.readInt2(buffer, 4));
+
+        // NameLength field (2 bytes) - should be 4 for "RqLs"
+        assertEquals(4, SMBUtil.readInt2(buffer, 6));
+
+        // Reserved field (2 bytes) - should be 0
+        assertEquals(0, SMBUtil.readInt2(buffer, 8));
+
+        // DataOffset field (2 bytes) - should be 24 (16 header + 4 name + 4 padding)
+        assertEquals(24, SMBUtil.readInt2(buffer, 10));
+
+        // DataLength field (4 bytes) - should be 32 (lease V1 structure size)
+        assertEquals(32, SMBUtil.readInt4(buffer, 12));
+
+        // Verify context name is encoded at offset 16
+        byte[] nameBytes = new byte[4];
+        System.arraycopy(buffer, 16, nameBytes, 0, 4);
+        assertArrayEquals("RqLs".getBytes(), nameBytes);
+
+        // Verify lease key is encoded at offset 24 (after header + name + padding)
+        byte[] encodedKey = new byte[16];
+        System.arraycopy(buffer, 24, encodedKey, 0, 16);
+        assertArrayEquals(testKey.getKey(), encodedKey);
+
+        // Verify lease state at offset 40 (24 + 16 for key)
+        assertEquals(testState, SMBUtil.readInt4(buffer, 40));
+
+        // Verify lease flags at offset 44 (40 + 4 for state)
+        assertEquals(0, SMBUtil.readInt4(buffer, 44));
+
+        // Verify lease duration at offset 48 (44 + 4 for flags) - should be 0 (reserved)
+        assertEquals(0, SMBUtil.readInt8(buffer, 48));
+    }
+}

--- a/src/test/java/jcifs/internal/smb2/create/LeaseV1CreateContextRequestTest.java
+++ b/src/test/java/jcifs/internal/smb2/create/LeaseV1CreateContextRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * © 2017 AgNO3 Gmbh & Co. KG
+ * © 2025 CodeLibs, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/jcifs/internal/smb2/lease/LeaseManagerTest.java
+++ b/src/test/java/jcifs/internal/smb2/lease/LeaseManagerTest.java
@@ -1,0 +1,240 @@
+/*
+ * © 2017 AgNO3 Gmbh & Co. KG
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package jcifs.internal.smb2.lease;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import jcifs.CIFSContext;
+import jcifs.internal.smb2.lease.LeaseManager.LeaseEntry;
+
+@DisplayName("LeaseManager Tests")
+class LeaseManagerTest {
+
+    private LeaseManager leaseManager;
+    private CIFSContext mockContext;
+
+    @BeforeEach
+    void setUp() {
+        mockContext = mock(CIFSContext.class);
+        leaseManager = new LeaseManager(mockContext);
+    }
+
+    @Test
+    @DisplayName("Should request new lease")
+    void testRequestLease() {
+        String path = "/share/file.txt";
+        int requestedState = Smb2LeaseState.SMB2_LEASE_FULL;
+
+        Smb2LeaseKey key = leaseManager.requestLease(path, requestedState);
+
+        assertNotNull(key);
+        LeaseEntry entry = leaseManager.getLease(key);
+        assertNotNull(entry);
+        assertEquals(requestedState, entry.getLeaseState());
+        assertEquals(path, entry.getPath());
+        assertEquals(1, entry.getEpoch());
+        assertFalse(entry.isBreaking());
+    }
+
+    @Test
+    @DisplayName("Should reuse existing lease for same path")
+    void testReuseExistingLease() {
+        String path = "/share/file.txt";
+        int requestedState = Smb2LeaseState.SMB2_LEASE_READ_WRITE;
+
+        Smb2LeaseKey key1 = leaseManager.requestLease(path, requestedState);
+        Smb2LeaseKey key2 = leaseManager.requestLease(path, requestedState);
+
+        assertEquals(key1, key2);
+    }
+
+    @Test
+    @DisplayName("Should update lease state")
+    void testUpdateLease() {
+        String path = "/share/file.txt";
+        int requestedState = Smb2LeaseState.SMB2_LEASE_FULL;
+        int grantedState = Smb2LeaseState.SMB2_LEASE_READ_WRITE;
+
+        Smb2LeaseKey key = leaseManager.requestLease(path, requestedState);
+        leaseManager.updateLease(key, grantedState);
+
+        LeaseEntry entry = leaseManager.getLease(key);
+        assertEquals(grantedState, entry.getLeaseState());
+    }
+
+    @Test
+    @DisplayName("Should handle lease break")
+    void testHandleLeaseBreak() {
+        String path = "/share/file.txt";
+        int initialState = Smb2LeaseState.SMB2_LEASE_FULL;
+        int newState = Smb2LeaseState.SMB2_LEASE_READ_CACHING;
+
+        Smb2LeaseKey key = leaseManager.requestLease(path, initialState);
+        leaseManager.updateLease(key, initialState);
+
+        int initialEpoch = leaseManager.getLease(key).getEpoch();
+        leaseManager.handleLeaseBreak(key, newState);
+
+        LeaseEntry entry = leaseManager.getLease(key);
+        assertEquals(newState, entry.getLeaseState());
+        assertEquals(initialEpoch + 1, entry.getEpoch());
+        assertFalse(entry.isBreaking()); // Should be false after break handling completes
+    }
+
+    @Test
+    @DisplayName("Should release lease")
+    void testReleaseLease() {
+        String path = "/share/file.txt";
+        int requestedState = Smb2LeaseState.SMB2_LEASE_READ_HANDLE;
+
+        Smb2LeaseKey key = leaseManager.requestLease(path, requestedState);
+        assertNotNull(leaseManager.getLease(key));
+
+        leaseManager.releaseLease(key);
+
+        assertNull(leaseManager.getLease(key));
+        assertNull(leaseManager.getLeaseByPath(path));
+    }
+
+    @Test
+    @DisplayName("Should get lease by path")
+    void testGetLeaseByPath() {
+        String path = "/share/document.doc";
+        int requestedState = Smb2LeaseState.SMB2_LEASE_READ_CACHING;
+
+        Smb2LeaseKey key = leaseManager.requestLease(path, requestedState);
+        LeaseEntry entryByKey = leaseManager.getLease(key);
+        LeaseEntry entryByPath = leaseManager.getLeaseByPath(path);
+
+        assertEquals(entryByKey, entryByPath);
+        assertEquals(path, entryByPath.getPath());
+    }
+
+    @Test
+    @DisplayName("Should release all leases")
+    void testReleaseAll() {
+        String path1 = "/share/file1.txt";
+        String path2 = "/share/file2.txt";
+
+        Smb2LeaseKey key1 = leaseManager.requestLease(path1, Smb2LeaseState.SMB2_LEASE_READ_CACHING);
+        Smb2LeaseKey key2 = leaseManager.requestLease(path2, Smb2LeaseState.SMB2_LEASE_WRITE_CACHING);
+
+        assertNotNull(leaseManager.getLease(key1));
+        assertNotNull(leaseManager.getLease(key2));
+
+        leaseManager.releaseAll();
+
+        assertNull(leaseManager.getLease(key1));
+        assertNull(leaseManager.getLease(key2));
+        assertTrue(leaseManager.getAllLeases().isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should clean up expired leases")
+    void testCleanupExpiredLeases() throws InterruptedException {
+        String path = "/share/expired.txt";
+        int requestedState = Smb2LeaseState.SMB2_LEASE_READ_CACHING;
+
+        Smb2LeaseKey key = leaseManager.requestLease(path, requestedState);
+        assertNotNull(leaseManager.getLease(key));
+
+        // Wait a bit and then cleanup with a very short expiration time
+        Thread.sleep(10);
+        int cleaned = leaseManager.cleanupExpiredLeases(1); // 1ms expiration
+
+        assertEquals(1, cleaned);
+        assertNull(leaseManager.getLease(key));
+    }
+
+    @Test
+    @DisplayName("Should not clean up recent leases")
+    void testCleanupRecentLeases() {
+        String path = "/share/recent.txt";
+        int requestedState = Smb2LeaseState.SMB2_LEASE_READ_CACHING;
+
+        Smb2LeaseKey key = leaseManager.requestLease(path, requestedState);
+        assertNotNull(leaseManager.getLease(key));
+
+        int cleaned = leaseManager.cleanupExpiredLeases(60000); // 1 minute expiration
+
+        assertEquals(0, cleaned);
+        assertNotNull(leaseManager.getLease(key));
+    }
+
+    @Test
+    @DisplayName("Should detect lease capabilities")
+    void testLeaseCapabilities() {
+        String path = "/share/file.txt";
+
+        // Test full lease
+        Smb2LeaseKey fullKey = leaseManager.requestLease(path + "1", Smb2LeaseState.SMB2_LEASE_FULL);
+        leaseManager.updateLease(fullKey, Smb2LeaseState.SMB2_LEASE_FULL);
+        LeaseEntry fullEntry = leaseManager.getLease(fullKey);
+
+        assertTrue(fullEntry.hasReadCache());
+        assertTrue(fullEntry.hasWriteCache());
+        assertTrue(fullEntry.hasHandleCache());
+
+        // Test read-only lease
+        Smb2LeaseKey readKey = leaseManager.requestLease(path + "2", Smb2LeaseState.SMB2_LEASE_READ_CACHING);
+        leaseManager.updateLease(readKey, Smb2LeaseState.SMB2_LEASE_READ_CACHING);
+        LeaseEntry readEntry = leaseManager.getLease(readKey);
+
+        assertTrue(readEntry.hasReadCache());
+        assertFalse(readEntry.hasWriteCache());
+        assertFalse(readEntry.hasHandleCache());
+
+        // Test no lease
+        Smb2LeaseKey noneKey = leaseManager.requestLease(path + "3", Smb2LeaseState.SMB2_LEASE_NONE);
+        leaseManager.updateLease(noneKey, Smb2LeaseState.SMB2_LEASE_NONE);
+        LeaseEntry noneEntry = leaseManager.getLease(noneKey);
+
+        assertFalse(noneEntry.hasReadCache());
+        assertFalse(noneEntry.hasWriteCache());
+        assertFalse(noneEntry.hasHandleCache());
+    }
+
+    @Test
+    @DisplayName("Should handle lease break with timeout")
+    void testHandleLeaseBreakWithTimeout() {
+        String path = "/share/timeout.txt";
+        int initialState = Smb2LeaseState.SMB2_LEASE_FULL;
+        int newState = Smb2LeaseState.SMB2_LEASE_READ_CACHING;
+
+        Smb2LeaseKey key = leaseManager.requestLease(path, initialState);
+        leaseManager.updateLease(key, initialState);
+
+        leaseManager.handleLeaseBreakWithTimeout(key, newState, 1);
+
+        LeaseEntry entry = leaseManager.getLease(key);
+        if (entry != null) {
+            // If entry still exists, it should have the new state
+            assertEquals(newState, entry.getLeaseState());
+        }
+        // If entry doesn't exist, it was cleaned up due to timeout
+    }
+}

--- a/src/test/java/jcifs/internal/smb2/lease/LeaseManagerTest.java
+++ b/src/test/java/jcifs/internal/smb2/lease/LeaseManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * © 2017 AgNO3 Gmbh & Co. KG
+ * © 2025 CodeLibs, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/jcifs/internal/smb2/lease/Smb2LeaseKeyTest.java
+++ b/src/test/java/jcifs/internal/smb2/lease/Smb2LeaseKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * © 2017 AgNO3 Gmbh & Co. KG
+ * © 2025 CodeLibs, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/jcifs/internal/smb2/lease/Smb2LeaseKeyTest.java
+++ b/src/test/java/jcifs/internal/smb2/lease/Smb2LeaseKeyTest.java
@@ -1,0 +1,167 @@
+/*
+ * © 2017 AgNO3 Gmbh & Co. KG
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package jcifs.internal.smb2.lease;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Smb2LeaseKey Tests")
+class Smb2LeaseKeyTest {
+
+    @Test
+    @DisplayName("Should generate random lease key with correct size")
+    void testRandomLeaseKeyGeneration() {
+        Smb2LeaseKey key = new Smb2LeaseKey();
+
+        assertNotNull(key.getKey());
+        assertEquals(16, key.getKey().length);
+        assertFalse(key.isZero());
+    }
+
+    @Test
+    @DisplayName("Should create lease key from byte array")
+    void testLeaseKeyFromBytes() {
+        byte[] testBytes = new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10 };
+
+        Smb2LeaseKey key = new Smb2LeaseKey(testBytes);
+
+        assertArrayEquals(testBytes, key.getKey());
+        assertFalse(key.isZero());
+    }
+
+    @Test
+    @DisplayName("Should create zero lease key")
+    void testZeroLeaseKey() {
+        byte[] zeroBytes = new byte[16];
+        Arrays.fill(zeroBytes, (byte) 0);
+
+        Smb2LeaseKey key = new Smb2LeaseKey(zeroBytes);
+
+        assertTrue(key.isZero());
+        assertArrayEquals(zeroBytes, key.getKey());
+    }
+
+    @Test
+    @DisplayName("Should reject null key")
+    void testNullKey() {
+        assertThrows(IllegalArgumentException.class, () -> new Smb2LeaseKey(null));
+    }
+
+    @Test
+    @DisplayName("Should reject wrong size key")
+    void testWrongSizeKey() {
+        assertThrows(IllegalArgumentException.class, () -> new Smb2LeaseKey(new byte[15]));
+        assertThrows(IllegalArgumentException.class, () -> new Smb2LeaseKey(new byte[17]));
+        assertThrows(IllegalArgumentException.class, () -> new Smb2LeaseKey(new byte[0]));
+    }
+
+    @Test
+    @DisplayName("Should encode lease key to buffer")
+    void testEncode() {
+        byte[] testBytes = new byte[] { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, (byte) 0x88, (byte) 0x99, (byte) 0xAA, (byte) 0xBB,
+                (byte) 0xCC, (byte) 0xDD, (byte) 0xEE, (byte) 0xFF, 0x00 };
+
+        Smb2LeaseKey key = new Smb2LeaseKey(testBytes);
+        byte[] buffer = new byte[20];
+
+        key.encode(buffer, 2);
+
+        for (int i = 0; i < 16; i++) {
+            assertEquals(testBytes[i], buffer[i + 2]);
+        }
+    }
+
+    @Test
+    @DisplayName("Should implement equals correctly")
+    void testEquals() {
+        byte[] testBytes1 = new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10 };
+        byte[] testBytes2 = Arrays.copyOf(testBytes1, 16);
+        byte[] testBytes3 = new byte[] { 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20 };
+
+        Smb2LeaseKey key1 = new Smb2LeaseKey(testBytes1);
+        Smb2LeaseKey key2 = new Smb2LeaseKey(testBytes2);
+        Smb2LeaseKey key3 = new Smb2LeaseKey(testBytes3);
+
+        assertEquals(key1, key2);
+        assertNotEquals(key1, key3);
+        assertNotEquals(key1, null);
+        assertNotEquals(key1, "not a lease key");
+        assertEquals(key1, key1); // reflexive
+    }
+
+    @Test
+    @DisplayName("Should implement hashCode correctly")
+    void testHashCode() {
+        byte[] testBytes1 = new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10 };
+        byte[] testBytes2 = Arrays.copyOf(testBytes1, 16);
+
+        Smb2LeaseKey key1 = new Smb2LeaseKey(testBytes1);
+        Smb2LeaseKey key2 = new Smb2LeaseKey(testBytes2);
+
+        assertEquals(key1.hashCode(), key2.hashCode());
+    }
+
+    @Test
+    @DisplayName("Should generate different random keys")
+    void testRandomKeyUniqueness() {
+        Smb2LeaseKey key1 = new Smb2LeaseKey();
+        Smb2LeaseKey key2 = new Smb2LeaseKey();
+
+        assertNotEquals(key1, key2);
+        assertFalse(Arrays.equals(key1.getKey(), key2.getKey()));
+    }
+
+    @Test
+    @DisplayName("Should return defensive copy of key")
+    void testDefensiveCopy() {
+        byte[] originalBytes =
+                new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10 };
+
+        Smb2LeaseKey key = new Smb2LeaseKey(originalBytes);
+        byte[] retrievedKey = key.getKey();
+
+        // Modify the retrieved key
+        retrievedKey[0] = (byte) 0xFF;
+
+        // Original key should remain unchanged
+        assertEquals(0x01, key.getKey()[0]);
+    }
+
+    @Test
+    @DisplayName("Should create readable string representation")
+    void testToString() {
+        byte[] testBytes = new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F };
+
+        Smb2LeaseKey key = new Smb2LeaseKey(testBytes);
+        String str = key.toString();
+
+        assertTrue(str.startsWith("LeaseKey["));
+        assertTrue(str.endsWith("]"));
+        assertTrue(str.contains("00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F"));
+    }
+}

--- a/src/test/java/jcifs/internal/smb2/lease/Smb2LeaseStateTest.java
+++ b/src/test/java/jcifs/internal/smb2/lease/Smb2LeaseStateTest.java
@@ -1,5 +1,5 @@
 /*
- * © 2017 AgNO3 Gmbh & Co. KG
+ * © 2025 CodeLibs, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/jcifs/internal/smb2/lease/Smb2LeaseStateTest.java
+++ b/src/test/java/jcifs/internal/smb2/lease/Smb2LeaseStateTest.java
@@ -1,0 +1,112 @@
+/*
+ * © 2017 AgNO3 Gmbh & Co. KG
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package jcifs.internal.smb2.lease;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Smb2LeaseState Tests")
+class Smb2LeaseStateTest {
+
+    @Test
+    @DisplayName("Should define correct lease state constants")
+    void testLeaseStateConstants() {
+        assertEquals(0x00, Smb2LeaseState.SMB2_LEASE_NONE);
+        assertEquals(0x01, Smb2LeaseState.SMB2_LEASE_READ_CACHING);
+        assertEquals(0x02, Smb2LeaseState.SMB2_LEASE_HANDLE_CACHING);
+        assertEquals(0x04, Smb2LeaseState.SMB2_LEASE_WRITE_CACHING);
+        assertEquals(0x03, Smb2LeaseState.SMB2_LEASE_READ_HANDLE);
+        assertEquals(0x05, Smb2LeaseState.SMB2_LEASE_READ_WRITE);
+        assertEquals(0x07, Smb2LeaseState.SMB2_LEASE_FULL);
+    }
+
+    @Test
+    @DisplayName("Should detect read caching correctly")
+    void testHasReadCaching() {
+        assertTrue(Smb2LeaseState.hasReadCaching(Smb2LeaseState.SMB2_LEASE_READ_CACHING));
+        assertTrue(Smb2LeaseState.hasReadCaching(Smb2LeaseState.SMB2_LEASE_READ_HANDLE));
+        assertTrue(Smb2LeaseState.hasReadCaching(Smb2LeaseState.SMB2_LEASE_READ_WRITE));
+        assertTrue(Smb2LeaseState.hasReadCaching(Smb2LeaseState.SMB2_LEASE_FULL));
+
+        assertFalse(Smb2LeaseState.hasReadCaching(Smb2LeaseState.SMB2_LEASE_NONE));
+        assertFalse(Smb2LeaseState.hasReadCaching(Smb2LeaseState.SMB2_LEASE_HANDLE_CACHING));
+        assertFalse(Smb2LeaseState.hasReadCaching(Smb2LeaseState.SMB2_LEASE_WRITE_CACHING));
+    }
+
+    @Test
+    @DisplayName("Should detect handle caching correctly")
+    void testHasHandleCaching() {
+        assertTrue(Smb2LeaseState.hasHandleCaching(Smb2LeaseState.SMB2_LEASE_HANDLE_CACHING));
+        assertTrue(Smb2LeaseState.hasHandleCaching(Smb2LeaseState.SMB2_LEASE_READ_HANDLE));
+        assertTrue(Smb2LeaseState.hasHandleCaching(Smb2LeaseState.SMB2_LEASE_FULL));
+
+        assertFalse(Smb2LeaseState.hasHandleCaching(Smb2LeaseState.SMB2_LEASE_NONE));
+        assertFalse(Smb2LeaseState.hasHandleCaching(Smb2LeaseState.SMB2_LEASE_READ_CACHING));
+        assertFalse(Smb2LeaseState.hasHandleCaching(Smb2LeaseState.SMB2_LEASE_WRITE_CACHING));
+        assertFalse(Smb2LeaseState.hasHandleCaching(Smb2LeaseState.SMB2_LEASE_READ_WRITE));
+    }
+
+    @Test
+    @DisplayName("Should detect write caching correctly")
+    void testHasWriteCaching() {
+        assertTrue(Smb2LeaseState.hasWriteCaching(Smb2LeaseState.SMB2_LEASE_WRITE_CACHING));
+        assertTrue(Smb2LeaseState.hasWriteCaching(Smb2LeaseState.SMB2_LEASE_READ_WRITE));
+        assertTrue(Smb2LeaseState.hasWriteCaching(Smb2LeaseState.SMB2_LEASE_FULL));
+
+        assertFalse(Smb2LeaseState.hasWriteCaching(Smb2LeaseState.SMB2_LEASE_NONE));
+        assertFalse(Smb2LeaseState.hasWriteCaching(Smb2LeaseState.SMB2_LEASE_READ_CACHING));
+        assertFalse(Smb2LeaseState.hasWriteCaching(Smb2LeaseState.SMB2_LEASE_HANDLE_CACHING));
+        assertFalse(Smb2LeaseState.hasWriteCaching(Smb2LeaseState.SMB2_LEASE_READ_HANDLE));
+    }
+
+    @Test
+    @DisplayName("Should combine lease states correctly")
+    void testLeaseStateCombinations() {
+        int readAndWrite = Smb2LeaseState.SMB2_LEASE_READ_CACHING | Smb2LeaseState.SMB2_LEASE_WRITE_CACHING;
+        assertEquals(Smb2LeaseState.SMB2_LEASE_READ_WRITE, readAndWrite);
+
+        int readAndHandle = Smb2LeaseState.SMB2_LEASE_READ_CACHING | Smb2LeaseState.SMB2_LEASE_HANDLE_CACHING;
+        assertEquals(Smb2LeaseState.SMB2_LEASE_READ_HANDLE, readAndHandle);
+
+        int fullLease =
+                Smb2LeaseState.SMB2_LEASE_READ_CACHING | Smb2LeaseState.SMB2_LEASE_WRITE_CACHING | Smb2LeaseState.SMB2_LEASE_HANDLE_CACHING;
+        assertEquals(Smb2LeaseState.SMB2_LEASE_FULL, fullLease);
+    }
+
+    @Test
+    @DisplayName("Should handle custom state combinations")
+    void testCustomStateCombinations() {
+        int customState = 0x06; // Write + Handle but no Read
+
+        assertFalse(Smb2LeaseState.hasReadCaching(customState));
+        assertTrue(Smb2LeaseState.hasWriteCaching(customState));
+        assertTrue(Smb2LeaseState.hasHandleCaching(customState));
+    }
+
+    @Test
+    @DisplayName("Should handle zero state")
+    void testZeroState() {
+        assertFalse(Smb2LeaseState.hasReadCaching(0));
+        assertFalse(Smb2LeaseState.hasWriteCaching(0));
+        assertFalse(Smb2LeaseState.hasHandleCaching(0));
+    }
+}


### PR DESCRIPTION
This PR introduces support for SMB2/SMB3 leases, improving client-side caching and consistency handling.
