### PR TITLE
Add Javadoc documentation for RDMA and Witness protocol classes

### DIFF
--- a/src/main/java/jcifs/config/BaseConfiguration.java
+++ b/src/main/java/jcifs/config/BaseConfiguration.java
@@ -288,19 +288,58 @@ public class BaseConfiguration implements Configuration {
     protected int channelHealthCheckInterval;
 
     // RDMA configuration
+    /**
+     * Flag indicating whether RDMA transport should be used when available
+     */
     protected boolean useRDMA;
+    /**
+     * RDMA provider implementation to use (e.g. "disni" or "tcp")
+     */
     protected String rdmaProvider;
+    /**
+     * Minimum size in bytes for using RDMA read/write operations
+     */
     protected int rdmaReadWriteThreshold;
+    /**
+     * Maximum size in bytes for RDMA send operations
+     */
     protected int rdmaMaxSendSize;
+    /**
+     * Maximum size in bytes for RDMA receive operations
+     */
     protected int rdmaMaxReceiveSize;
+    /**
+     * Number of RDMA credits to request during negotiation
+     */
     protected int rdmaCredits;
+    /**
+     * Flag indicating whether RDMA is currently enabled and available
+     */
     protected boolean rdmaEnabled = false;
+    /**
+     * Port number for RDMA connections (default: 5445)
+     */
     protected int rdmaPort = 5445;
     // Witness protocol configuration fields
+    /**
+     * Flag indicating whether SMB Witness protocol should be used for failover
+     */
     protected boolean useWitness = false; // Disabled by default
+    /**
+     * Timeout in milliseconds for witness heartbeat messages
+     */
     protected long witnessHeartbeatTimeout = 120000; // 2 minutes
+    /**
+     * Timeout in milliseconds for witness registration
+     */
     protected long witnessRegistrationTimeout = 300000; // 5 minutes
+    /**
+     * Delay in milliseconds before attempting witness reconnection
+     */
     protected long witnessReconnectDelay = 1000; // 1 second
+    /**
+     * Flag indicating whether automatic witness service discovery is enabled
+     */
     protected boolean witnessServiceDiscovery = true;
 
     /**

--- a/src/main/java/jcifs/internal/smb2/nego/Smb2RdmaTransformCapabilitiesContext.java
+++ b/src/main/java/jcifs/internal/smb2/nego/Smb2RdmaTransformCapabilitiesContext.java
@@ -21,9 +21,16 @@ import jcifs.internal.SMBProtocolDecodingException;
 import jcifs.internal.smb2.Smb2Constants;
 import jcifs.internal.util.SMBUtil;
 
+/**
+ * SMB2 RDMA Transform Capabilities negotiate context.
+ *
+ * This context is used during SMB2 negotiation to indicate RDMA transform
+ * capabilities when SMB Direct is supported by the client and server.
+ */
 public class Smb2RdmaTransformCapabilitiesContext implements NegotiateContextRequest, NegotiateContextResponse {
 
     // Context type
+    /** Context ID for RDMA transform capabilities */
     public static final int CONTEXT_ID = Smb2Constants.SMB2_RDMA_TRANSFORM_CAPABILITIES;
 
     // Transform count and reserved fields

--- a/src/main/java/jcifs/internal/smb2/rdma/RdmaChannelInfo.java
+++ b/src/main/java/jcifs/internal/smb2/rdma/RdmaChannelInfo.java
@@ -17,6 +17,12 @@
  */
 package jcifs.internal.smb2.rdma;
 
+/**
+ * RDMA channel information for SMB Direct operations.
+ *
+ * This class encapsulates RDMA channel metadata including remote memory keys,
+ * addresses, and lengths for direct memory access operations.
+ */
 public class RdmaChannelInfo {
 
     private final Smb2RdmaTransform transform;

--- a/src/main/java/jcifs/internal/smb2/rdma/RdmaConnection.java
+++ b/src/main/java/jcifs/internal/smb2/rdma/RdmaConnection.java
@@ -37,19 +37,41 @@ public abstract class RdmaConnection implements AutoCloseable {
      * RDMA connection state enumeration
      */
     public enum RdmaConnectionState {
-        DISCONNECTED, CONNECTING, CONNECTED, ESTABLISHED, ERROR, CLOSING, CLOSED
+        /** Connection is not established */
+        DISCONNECTED,
+        /** Connection is being established */
+        CONNECTING,
+        /** Connection is established but not ready for RDMA operations */
+        CONNECTED,
+        /** Connection is fully established and ready for RDMA operations */
+        ESTABLISHED,
+        /** Connection encountered an error */
+        ERROR,
+        /** Connection is being closed */
+        CLOSING,
+        /** Connection is closed */
+        CLOSED
     }
 
+    /** Remote endpoint address */
     protected final InetSocketAddress remoteAddress;
+    /** Local endpoint address */
     protected final InetSocketAddress localAddress;
+    /** Available send credits for flow control */
     protected final AtomicInteger sendCredits;
+    /** Available receive credits for flow control */
     protected final AtomicInteger receiveCredits;
+    /** Queue of pending RDMA work requests */
     protected final BlockingQueue<RdmaWorkRequest> pendingRequests;
 
     // Connection state
+    /** Current connection state */
     protected volatile RdmaConnectionState state;
+    /** Credit management for SMB Direct */
     protected RdmaCredits credits;
+    /** Maximum size for fragmented operations */
     protected int maxFragmentedSize;
+    /** Maximum size for RDMA read/write operations */
     protected int maxReadWriteSize;
 
     /**

--- a/src/main/java/jcifs/internal/smb2/rdma/RdmaErrorHandler.java
+++ b/src/main/java/jcifs/internal/smb2/rdma/RdmaErrorHandler.java
@@ -190,6 +190,7 @@ public class RdmaErrorHandler {
     /**
      * Execute an RDMA operation with automatic retry and error handling
      *
+     * @param <T> the type of result returned by the operation
      * @param operation the operation to execute
      * @param connection the RDMA connection to use
      * @return operation result
@@ -241,9 +242,17 @@ public class RdmaErrorHandler {
 
     /**
      * Functional interface for RDMA operations that can be retried
+     *
+     * @param <T> the type of result returned by the operation
      */
     @FunctionalInterface
     public interface RdmaOperation<T> {
+        /**
+         * Execute the RDMA operation
+         *
+         * @return the result of the operation
+         * @throws Exception if the operation fails
+         */
         T execute() throws Exception;
     }
 }

--- a/src/main/java/jcifs/internal/smb2/rdma/RdmaMemoryRegion.java
+++ b/src/main/java/jcifs/internal/smb2/rdma/RdmaMemoryRegion.java
@@ -29,11 +29,17 @@ import java.util.EnumSet;
  */
 public abstract class RdmaMemoryRegion implements AutoCloseable {
 
+    /** Memory buffer for RDMA operations */
     protected final ByteBuffer buffer;
+    /** Access permissions for this memory region */
     protected final EnumSet<RdmaAccess> accessFlags;
+    /** Local key for accessing this memory region */
     protected final int localKey;
+    /** Remote key for remote RDMA access */
     protected final int remoteKey;
+    /** Virtual address of the memory region */
     protected final long address;
+    /** Flag indicating if the memory region is still valid */
     protected volatile boolean valid;
 
     /**

--- a/src/main/java/jcifs/internal/smb2/rdma/RdmaProviderFactory.java
+++ b/src/main/java/jcifs/internal/smb2/rdma/RdmaProviderFactory.java
@@ -35,6 +35,13 @@ import jcifs.internal.smb2.rdma.tcp.TcpRdmaProvider;
  */
 public class RdmaProviderFactory {
 
+    /**
+     * Private constructor to prevent instantiation
+     */
+    private RdmaProviderFactory() {
+        // Factory class - not instantiable
+    }
+
     private static final Logger log = LoggerFactory.getLogger(RdmaProviderFactory.class);
 
     /**

--- a/src/main/java/jcifs/internal/smb2/rdma/RdmaStatistics.java
+++ b/src/main/java/jcifs/internal/smb2/rdma/RdmaStatistics.java
@@ -27,6 +27,13 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class RdmaStatistics {
 
+    /**
+     * Creates a new RDMA statistics tracker
+     */
+    public RdmaStatistics() {
+        // Default constructor
+    }
+
     private final AtomicLong rdmaReads = new AtomicLong();
     private final AtomicLong rdmaWrites = new AtomicLong();
     private final AtomicLong rdmaSends = new AtomicLong();

--- a/src/main/java/jcifs/internal/smb2/rdma/RdmaWorkRequest.java
+++ b/src/main/java/jcifs/internal/smb2/rdma/RdmaWorkRequest.java
@@ -29,7 +29,14 @@ public class RdmaWorkRequest {
      * Type of RDMA work request
      */
     public enum RequestType {
-        SEND, RECEIVE, READ, WRITE
+        /** Send operation */
+        SEND,
+        /** Receive operation */
+        RECEIVE,
+        /** RDMA read operation */
+        READ,
+        /** RDMA write operation */
+        WRITE
     }
 
     private final long requestId;

--- a/src/main/java/jcifs/internal/smb2/rdma/SmbDirectNegotiateRequest.java
+++ b/src/main/java/jcifs/internal/smb2/rdma/SmbDirectNegotiateRequest.java
@@ -28,8 +28,11 @@ import jcifs.internal.util.SMBUtil;
 public class SmbDirectNegotiateRequest {
 
     // Protocol constants
+    /** Minimum supported SMB Direct protocol version (1.0) */
     public static final int MIN_VERSION = 0x0100; // SMB Direct 1.0
+    /** Maximum supported SMB Direct protocol version (1.0) */
     public static final int MAX_VERSION = 0x0100; // SMB Direct 1.0
+    /** SMB Direct negotiate request message type */
     public static final int NEGOTIATE_REQUEST = 0x01;
 
     // Message fields
@@ -88,50 +91,110 @@ public class SmbDirectNegotiateRequest {
 
     // Getters and setters
 
+    /**
+     * Get the minimum SMB Direct protocol version
+     *
+     * @return minimum protocol version
+     */
     public int getMinVersion() {
         return minVersion;
     }
 
+    /**
+     * Set the minimum SMB Direct protocol version
+     *
+     * @param minVersion minimum protocol version
+     */
     public void setMinVersion(int minVersion) {
         this.minVersion = minVersion;
     }
 
+    /**
+     * Get the maximum SMB Direct protocol version
+     *
+     * @return maximum protocol version
+     */
     public int getMaxVersion() {
         return maxVersion;
     }
 
+    /**
+     * Set the maximum SMB Direct protocol version
+     *
+     * @param maxVersion maximum protocol version
+     */
     public void setMaxVersion(int maxVersion) {
         this.maxVersion = maxVersion;
     }
 
+    /**
+     * Get the number of send credits requested
+     *
+     * @return credits requested
+     */
     public int getCreditsRequested() {
         return creditsRequested;
     }
 
+    /**
+     * Set the number of send credits requested
+     *
+     * @param creditsRequested credits to request
+     */
     public void setCreditsRequested(int creditsRequested) {
         this.creditsRequested = creditsRequested;
     }
 
+    /**
+     * Get the preferred size for send operations
+     *
+     * @return preferred send size in bytes
+     */
     public int getPreferredSendSize() {
         return preferredSendSize;
     }
 
+    /**
+     * Set the preferred size for send operations
+     *
+     * @param preferredSendSize preferred send size in bytes
+     */
     public void setPreferredSendSize(int preferredSendSize) {
         this.preferredSendSize = preferredSendSize;
     }
 
+    /**
+     * Get the maximum size for receive operations
+     *
+     * @return maximum receive size in bytes
+     */
     public int getMaxReceiveSize() {
         return maxReceiveSize;
     }
 
+    /**
+     * Set the maximum size for receive operations
+     *
+     * @param maxReceiveSize maximum receive size in bytes
+     */
     public void setMaxReceiveSize(int maxReceiveSize) {
         this.maxReceiveSize = maxReceiveSize;
     }
 
+    /**
+     * Get the maximum size for fragmented operations
+     *
+     * @return maximum fragmented size in bytes
+     */
     public int getMaxFragmentedSize() {
         return maxFragmentedSize;
     }
 
+    /**
+     * Set the maximum size for fragmented operations
+     *
+     * @param maxFragmentedSize maximum fragmented size in bytes
+     */
     public void setMaxFragmentedSize(int maxFragmentedSize) {
         this.maxFragmentedSize = maxFragmentedSize;
     }

--- a/src/main/java/jcifs/internal/smb2/rdma/SmbDirectNegotiateResponse.java
+++ b/src/main/java/jcifs/internal/smb2/rdma/SmbDirectNegotiateResponse.java
@@ -28,9 +28,13 @@ import jcifs.internal.util.SMBUtil;
 public class SmbDirectNegotiateResponse {
 
     // Protocol constants
+    /** SMB Direct negotiate response message type */
     public static final int NEGOTIATE_RESPONSE = 0x02;
+    /** Status indicating successful negotiation */
     public static final int STATUS_SUCCESS = 0x00000000;
+    /** Status indicating SMB Direct is not supported */
     public static final int STATUS_NOT_SUPPORTED = 0x00000001;
+    /** Status indicating insufficient resources for SMB Direct */
     public static final int STATUS_INSUFFICIENT_RESOURCES = 0x00000002;
 
     // Message fields
@@ -148,82 +152,182 @@ public class SmbDirectNegotiateResponse {
 
     // Getters and setters
 
+    /**
+     * Get the minimum SMB Direct protocol version
+     *
+     * @return minimum protocol version
+     */
     public int getMinVersion() {
         return minVersion;
     }
 
+    /**
+     * Set the minimum SMB Direct protocol version
+     *
+     * @param minVersion minimum protocol version
+     */
     public void setMinVersion(int minVersion) {
         this.minVersion = minVersion;
     }
 
+    /**
+     * Get the maximum SMB Direct protocol version
+     *
+     * @return maximum protocol version
+     */
     public int getMaxVersion() {
         return maxVersion;
     }
 
+    /**
+     * Set the maximum SMB Direct protocol version
+     *
+     * @param maxVersion maximum protocol version
+     */
     public void setMaxVersion(int maxVersion) {
         this.maxVersion = maxVersion;
     }
 
+    /**
+     * Get the negotiated SMB Direct protocol version
+     *
+     * @return negotiated protocol version
+     */
     public int getNegotiatedVersion() {
         return negotiatedVersion;
     }
 
+    /**
+     * Set the negotiated SMB Direct protocol version
+     *
+     * @param negotiatedVersion negotiated protocol version
+     */
     public void setNegotiatedVersion(int negotiatedVersion) {
         this.negotiatedVersion = negotiatedVersion;
     }
 
+    /**
+     * Get the number of send credits granted
+     *
+     * @return credits granted
+     */
     public int getCreditsGranted() {
         return creditsGranted;
     }
 
+    /**
+     * Set the number of send credits granted
+     *
+     * @param creditsGranted credits to grant
+     */
     public void setCreditsGranted(int creditsGranted) {
         this.creditsGranted = creditsGranted;
     }
 
+    /**
+     * Get the number of send credits requested
+     *
+     * @return credits requested
+     */
     public int getCreditsRequested() {
         return creditsRequested;
     }
 
+    /**
+     * Set the number of send credits requested
+     *
+     * @param creditsRequested credits to request
+     */
     public void setCreditsRequested(int creditsRequested) {
         this.creditsRequested = creditsRequested;
     }
 
+    /**
+     * Get the negotiation status
+     *
+     * @return status code
+     */
     public int getStatus() {
         return status;
     }
 
+    /**
+     * Set the negotiation status
+     *
+     * @param status status code
+     */
     public void setStatus(int status) {
         this.status = status;
     }
 
+    /**
+     * Get the maximum size for RDMA read/write operations
+     *
+     * @return maximum read/write size in bytes
+     */
     public int getMaxReadWriteSize() {
         return maxReadWriteSize;
     }
 
+    /**
+     * Set the maximum size for RDMA read/write operations
+     *
+     * @param maxReadWriteSize maximum read/write size in bytes
+     */
     public void setMaxReadWriteSize(int maxReadWriteSize) {
         this.maxReadWriteSize = maxReadWriteSize;
     }
 
+    /**
+     * Get the preferred size for send operations
+     *
+     * @return preferred send size in bytes
+     */
     public int getPreferredSendSize() {
         return preferredSendSize;
     }
 
+    /**
+     * Set the preferred size for send operations
+     *
+     * @param preferredSendSize preferred send size in bytes
+     */
     public void setPreferredSendSize(int preferredSendSize) {
         this.preferredSendSize = preferredSendSize;
     }
 
+    /**
+     * Get the maximum size for receive operations
+     *
+     * @return maximum receive size in bytes
+     */
     public int getMaxReceiveSize() {
         return maxReceiveSize;
     }
 
+    /**
+     * Set the maximum size for receive operations
+     *
+     * @param maxReceiveSize maximum receive size in bytes
+     */
     public void setMaxReceiveSize(int maxReceiveSize) {
         this.maxReceiveSize = maxReceiveSize;
     }
 
+    /**
+     * Get the maximum size for fragmented operations
+     *
+     * @return maximum fragmented size in bytes
+     */
     public int getMaxFragmentedSize() {
         return maxFragmentedSize;
     }
 
+    /**
+     * Set the maximum size for fragmented operations
+     *
+     * @param maxFragmentedSize maximum fragmented size in bytes
+     */
     public void setMaxFragmentedSize(int maxFragmentedSize) {
         this.maxFragmentedSize = maxFragmentedSize;
     }

--- a/src/main/java/jcifs/internal/smb2/rdma/disni/DisniRdmaProvider.java
+++ b/src/main/java/jcifs/internal/smb2/rdma/disni/DisniRdmaProvider.java
@@ -41,6 +41,13 @@ import jcifs.internal.smb2.rdma.RdmaProvider;
  */
 public class DisniRdmaProvider implements RdmaProvider {
 
+    /**
+     * Creates a new DiSNI RDMA provider instance
+     */
+    public DisniRdmaProvider() {
+        // Default constructor
+    }
+
     private static final Logger log = LoggerFactory.getLogger(DisniRdmaProvider.class);
 
     // DiSNI components - these would be actual DiSNI objects in a real implementation

--- a/src/main/java/jcifs/internal/smb2/rdma/tcp/TcpRdmaProvider.java
+++ b/src/main/java/jcifs/internal/smb2/rdma/tcp/TcpRdmaProvider.java
@@ -38,6 +38,13 @@ import jcifs.internal.smb2.rdma.RdmaProvider;
  */
 public class TcpRdmaProvider implements RdmaProvider {
 
+    /**
+     * Creates a new TCP RDMA provider instance
+     */
+    public TcpRdmaProvider() {
+        // Default constructor
+    }
+
     @Override
     public boolean isAvailable() {
         return true; // TCP is always available

--- a/src/main/java/jcifs/internal/witness/WitnessAsyncNotifyMessage.java
+++ b/src/main/java/jcifs/internal/witness/WitnessAsyncNotifyMessage.java
@@ -301,32 +301,70 @@ public class WitnessAsyncNotifyMessage extends WitnessRpcMessage {
 
     /**
      * Response structure for witness notifications.
+     * Contains the notification type and associated messages from the witness service.
      */
     public static class WitnessNotificationResponse {
+        /**
+         * Creates a new witness notification response.
+         */
+        public WitnessNotificationResponse() {
+            // Default constructor
+        }
+
         private WitnessEventType notificationType;
         private int length;
         private List<WitnessNotificationMessage> messages;
 
+        /**
+         * Gets the notification type.
+         *
+         * @return the witness event type for this notification
+         */
         public WitnessEventType getNotificationType() {
             return notificationType;
         }
 
+        /**
+         * Sets the notification type.
+         *
+         * @param notificationType the witness event type for this notification
+         */
         public void setNotificationType(WitnessEventType notificationType) {
             this.notificationType = notificationType;
         }
 
+        /**
+         * Gets the total length of the notification response.
+         *
+         * @return the length in bytes of the entire notification response
+         */
         public int getLength() {
             return length;
         }
 
+        /**
+         * Sets the total length of the notification response.
+         *
+         * @param length the length in bytes of the entire notification response
+         */
         public void setLength(int length) {
             this.length = length;
         }
 
+        /**
+         * Gets the list of notification messages.
+         *
+         * @return the list of individual notification messages contained in this response
+         */
         public List<WitnessNotificationMessage> getMessages() {
             return messages;
         }
 
+        /**
+         * Sets the list of notification messages.
+         *
+         * @param messages the list of individual notification messages contained in this response
+         */
         public void setMessages(List<WitnessNotificationMessage> messages) {
             this.messages = messages;
         }
@@ -337,10 +375,21 @@ public class WitnessAsyncNotifyMessage extends WitnessRpcMessage {
      */
     public static class WitnessNotificationMessage {
 
+        /**
+         * Creates a new witness notification message
+         */
+        public WitnessNotificationMessage() {
+            // Default constructor
+        }
+
         // Message types from MS-SWN specification
+        /** Witness resource change notification type */
         public static final int WITNESS_RESOURCE_CHANGE = 1;
+        /** Witness client move notification type */
         public static final int WITNESS_CLIENT_MOVE = 2;
+        /** Witness share move notification type */
         public static final int WITNESS_SHARE_MOVE = 3;
+        /** Witness IP address change notification type */
         public static final int WITNESS_IP_CHANGE = 4;
 
         private int type;
@@ -351,58 +400,128 @@ public class WitnessAsyncNotifyMessage extends WitnessRpcMessage {
         private String destinationNode;
         private List<String> ipAddresses;
 
+        /**
+         * Get the notification message type
+         *
+         * @return message type
+         */
         public int getType() {
             return type;
         }
 
+        /**
+         * Sets the notification message type.
+         *
+         * @param type the message type (WITNESS_RESOURCE_CHANGE, WITNESS_CLIENT_MOVE, WITNESS_SHARE_MOVE, or WITNESS_IP_CHANGE)
+         */
         public void setType(int type) {
             this.type = type;
         }
 
+        /**
+         * Get the notification message length
+         *
+         * @return message length in bytes
+         */
         public int getLength() {
             return length;
         }
 
+        /**
+         * Sets the notification message length.
+         *
+         * @param length the message length in bytes
+         */
         public void setLength(int length) {
             this.length = length;
         }
 
+        /**
+         * Get the notification timestamp
+         *
+         * @return timestamp in milliseconds
+         */
         public long getTimestamp() {
             return timestamp;
         }
 
+        /**
+         * Sets the notification timestamp.
+         *
+         * @param timestamp the timestamp value in FILETIME format (100-nanosecond intervals since January 1, 1601 UTC)
+         */
         public void setTimestamp(long timestamp) {
             this.timestamp = timestamp;
         }
 
+        /**
+         * Get the resource name associated with the notification
+         *
+         * @return resource name
+         */
         public String getResourceName() {
             return resourceName;
         }
 
+        /**
+         * Sets the resource name associated with the notification.
+         *
+         * @param resourceName the name of the resource affected by the change
+         */
         public void setResourceName(String resourceName) {
             this.resourceName = resourceName;
         }
 
+        /**
+         * Get the source node for move operations
+         *
+         * @return source node name
+         */
         public String getSourceNode() {
             return sourceNode;
         }
 
+        /**
+         * Sets the source node for move operations.
+         *
+         * @param sourceNode the name of the source node in a share move operation
+         */
         public void setSourceNode(String sourceNode) {
             this.sourceNode = sourceNode;
         }
 
+        /**
+         * Get the destination node for move operations
+         *
+         * @return destination node name
+         */
         public String getDestinationNode() {
             return destinationNode;
         }
 
+        /**
+         * Sets the destination node for move operations.
+         *
+         * @param destinationNode the name of the destination node in a client or share move operation
+         */
         public void setDestinationNode(String destinationNode) {
             this.destinationNode = destinationNode;
         }
 
+        /**
+         * Get the list of IP addresses for IP change notifications
+         *
+         * @return list of IP addresses
+         */
         public List<String> getIpAddresses() {
             return ipAddresses;
         }
 
+        /**
+         * Sets the list of IP addresses for IP change notifications.
+         *
+         * @param ipAddresses the list of new IP addresses available for the witness service
+         */
         public void setIpAddresses(List<String> ipAddresses) {
             this.ipAddresses = ipAddresses;
         }

--- a/src/main/java/jcifs/internal/witness/WitnessHeartbeatRequest.java
+++ b/src/main/java/jcifs/internal/witness/WitnessHeartbeatRequest.java
@@ -22,6 +22,13 @@ package jcifs.internal.witness;
  * Used to maintain active witness registrations.
  */
 public class WitnessHeartbeatRequest {
+    /**
+     * Creates a new witness heartbeat request.
+     */
+    public WitnessHeartbeatRequest() {
+        // Default constructor
+    }
+
     private String registrationId;
     private long sequenceNumber;
     private byte[] contextHandle;

--- a/src/main/java/jcifs/internal/witness/WitnessHeartbeatResponse.java
+++ b/src/main/java/jcifs/internal/witness/WitnessHeartbeatResponse.java
@@ -22,6 +22,13 @@ package jcifs.internal.witness;
  * Contains the result of a witness heartbeat request.
  */
 public class WitnessHeartbeatResponse {
+    /**
+     * Creates a new witness heartbeat response.
+     */
+    public WitnessHeartbeatResponse() {
+        // Default constructor
+    }
+
     private long sequenceNumber;
     private int returnCode;
     private long recommendedHeartbeatInterval;

--- a/src/main/java/jcifs/internal/witness/WitnessNotification.java
+++ b/src/main/java/jcifs/internal/witness/WitnessNotification.java
@@ -36,8 +36,11 @@ public class WitnessNotification {
     private String newNodeAddress;
 
     // Notification flags
+    /** Resource state is unknown */
     public static final int WITNESS_RESOURCE_STATE_UNKNOWN = 0x00000000;
+    /** Resource is available for use */
     public static final int WITNESS_RESOURCE_STATE_AVAILABLE = 0x00000001;
+    /** Resource is unavailable */
     public static final int WITNESS_RESOURCE_STATE_UNAVAILABLE = 0x000000FF;
 
     /**
@@ -73,7 +76,9 @@ public class WitnessNotification {
         private final InetAddress address;
         private final int flags;
 
+        /** Flag indicating IPv4 address type */
         public static final int IPV4 = 0x01;
+        /** Flag indicating IPv6 address type */
         public static final int IPV6 = 0x02;
 
         /**

--- a/src/main/java/jcifs/internal/witness/WitnessRegisterRequest.java
+++ b/src/main/java/jcifs/internal/witness/WitnessRegisterRequest.java
@@ -22,6 +22,13 @@ package jcifs.internal.witness;
  * Used to register for witness notifications from the witness service.
  */
 public class WitnessRegisterRequest {
+    /**
+     * Creates a new witness register request.
+     */
+    public WitnessRegisterRequest() {
+        // Default constructor
+    }
+
     private int version;
     private String shareName;
     private String serverAddress;

--- a/src/main/java/jcifs/internal/witness/WitnessRegisterResponse.java
+++ b/src/main/java/jcifs/internal/witness/WitnessRegisterResponse.java
@@ -22,6 +22,13 @@ package jcifs.internal.witness;
  * Contains the result of a witness registration request.
  */
 public class WitnessRegisterResponse {
+    /**
+     * Creates a new witness register response.
+     */
+    public WitnessRegisterResponse() {
+        // Default constructor
+    }
+
     private String registrationId;
     private int returnCode;
     private byte[] contextHandle;

--- a/src/main/java/jcifs/internal/witness/WitnessRegistration.java
+++ b/src/main/java/jcifs/internal/witness/WitnessRegistration.java
@@ -36,7 +36,9 @@ public class WitnessRegistration {
     private byte[] contextHandle;
 
     // Registration flags
+    /** No special registration flags */
     public static final int WITNESS_REGISTER_NONE = 0x00000000;
+    /** Register for IP address change notifications */
     public static final int WITNESS_REGISTER_IP_NOTIFICATION = 0x00000001;
 
     // Registration state
@@ -48,7 +50,16 @@ public class WitnessRegistration {
      * Enumeration of possible witness registration states.
      */
     public enum WitnessRegistrationState {
-        REGISTERING, REGISTERED, UNREGISTERING, FAILED, EXPIRED
+        /** Registration is in progress */
+        REGISTERING,
+        /** Registration is active and confirmed */
+        REGISTERED,
+        /** Unregistration is in progress */
+        UNREGISTERING,
+        /** Registration has failed */
+        FAILED,
+        /** Registration has expired due to timeout */
+        EXPIRED
     }
 
     /**

--- a/src/main/java/jcifs/internal/witness/WitnessRpcClient.java
+++ b/src/main/java/jcifs/internal/witness/WitnessRpcClient.java
@@ -27,6 +27,10 @@ import org.slf4j.LoggerFactory;
 import jcifs.CIFSContext;
 import jcifs.dcerpc.DcerpcHandle;
 
+/**
+ * Client implementation for the SMB Witness RPC protocol (MS-SWN).
+ * Provides communication with witness servers for monitoring SMB resource availability.
+ */
 public class WitnessRpcClient implements AutoCloseable {
     private static final Logger log = LoggerFactory.getLogger(WitnessRpcClient.class);
 

--- a/src/main/java/jcifs/internal/witness/WitnessRpcMessage.java
+++ b/src/main/java/jcifs/internal/witness/WitnessRpcMessage.java
@@ -28,24 +28,38 @@ import jcifs.dcerpc.ndr.NdrException;
 public abstract class WitnessRpcMessage extends DcerpcMessage {
 
     // MS-SWN Witness Protocol Interface UUID and Version
+    /** Witness Protocol Interface UUID from MS-SWN specification */
     public static final String WITNESS_INTERFACE_UUID = "ccd8c074-d0e5-4a40-92b4-d074faa6ba28";
+    /** Witness Protocol major version number */
     public static final int WITNESS_INTERFACE_VERSION_MAJOR = 1;
+    /** Witness Protocol minor version number */
     public static final int WITNESS_INTERFACE_VERSION_MINOR = 0;
 
     // MS-SWN RPC Operation Numbers
+    /** WitnessRegister operation number */
     public static final int WITNESS_REGISTER = 0;
+    /** WitnessUnregister operation number */
     public static final int WITNESS_UNREGISTER = 1;
+    /** WitnessAsyncNotify operation number */
     public static final int WITNESS_ASYNC_NOTIFY = 2;
+    /** Witness heartbeat operation number */
     public static final int WITNESS_HEARTBEAT = 3;
 
     // Common return codes from MS-SWN specification
+    /** Operation completed successfully */
     public static final int ERROR_SUCCESS = 0x00000000;
+    /** Invalid parameter was passed to the operation */
     public static final int ERROR_INVALID_PARAMETER = 0x00000057;
+    /** Buffer provided is insufficient */
     public static final int ERROR_INSUFFICIENT_BUFFER = 0x0000007A;
+    /** Operation is not supported */
     public static final int ERROR_NOT_SUPPORTED = 0x00000032;
+    /** Access denied to perform the operation */
     public static final int ERROR_ACCESS_DENIED = 0x00000005;
+    /** Invalid state for the operation */
     public static final int ERROR_INVALID_STATE = 0x0000139F;
 
+    /** Return code from the RPC operation */
     protected int returnCode = ERROR_SUCCESS;
     private int opnum;
 

--- a/src/main/java/jcifs/internal/witness/WitnessUnregisterRequest.java
+++ b/src/main/java/jcifs/internal/witness/WitnessUnregisterRequest.java
@@ -22,6 +22,13 @@ package jcifs.internal.witness;
  * Used to unregister from witness notifications.
  */
 public class WitnessUnregisterRequest {
+    /**
+     * Creates a new witness unregister request.
+     */
+    public WitnessUnregisterRequest() {
+        // Default constructor
+    }
+
     private String registrationId;
     private byte[] contextHandle;
 

--- a/src/main/java/jcifs/internal/witness/WitnessUnregisterResponse.java
+++ b/src/main/java/jcifs/internal/witness/WitnessUnregisterResponse.java
@@ -22,6 +22,13 @@ package jcifs.internal.witness;
  * Contains the result of a witness unregistration request.
  */
 public class WitnessUnregisterResponse {
+    /**
+     * Creates a new witness unregister response.
+     */
+    public WitnessUnregisterResponse() {
+        // Default constructor
+    }
+
     private int returnCode;
     private String error;
 


### PR DESCRIPTION
This PR enhances the readability and maintainability of the RDMA and Witness protocol implementation by adding comprehensive Javadoc comments.

Key changes:

- BaseConfiguration: Added documentation for RDMA and Witness-related configuration fields.
- RDMA classes (RdmaConnection, RdmaChannelInfo, RdmaMemoryRegion, RdmaStatistics, RdmaWorkRequest, etc.):
  - Documented fields, constructors, enums, and methods.
  - Clarified connection states, memory region attributes, and work request types.
- SMB Direct negotiation classes (SmbDirectNegotiateRequest, SmbDirectNegotiateResponse, Smb2RdmaTransformCapabilitiesContext):
  - Added documentation for constants, getters, and setters.
- Witness protocol classes (WitnessAsyncNotifyMessage, WitnessRegisterRequest/Response, WitnessHeartbeatRequest/Response, WitnessNotification, WitnessRegistration, WitnessUnregisterRequest/Response, WitnessRpcClient, WitnessRpcMessage):
  - Documented constants, enums, constructors, and accessors.
  - Improved clarity on notification types, registration states, and RPC error codes.
- Factory and provider classes (RdmaProviderFactory, DisniRdmaProvider, TcpRdmaProvider):
  - Added documentation to constructors and factory usage.

This change does not modify functionality but improves code documentation, clarity, and developer onboarding.