### PR TITLE
Improve Javadocs and documentation for SMB2/SMB3 directory leasing and handle management

### DIFF
--- a/src/main/java/jcifs/config/BaseConfiguration.java
+++ b/src/main/java/jcifs/config/BaseConfiguration.java
@@ -244,17 +244,47 @@ public class BaseConfiguration implements Configuration {
     protected String handleStateDirectory;
 
     // Directory leasing configuration fields
+    /**
+     * Whether to use directory leasing for cached directory listings
+     */
     protected boolean useDirectoryLeasing = true;
+    /**
+     * The scope of directory caching: ALL (entire subtree) or IMMEDIATE_CHILDREN (direct children only)
+     */
     protected String directoryCacheScope = "IMMEDIATE_CHILDREN";
+    /**
+     * Directory cache timeout in milliseconds
+     */
     protected long directoryCacheTimeout = 30000L;
+    /**
+     * Whether directory change notifications are enabled for cache invalidation
+     */
     protected boolean directoryNotificationsEnabled = true;
+    /**
+     * Maximum number of cached directory entries
+     */
     protected int maxDirectoryCacheEntries = 1000;
 
     // Multi-channel configuration fields
+    /**
+     * Whether to use SMB3 multi-channel support for improved performance and redundancy
+     */
     protected boolean useMultiChannel;
+    /**
+     * Maximum number of SMB3 channels to establish per session
+     */
     protected int maxChannels;
+    /**
+     * Channel binding policy: -1=not set, 0=disabled, 1=preferred, 2=required
+     */
     protected int channelBindingPolicy = -1; // -1=not set, 0=disabled, 1=preferred, 2=required
+    /**
+     * Load balancing strategy for distributing operations across channels
+     */
     protected String loadBalancingStrategy;
+    /**
+     * Interval in milliseconds for checking channel health
+     */
     protected int channelHealthCheckInterval;
 
     /**

--- a/src/main/java/jcifs/config/PropertyConfiguration.java
+++ b/src/main/java/jcifs/config/PropertyConfiguration.java
@@ -37,8 +37,8 @@ public final class PropertyConfiguration extends BaseConfiguration implements Co
     /**
      * Create a configuration backed by properties
      *
-     * @param props
-     * @throws CIFSException
+     * @param props properties object containing JCIFS configuration settings
+     * @throws CIFSException if configuration initialization fails
      */
     public PropertyConfiguration(Properties props) throws CIFSException {
         super(false);

--- a/src/main/java/jcifs/internal/smb2/create/LeaseV1CreateContextRequest.java
+++ b/src/main/java/jcifs/internal/smb2/create/LeaseV1CreateContextRequest.java
@@ -65,6 +65,7 @@ public class LeaseV1CreateContextRequest implements CreateContextRequest {
     }
 
     /**
+     * Gets the lease key for this lease request
      * @return the lease key
      */
     public Smb2LeaseKey getLeaseKey() {
@@ -72,6 +73,7 @@ public class LeaseV1CreateContextRequest implements CreateContextRequest {
     }
 
     /**
+     * Sets the lease key for this lease request
      * @param leaseKey the lease key to set
      */
     public void setLeaseKey(Smb2LeaseKey leaseKey) {
@@ -79,6 +81,7 @@ public class LeaseV1CreateContextRequest implements CreateContextRequest {
     }
 
     /**
+     * Gets the requested lease state flags
      * @return the requested lease state
      */
     public int getLeaseState() {
@@ -86,6 +89,7 @@ public class LeaseV1CreateContextRequest implements CreateContextRequest {
     }
 
     /**
+     * Sets the requested lease state flags
      * @param leaseState the lease state to set
      */
     public void setLeaseState(int leaseState) {
@@ -93,6 +97,7 @@ public class LeaseV1CreateContextRequest implements CreateContextRequest {
     }
 
     /**
+     * Gets the lease flags for this request
      * @return the lease flags
      */
     public int getLeaseFlags() {
@@ -100,6 +105,7 @@ public class LeaseV1CreateContextRequest implements CreateContextRequest {
     }
 
     /**
+     * Sets the lease flags for this request
      * @param leaseFlags the lease flags to set
      */
     public void setLeaseFlags(int leaseFlags) {

--- a/src/main/java/jcifs/internal/smb2/create/LeaseV1CreateContextResponse.java
+++ b/src/main/java/jcifs/internal/smb2/create/LeaseV1CreateContextResponse.java
@@ -51,6 +51,7 @@ public class LeaseV1CreateContextResponse implements CreateContextResponse {
     }
 
     /**
+     * Gets the lease key from the server response
      * @return the lease key
      */
     public Smb2LeaseKey getLeaseKey() {
@@ -58,6 +59,7 @@ public class LeaseV1CreateContextResponse implements CreateContextResponse {
     }
 
     /**
+     * Gets the lease state granted by the server
      * @return the granted lease state
      */
     public int getLeaseState() {
@@ -65,6 +67,7 @@ public class LeaseV1CreateContextResponse implements CreateContextResponse {
     }
 
     /**
+     * Gets the lease flags from the server response
      * @return the lease flags
      */
     public int getLeaseFlags() {

--- a/src/main/java/jcifs/internal/smb2/create/LeaseV2CreateContextRequest.java
+++ b/src/main/java/jcifs/internal/smb2/create/LeaseV2CreateContextRequest.java
@@ -73,6 +73,7 @@ public class LeaseV2CreateContextRequest implements CreateContextRequest {
     }
 
     /**
+     * Gets the lease key for this V2 lease request
      * @return the lease key
      */
     public Smb2LeaseKey getLeaseKey() {
@@ -80,6 +81,7 @@ public class LeaseV2CreateContextRequest implements CreateContextRequest {
     }
 
     /**
+     * Sets the lease key for this V2 lease request
      * @param leaseKey the lease key to set
      */
     public void setLeaseKey(Smb2LeaseKey leaseKey) {
@@ -87,6 +89,7 @@ public class LeaseV2CreateContextRequest implements CreateContextRequest {
     }
 
     /**
+     * Gets the requested lease state flags for V2
      * @return the requested lease state
      */
     public int getLeaseState() {
@@ -94,6 +97,7 @@ public class LeaseV2CreateContextRequest implements CreateContextRequest {
     }
 
     /**
+     * Sets the requested lease state flags for V2
      * @param leaseState the lease state to set
      */
     public void setLeaseState(int leaseState) {
@@ -101,6 +105,7 @@ public class LeaseV2CreateContextRequest implements CreateContextRequest {
     }
 
     /**
+     * Gets the lease flags for this V2 request
      * @return the lease flags
      */
     public int getLeaseFlags() {
@@ -108,6 +113,7 @@ public class LeaseV2CreateContextRequest implements CreateContextRequest {
     }
 
     /**
+     * Sets the lease flags for this V2 request
      * @param leaseFlags the lease flags to set
      */
     public void setLeaseFlags(int leaseFlags) {
@@ -115,6 +121,7 @@ public class LeaseV2CreateContextRequest implements CreateContextRequest {
     }
 
     /**
+     * Gets the parent lease key for directory hierarchies
      * @return the parent lease key
      */
     public Smb2LeaseKey getParentLeaseKey() {
@@ -122,6 +129,7 @@ public class LeaseV2CreateContextRequest implements CreateContextRequest {
     }
 
     /**
+     * Sets the parent lease key for directory hierarchies
      * @param parentLeaseKey the parent lease key to set
      */
     public void setParentLeaseKey(Smb2LeaseKey parentLeaseKey) {
@@ -129,6 +137,7 @@ public class LeaseV2CreateContextRequest implements CreateContextRequest {
     }
 
     /**
+     * Gets the lease epoch for V2 lease versioning
      * @return the epoch
      */
     public int getEpoch() {
@@ -136,6 +145,7 @@ public class LeaseV2CreateContextRequest implements CreateContextRequest {
     }
 
     /**
+     * Sets the lease epoch for V2 lease versioning
      * @param epoch the epoch to set
      */
     public void setEpoch(int epoch) {

--- a/src/main/java/jcifs/internal/smb2/create/LeaseV2CreateContextResponse.java
+++ b/src/main/java/jcifs/internal/smb2/create/LeaseV2CreateContextResponse.java
@@ -53,6 +53,7 @@ public class LeaseV2CreateContextResponse implements CreateContextResponse {
     }
 
     /**
+     * Gets the lease key from the V2 server response
      * @return the lease key
      */
     public Smb2LeaseKey getLeaseKey() {
@@ -60,6 +61,7 @@ public class LeaseV2CreateContextResponse implements CreateContextResponse {
     }
 
     /**
+     * Gets the lease state granted by the server for V2
      * @return the granted lease state
      */
     public int getLeaseState() {
@@ -67,6 +69,7 @@ public class LeaseV2CreateContextResponse implements CreateContextResponse {
     }
 
     /**
+     * Gets the lease flags from the V2 server response
      * @return the lease flags
      */
     public int getLeaseFlags() {
@@ -74,6 +77,7 @@ public class LeaseV2CreateContextResponse implements CreateContextResponse {
     }
 
     /**
+     * Gets the parent lease key from the V2 response
      * @return the parent lease key
      */
     public Smb2LeaseKey getParentLeaseKey() {
@@ -81,6 +85,7 @@ public class LeaseV2CreateContextResponse implements CreateContextResponse {
     }
 
     /**
+     * Gets the lease epoch from the V2 response
      * @return the epoch
      */
     public int getEpoch() {

--- a/src/main/java/jcifs/internal/smb2/create/Smb2CreateRequest.java
+++ b/src/main/java/jcifs/internal/smb2/create/Smb2CreateRequest.java
@@ -513,7 +513,7 @@ public class Smb2CreateRequest extends ServerMessageBlock2Request<Smb2CreateResp
 
     /**
      * Add a durable handle V2 context to this request
-     * @param timeout the timeout in milliseconds (0 for persistent handles)
+     * @param timeoutMs the timeout in milliseconds (0 for persistent handles)
      * @param persistent true if this should be a persistent handle
      * @return the create GUID for this handle
      */
@@ -526,7 +526,7 @@ public class Smb2CreateRequest extends ServerMessageBlock2Request<Smb2CreateResp
 
     /**
      * Add a durable handle V2 context with specific GUID
-     * @param timeout the timeout in milliseconds
+     * @param timeoutMs the timeout in milliseconds
      * @param persistent true if this should be a persistent handle
      * @param createGuid the create GUID to use
      */

--- a/src/main/java/jcifs/internal/smb2/lease/DirectoryCacheEntry.java
+++ b/src/main/java/jcifs/internal/smb2/lease/DirectoryCacheEntry.java
@@ -114,6 +114,7 @@ public class DirectoryCacheEntry {
         }
 
         /**
+         * Gets the name of this cached file or directory
          * @return the file name
          */
         public String getName() {
@@ -121,6 +122,7 @@ public class DirectoryCacheEntry {
         }
 
         /**
+         * Gets the size of this cached file in bytes
          * @return the file size
          */
         public long getSize() {
@@ -128,6 +130,7 @@ public class DirectoryCacheEntry {
         }
 
         /**
+         * Gets the last modification timestamp of this cached item
          * @return the last modified time
          */
         public long getLastModified() {
@@ -135,6 +138,7 @@ public class DirectoryCacheEntry {
         }
 
         /**
+         * Checks if this cached item represents a directory
          * @return true if this is a directory
          */
         public boolean isDirectory() {
@@ -142,6 +146,7 @@ public class DirectoryCacheEntry {
         }
 
         /**
+         * Gets the SMB file attributes for this cached item
          * @return the file attributes
          */
         public long getAttributes() {
@@ -149,6 +154,7 @@ public class DirectoryCacheEntry {
         }
 
         /**
+         * Gets the creation timestamp of this cached item
          * @return the creation time
          */
         public long getCreationTime() {
@@ -156,6 +162,7 @@ public class DirectoryCacheEntry {
         }
 
         /**
+         * Gets the last access timestamp of this cached item
          * @return the last access time
          */
         public long getLastAccessTime() {
@@ -302,6 +309,7 @@ public class DirectoryCacheEntry {
     }
 
     /**
+     * Gets the directory path for this cache entry
      * @return the directory path
      */
     public String getDirectoryPath() {
@@ -309,6 +317,7 @@ public class DirectoryCacheEntry {
     }
 
     /**
+     * Gets the lease key associated with this directory cache
      * @return the lease key
      */
     public Smb2LeaseKey getLeaseKey() {
@@ -316,6 +325,7 @@ public class DirectoryCacheEntry {
     }
 
     /**
+     * Checks if the complete directory enumeration has been cached
      * @return true if full enumeration is cached
      */
     public boolean isComplete() {
@@ -323,6 +333,7 @@ public class DirectoryCacheEntry {
     }
 
     /**
+     * Gets the cache scope (ALL or IMMEDIATE_CHILDREN)
      * @return the cache scope
      */
     public DirectoryCacheScope getScope() {
@@ -330,6 +341,7 @@ public class DirectoryCacheEntry {
     }
 
     /**
+     * Sets the cache scope for this directory cache
      * @param scope the cache scope to set
      */
     public void setScope(DirectoryCacheScope scope) {
@@ -337,6 +349,7 @@ public class DirectoryCacheEntry {
     }
 
     /**
+     * Gets the maximum age for cached data before requiring refresh
      * @return the maximum cache age in milliseconds
      */
     public long getMaxAge() {
@@ -344,6 +357,7 @@ public class DirectoryCacheEntry {
     }
 
     /**
+     * Sets the maximum age for cached data
      * @param maxAge the maximum cache age in milliseconds
      */
     public void setMaxAge(long maxAge) {
@@ -351,6 +365,7 @@ public class DirectoryCacheEntry {
     }
 
     /**
+     * Gets the timestamp when this cache entry was created
      * @return the create time
      */
     public long getCreateTime() {
@@ -358,6 +373,7 @@ public class DirectoryCacheEntry {
     }
 
     /**
+     * Gets the timestamp of the last cache update
      * @return the last update time
      */
     public long getLastUpdateTime() {
@@ -365,6 +381,7 @@ public class DirectoryCacheEntry {
     }
 
     /**
+     * Gets the timestamp of the last cache access
      * @return the last access time
      */
     public long getLastAccessTime() {
@@ -372,6 +389,7 @@ public class DirectoryCacheEntry {
     }
 
     /**
+     * Checks if the cache has pending changes
      * @return true if cache has changes
      */
     public boolean hasChanges() {

--- a/src/main/java/jcifs/internal/smb2/lease/DirectoryChangeNotifier.java
+++ b/src/main/java/jcifs/internal/smb2/lease/DirectoryChangeNotifier.java
@@ -41,7 +41,26 @@ public class DirectoryChangeNotifier {
      * Directory change types
      */
     public enum DirectoryChangeType {
-        FILE_ADDED, FILE_REMOVED, FILE_MODIFIED, DIRECTORY_RENAMED, ATTRIBUTES_CHANGED
+        /**
+         * File was added to the directory
+         */
+        FILE_ADDED,
+        /**
+         * File was removed from the directory
+         */
+        FILE_REMOVED,
+        /**
+         * File was modified in the directory
+         */
+        FILE_MODIFIED,
+        /**
+         * Directory was renamed
+         */
+        DIRECTORY_RENAMED,
+        /**
+         * File or directory attributes were changed
+         */
+        ATTRIBUTES_CHANGED
     }
 
     /**
@@ -87,6 +106,7 @@ public class DirectoryChangeNotifier {
         }
 
         /**
+         * Gets the path of the directory being monitored
          * @return the directory path
          */
         public String getDirectoryPath() {
@@ -94,6 +114,7 @@ public class DirectoryChangeNotifier {
         }
 
         /**
+         * Gets the lease key associated with this notification handle
          * @return the lease key
          */
         public Smb2LeaseKey getLeaseKey() {
@@ -101,6 +122,7 @@ public class DirectoryChangeNotifier {
         }
 
         /**
+         * Gets the SMB file handle for the monitored directory
          * @return the directory file
          */
         public SmbFile getDirectoryFile() {
@@ -108,6 +130,7 @@ public class DirectoryChangeNotifier {
         }
 
         /**
+         * Checks if directory change monitoring is currently active
          * @return true if watching is active
          */
         public boolean isActive() {
@@ -124,6 +147,7 @@ public class DirectoryChangeNotifier {
         }
 
         /**
+         * Gets the future for asynchronous notification completion
          * @return the notification future
          */
         public CompletableFuture<Void> getNotificationFuture() {
@@ -131,6 +155,7 @@ public class DirectoryChangeNotifier {
         }
 
         /**
+         * Sets the future for asynchronous notification completion
          * @param future the notification future to set
          */
         public void setNotificationFuture(CompletableFuture<Void> future) {

--- a/src/main/java/jcifs/internal/smb2/lease/DirectoryLeaseContext.java
+++ b/src/main/java/jcifs/internal/smb2/lease/DirectoryLeaseContext.java
@@ -79,6 +79,7 @@ public class DirectoryLeaseContext implements CreateContextRequest {
     }
 
     /**
+     * Gets the lease key for this directory lease context
      * @return the lease key
      */
     public Smb2LeaseKey getLeaseKey() {
@@ -86,6 +87,7 @@ public class DirectoryLeaseContext implements CreateContextRequest {
     }
 
     /**
+     * Sets the lease key for this directory lease context
      * @param leaseKey the lease key to set
      */
     public void setLeaseKey(Smb2LeaseKey leaseKey) {
@@ -93,6 +95,7 @@ public class DirectoryLeaseContext implements CreateContextRequest {
     }
 
     /**
+     * Gets the current lease state flags for this directory
      * @return the lease state
      */
     public int getLeaseState() {
@@ -100,6 +103,7 @@ public class DirectoryLeaseContext implements CreateContextRequest {
     }
 
     /**
+     * Sets the lease state flags for this directory
      * @param leaseState the lease state to set
      */
     public void setLeaseState(int leaseState) {
@@ -107,6 +111,7 @@ public class DirectoryLeaseContext implements CreateContextRequest {
     }
 
     /**
+     * Gets the cache scope for directory enumeration caching
      * @return the cache scope
      */
     public DirectoryCacheScope getCacheScope() {
@@ -114,6 +119,7 @@ public class DirectoryLeaseContext implements CreateContextRequest {
     }
 
     /**
+     * Sets the cache scope for directory enumeration caching
      * @param cacheScope the cache scope to set
      */
     public void setCacheScope(DirectoryCacheScope cacheScope) {
@@ -121,6 +127,7 @@ public class DirectoryLeaseContext implements CreateContextRequest {
     }
 
     /**
+     * Gets the maximum age for cached directory data before requiring refresh
      * @return the maximum cache age in milliseconds
      */
     public long getMaxCacheAge() {
@@ -128,6 +135,7 @@ public class DirectoryLeaseContext implements CreateContextRequest {
     }
 
     /**
+     * Sets the maximum age for cached directory data
      * @param maxCacheAge the maximum cache age in milliseconds
      */
     public void setMaxCacheAge(long maxCacheAge) {
@@ -135,6 +143,7 @@ public class DirectoryLeaseContext implements CreateContextRequest {
     }
 
     /**
+     * Checks if directory change notifications are enabled for cache invalidation
      * @return true if change notifications are enabled
      */
     public boolean isNotificationEnabled() {
@@ -142,6 +151,7 @@ public class DirectoryLeaseContext implements CreateContextRequest {
     }
 
     /**
+     * Enables or disables directory change notifications
      * @param notificationEnabled true to enable change notifications
      */
     public void setNotificationEnabled(boolean notificationEnabled) {
@@ -149,6 +159,7 @@ public class DirectoryLeaseContext implements CreateContextRequest {
     }
 
     /**
+     * Gets the notification filter flags that specify which changes to monitor
      * @return the notification filter flags
      */
     public int getNotificationFilter() {
@@ -156,6 +167,7 @@ public class DirectoryLeaseContext implements CreateContextRequest {
     }
 
     /**
+     * Sets the notification filter flags that specify which changes to monitor
      * @param notificationFilter the notification filter flags
      */
     public void setNotificationFilter(int notificationFilter) {

--- a/src/main/java/jcifs/internal/smb2/lease/DirectoryLeaseState.java
+++ b/src/main/java/jcifs/internal/smb2/lease/DirectoryLeaseState.java
@@ -18,14 +18,20 @@
 package jcifs.internal.smb2.lease;
 
 /**
- * Directory-specific lease state definitions for SMB3 directory leasing
+ * Defines directory lease state constants for SMB2/SMB3 directory leasing.
  *
- * Standard lease states apply with directory-specific semantics:
- * - READ_CACHING: Can cache directory enumeration results, file existence queries, and basic file attributes
- * - HANDLE_CACHING: Can keep directory handle open and cache subdirectory handles
- * - WRITE_CACHING: Can cache file creation/deletion notifications and perform optimistic file operations
+ * This class provides constants and utility methods for managing directory lease states
+ * in SMB2/SMB3 protocol implementations. Directory leases enable clients to cache
+ * directory metadata and reduce network round-trips for directory operations.
  */
 public class DirectoryLeaseState {
+
+    /**
+     * Private constructor to prevent instantiation of this utility class
+     */
+    private DirectoryLeaseState() {
+        // Utility class - prevent instantiation
+    }
 
     /**
      * Directory Read and Handle caching (RH) - recommended for directory operations

--- a/src/main/java/jcifs/internal/smb2/lease/LeaseManager.java
+++ b/src/main/java/jcifs/internal/smb2/lease/LeaseManager.java
@@ -156,6 +156,7 @@ public class LeaseManager {
         }
 
         /**
+         * Gets the unique lease key identifier for this lease entry
          * @return the lease key
          */
         public Smb2LeaseKey getLeaseKey() {
@@ -163,6 +164,7 @@ public class LeaseManager {
         }
 
         /**
+         * Gets the current lease state flags for this entry
          * @return the current lease state
          */
         public int getLeaseState() {
@@ -170,6 +172,7 @@ public class LeaseManager {
         }
 
         /**
+         * Gets the current lease epoch value for versioning
          * @return the current epoch
          */
         public int getEpoch() {
@@ -177,6 +180,7 @@ public class LeaseManager {
         }
 
         /**
+         * Gets the file path associated with this lease
          * @return the file path
          */
         public String getPath() {
@@ -184,6 +188,7 @@ public class LeaseManager {
         }
 
         /**
+         * Checks if this lease is currently in a breaking state
          * @return true if lease is currently breaking
          */
         public boolean isBreaking() {
@@ -191,6 +196,7 @@ public class LeaseManager {
         }
 
         /**
+         * Sets the breaking state for this lease
          * @param breaking set breaking state
          */
         public void setBreaking(boolean breaking) {
@@ -198,6 +204,7 @@ public class LeaseManager {
         }
 
         /**
+         * Gets the timestamp of the last lease access
          * @return last access time in milliseconds
          */
         public long getLastAccessTime() {

--- a/src/main/java/jcifs/internal/smb2/lock/Smb2LeaseBreakAcknowledgment.java
+++ b/src/main/java/jcifs/internal/smb2/lock/Smb2LeaseBreakAcknowledgment.java
@@ -63,6 +63,7 @@ public class Smb2LeaseBreakAcknowledgment extends ServerMessageBlock2Request<Smb
     }
 
     /**
+     * Gets the lease key for this acknowledgment
      * @return the lease key
      */
     public Smb2LeaseKey getLeaseKey() {
@@ -70,6 +71,7 @@ public class Smb2LeaseBreakAcknowledgment extends ServerMessageBlock2Request<Smb
     }
 
     /**
+     * Gets the lease state being acknowledged
      * @return the lease state
      */
     public int getLeaseState() {
@@ -77,6 +79,7 @@ public class Smb2LeaseBreakAcknowledgment extends ServerMessageBlock2Request<Smb
     }
 
     /**
+     * Gets the lease flags for this acknowledgment
      * @return the lease flags
      */
     public int getLeaseFlags() {
@@ -84,6 +87,7 @@ public class Smb2LeaseBreakAcknowledgment extends ServerMessageBlock2Request<Smb
     }
 
     /**
+     * Sets the lease flags for this acknowledgment
      * @param flags the lease flags to set
      */
     public void setLeaseFlags(int flags) {

--- a/src/main/java/jcifs/internal/smb2/lock/Smb2LeaseBreakNotification.java
+++ b/src/main/java/jcifs/internal/smb2/lock/Smb2LeaseBreakNotification.java
@@ -49,6 +49,7 @@ public class Smb2LeaseBreakNotification extends ServerMessageBlock2Response {
     }
 
     /**
+     * Gets the lease key that is being broken
      * @return the lease key
      */
     public Smb2LeaseKey getLeaseKey() {
@@ -56,6 +57,7 @@ public class Smb2LeaseBreakNotification extends ServerMessageBlock2Response {
     }
 
     /**
+     * Gets the current lease state before the break
      * @return the current lease state
      */
     public int getCurrentLeaseState() {
@@ -63,6 +65,7 @@ public class Smb2LeaseBreakNotification extends ServerMessageBlock2Response {
     }
 
     /**
+     * Gets the new lease state after the break
      * @return the new lease state
      */
     public int getNewLeaseState() {
@@ -70,6 +73,7 @@ public class Smb2LeaseBreakNotification extends ServerMessageBlock2Response {
     }
 
     /**
+     * Gets the reason for the lease break
      * @return the break reason
      */
     public int getBreakReason() {
@@ -77,6 +81,7 @@ public class Smb2LeaseBreakNotification extends ServerMessageBlock2Response {
     }
 
     /**
+     * Gets the lease flags from the notification
      * @return the lease flags
      */
     public int getLeaseFlags() {
@@ -84,6 +89,7 @@ public class Smb2LeaseBreakNotification extends ServerMessageBlock2Response {
     }
 
     /**
+     * Gets the access mask hint for optimizing lease handling
      * @return the access mask hint
      */
     public int getAccessMaskHint() {
@@ -91,6 +97,7 @@ public class Smb2LeaseBreakNotification extends ServerMessageBlock2Response {
     }
 
     /**
+     * Gets the share access hint for optimizing lease handling
      * @return the share access hint
      */
     public int getShareAccessHint() {

--- a/src/main/java/jcifs/internal/smb2/lock/Smb2LeaseBreakResponse.java
+++ b/src/main/java/jcifs/internal/smb2/lock/Smb2LeaseBreakResponse.java
@@ -46,6 +46,7 @@ public class Smb2LeaseBreakResponse extends ServerMessageBlock2Response {
     }
 
     /**
+     * Gets the lease key from the break response
      * @return the lease key
      */
     public Smb2LeaseKey getLeaseKey() {
@@ -53,6 +54,7 @@ public class Smb2LeaseBreakResponse extends ServerMessageBlock2Response {
     }
 
     /**
+     * Gets the granted lease state from the break response
      * @return the lease state
      */
     public int getLeaseState() {
@@ -60,6 +62,7 @@ public class Smb2LeaseBreakResponse extends ServerMessageBlock2Response {
     }
 
     /**
+     * Gets the lease flags from the break response
      * @return the lease flags
      */
     public int getLeaseFlags() {
@@ -67,6 +70,7 @@ public class Smb2LeaseBreakResponse extends ServerMessageBlock2Response {
     }
 
     /**
+     * Gets the lease duration from the break response
      * @return the lease duration
      */
     public long getLeaseDuration() {

--- a/src/main/java/jcifs/internal/smb2/persistent/HandleGuid.java
+++ b/src/main/java/jcifs/internal/smb2/persistent/HandleGuid.java
@@ -29,6 +29,9 @@ public class HandleGuid implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * The underlying UUID representing this handle GUID
+     */
     private final UUID guid;
 
     /**

--- a/src/main/java/jcifs/internal/smb2/persistent/HandleInfo.java
+++ b/src/main/java/jcifs/internal/smb2/persistent/HandleInfo.java
@@ -27,14 +27,49 @@ public class HandleInfo implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * The full path to the file or directory associated with this handle
+     */
     private final String path;
+
+    /**
+     * The create GUID used to uniquely identify this handle for reconnection
+     */
     private final HandleGuid createGuid;
+
+    /**
+     * The 16-byte file ID returned by the server for this handle
+     */
     private final byte[] fileId;
+
+    /**
+     * The type of handle (DURABLE_V1, DURABLE_V2, or PERSISTENT)
+     */
     private final HandleType type;
+
+    /**
+     * The timeout in milliseconds for durable handles (not applicable for persistent handles)
+     */
     private final long timeout;
+
+    /**
+     * The timestamp when this handle was created
+     */
     private final long createTime;
+
+    /**
+     * The timestamp of the last access to this handle
+     */
     private volatile long lastAccessTime;
-    private final Smb2LeaseKey leaseKey; // Associated lease if any
+
+    /**
+     * The associated lease key if this handle has an SMB2 lease
+     */
+    private final Smb2LeaseKey leaseKey;
+
+    /**
+     * Flag indicating whether this handle is currently being reconnected
+     */
     private volatile boolean reconnecting;
 
     // Not serialized - will be null after deserialization

--- a/src/main/java/jcifs/internal/smb2/persistent/PersistentHandleManager.java
+++ b/src/main/java/jcifs/internal/smb2/persistent/PersistentHandleManager.java
@@ -336,6 +336,9 @@ public class PersistentHandleManager {
         }
     }
 
+    /**
+     * Shuts down the persistent handle manager and its background tasks
+     */
     public void shutdown() {
         shutdown = true;
         scheduler.shutdown();

--- a/src/main/java/jcifs/smb/SmbFileDirectoryLeasingExtension.java
+++ b/src/main/java/jcifs/smb/SmbFileDirectoryLeasingExtension.java
@@ -30,9 +30,20 @@ import jcifs.internal.smb2.lease.Smb2LeaseKey;
 import jcifs.internal.smb2.lease.Smb2LeaseState;
 
 /**
- * Extension methods for SmbFile to support directory leasing functionality
+ * Extension methods for SmbFile to support directory leasing functionality.
+ *
+ * This utility class provides static methods that enhance SmbFile operations with
+ * directory leasing capabilities for improved performance through caching when
+ * SMB3 directory leasing is available and enabled.
  */
 public class SmbFileDirectoryLeasingExtension {
+
+    /**
+     * Private constructor to prevent instantiation of this utility class
+     */
+    private SmbFileDirectoryLeasingExtension() {
+        // Utility class - prevent instantiation
+    }
 
     private static final Logger log = LoggerFactory.getLogger(SmbFileDirectoryLeasingExtension.class);
 


### PR DESCRIPTION
This PR enhances documentation across several JCIFS classes by adding detailed Javadoc comments for directory leasing, lease handling, and persistent handle management. The changes improve code readability, maintainability, and developer understanding of SMB2/SMB3 features.

Key changes:

- BaseConfiguration: Added detailed Javadocs for directory leasing and multi-channel configuration fields.
- PropertyConfiguration: Improved constructor documentation with parameter/exception details.
- Lease request/response classes (V1 & V2): Added method-level Javadocs clarifying lease key, state, and flag usage.
- Smb2CreateRequest: Corrected parameter naming in Javadocs (timeout → timeoutMs).
- DirectoryCacheEntry, DirectoryChangeNotifier, DirectoryLeaseContext, LeaseManager: Added Javadocs for getters/setters and clarified caching/notification behavior.
- DirectoryLeaseState & SmbFileDirectoryLeasingExtension: Converted into proper utility classes with private constructors and improved top-level documentation.
- HandleGuid, HandleInfo, PersistentHandleManager: Added detailed field and method-level documentation regarding persistent/durable handle behavior.
- Lease break classes: Added clear documentation for response/acknowledgment fields.

This update provides clearer developer-facing documentation without altering runtime behavior.