### PR TITLE
Improve README with detailed usage guide and modernize test annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,53 @@
-JCIFS
+# JCIFS - Java CIFS/SMB Client Library
+
 [![Java CI with Maven](https://github.com/codelibs/jcifs/actions/workflows/maven.yml/badge.svg)](https://github.com/codelibs/jcifs/actions/workflows/maven.yml)
-=====
+[![Maven Central](https://img.shields.io/maven-central/v/org.codelibs/jcifs.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22org.codelibs%22%20AND%20a:%22jcifs%22)
+[![License: LGPL v2.1](https://img.shields.io/badge/License-LGPL%20v2.1-blue.svg)](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
+[![Java Version](https://img.shields.io/badge/Java-17%2B-green.svg)](https://openjdk.java.net/)
 
-JCIFS is an Open Source client library that implements the CIFS/SMB networking protocol in 100% Java.
-From version 2.x, this project is forked from [jcifs-ng](https://github.com/AgNO3/jcifs-ng) and existing jcifs code is merged as `smb1`.
-Version 3.x introduces SMB3 encryption and enhanced security features, while maintaining backward compatibility with legacy SMB devices.
+JCIFS is a comprehensive, pure Java implementation of the CIFS/SMB networking protocol suite, providing seamless access to Windows file shares and SMB servers. This library enables Java applications to interact with SMB resources across all major protocol versions while maintaining excellent compatibility with legacy systems.
 
-## Version
+## 🚀 Key Features
 
-[Versions in Maven Repository](https://repo1.maven.org/maven2/org/codelibs/jcifs/)
+### **Protocol Support**
+- **SMB1/CIFS**: Legacy protocol support for older devices and systems
+- **SMB2**: Full SMB 2.0.2, 2.1 support with enhanced performance
+- **SMB3**: Complete SMB 3.0, 3.0.2, 3.1.1 implementation featuring:
+  - **AES-128-CCM encryption** (SMB 3.0/3.0.2)
+  - **AES-128-GCM encryption** (SMB 3.1.1)
+  - **Pre-Authentication Integrity** (SMB 3.1.1)
+  - **AES-CMAC signing** for data integrity
+  - **Automatic protocol negotiation**
+  - **Transparent encryption** when required by server
 
-## Requirements
+### **Security & Authentication**
+- **Multi-method Authentication**: NTLMSSP, Kerberos, SPNEGO
+- **Enterprise Security**: Domain authentication with credential renewal
+- **Guest & Anonymous Access**: Flexible credential management
+- **Per-context Configuration**: No global state, thread-safe operations
 
-- Java 17 or higher (upgraded from Java 8)
-- SLF4J for logging
+### **Performance & Reliability**
+- **Large File Support**: Efficient ReadX/WriteX operations for multi-GB files
+- **Streaming Operations**: Memory-efficient directory listings and file transfers
+- **Connection Pooling**: Intelligent transport management and reuse
+- **Buffer Caching**: Optimized memory management for high-throughput scenarios
+- **DFS Support**: Distributed File System path resolution
 
-## Using Maven
+### **Modern Java Integration**
+- **Java 17+ Requirement**: Modern language features and performance
+- **SLF4J Logging**: Configurable, enterprise-grade logging
+- **AutoCloseable Resources**: Proper resource management patterns
+- **Jakarta EE Support**: Compatible with modern servlet containers
 
-```xml
-<dependency>
-    <groupId>org.codelibs</groupId>
-    <artifactId>jcifs</artifactId>
-    <version>2.1.39</version>
-</dependency>
-```
+## 📋 Requirements
 
-For the latest version with SMB3 support (coming soon):
+- **Java**: 17 or higher (LTS recommended)
+- **Dependencies**: SLF4J for logging, Bouncy Castle for cryptography
+- **Network**: SMB/CIFS protocol access (typically ports 139/445)
+
+## 📦 Installation
+
+### Maven
 ```xml
 <dependency>
     <groupId>org.codelibs</groupId>
@@ -34,48 +56,17 @@ For the latest version with SMB3 support (coming soon):
 </dependency>
 ```
 
-## Features
+### Gradle
+```groovy
+implementation 'org.codelibs:jcifs:3.0.0'
+```
 
-### Protocol Support
- * **SMB1/CIFS**: Legacy protocol support for older devices
- * **SMB2**: Full SMB 2.0.2, 2.1 support
- * **SMB3**: SMB 3.0, 3.0.2, 3.1.1 security features with:
-   - AES-128-CCM encryption (SMB 3.0/3.0.2)
-   - AES-128-GCM encryption (SMB 3.1.1)
-   - Pre-Authentication Integrity (SMB 3.1.1)
-   - Automatic protocol negotiation
-   - Transparent encryption when required by server
+### Latest Versions
+Check [Maven Central](https://repo1.maven.org/maven2/org/codelibs/jcifs/) for the most recent releases.
 
-### Core Features
- * Per-context configuration (no global state)
- * SLF4J logging framework
- * Unified authentication: NTLMSSP, Kerberos, SPNEGO
- * Large file transfer support (ReadX/WriteX)
- * Streaming operations for directory listings
- * DFS (Distributed File System) support
- * NtTransNotifyChange support for file monitoring
- * Comprehensive test suite with JUnit 4
+## 🏃‍♂️ Quick Start
 
-### Recent Improvements (v3.x)
- * Java 17 minimum requirement
- * Jakarta Servlet namespace migration
- * SMB3 encryption (AES-CCM/GCM) and signing (AES-CMAC) implementation
- * Enhanced protocol negotiation
- * Improved thread safety
- * Better resource management with AutoCloseable patterns
-
-### Known Limitations
- * SMB3 advanced features not yet implemented:
-   - Multi-channel support
-   - Persistent handles
-   - Directory leasing
-   - RDMA transport
- * Uses traditional oplocks instead of SMB3 leases
-
-## Quick Start
-
-### Basic Usage
-
+### Basic File Access
 ```java
 import org.codelibs.jcifs.smb.CIFSContext;
 import org.codelibs.jcifs.smb.context.SingletonContext;
@@ -88,54 +79,364 @@ CIFSContext context = SingletonContext.getInstance();
 try (SmbFile file = new SmbFile("smb://server/share/file.txt", context)) {
     if (file.exists()) {
         System.out.println("File size: " + file.length());
+        System.out.println("Last modified: " + new Date(file.lastModified()));
     }
 }
 ```
 
-### With Authentication
-
+### Reading File Content
 ```java
-import org.codelibs.jcifs.smb.CIFSContext;
+try (SmbFile file = new SmbFile("smb://server/share/document.txt", context);
+     InputStream is = file.getInputStream();
+     BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
+
+    String line;
+    while ((line = reader.readLine()) != null) {
+        System.out.println(line);
+    }
+}
+```
+
+### Directory Listing
+```java
+try (SmbFile dir = new SmbFile("smb://server/share/", context)) {
+    for (SmbFile file : dir.listFiles()) {
+        System.out.printf("%s %10d %s%n",
+            file.isDirectory() ? "[DIR]" : "[FILE]",
+            file.length(),
+            file.getName());
+    }
+}
+```
+
+## 🔐 Authentication Examples
+
+### Domain Authentication
+```java
 import org.codelibs.jcifs.smb.context.BaseContext;
 import org.codelibs.jcifs.smb.impl.NtlmPasswordAuthenticator;
+import org.codelibs.jcifs.smb.config.PropertyConfiguration;
 
-// Create context with credentials
-CIFSContext context = new BaseContext(new org.codelibs.jcifs.smb.config.PropertyConfiguration());
-NtlmPasswordAuthenticator auth = new NtlmPasswordAuthenticator("domain", "username", "password");
-CIFSContext authContext = context.withCredentials(auth);
+// Create context with domain credentials
+Properties props = new Properties();
+// Optional: Set SMB protocol preferences
+props.setProperty("jcifs.smb.client.minVersion", "SMB202");
+props.setProperty("jcifs.smb.client.maxVersion", "SMB311");
+
+CIFSContext baseContext = new BaseContext(new PropertyConfiguration(props));
+NtlmPasswordAuthenticator auth = new NtlmPasswordAuthenticator(
+    "DOMAIN",           // Domain name
+    "username",         // Username
+    "password"          // Password
+);
+
+CIFSContext authContext = baseContext.withCredentials(auth);
 
 // Use authenticated context
 try (SmbFile file = new SmbFile("smb://server/share/", authContext)) {
-    for (SmbFile f : file.listFiles()) {
-        System.out.println(f.getName());
+    // Authenticated operations...
+}
+```
+
+### Kerberos Authentication
+```java
+import org.codelibs.jcifs.smb.impl.KerberosCredentials;
+
+// Kerberos authentication (requires proper Kerberos setup)
+KerberosCredentials kerbCreds = new KerberosCredentials("user@DOMAIN.COM");
+CIFSContext kerbContext = baseContext.withCredentials(kerbCreds);
+```
+
+### Guest Access
+```java
+// Guest access for servers that allow it
+CIFSContext guestContext = baseContext.withGuestCrendentials();
+```
+
+## 🔧 Advanced Usage
+
+### Large File Operations
+```java
+// Efficient large file copying
+try (SmbFile source = new SmbFile("smb://server/share/largefile.zip", context);
+     SmbFile dest = new SmbFile("smb://server/backup/largefile.zip", context);
+     InputStream is = source.getInputStream();
+     OutputStream os = dest.getOutputStream()) {
+
+    byte[] buffer = new byte[65536]; // 64KB buffer
+    int bytesRead;
+    while ((bytesRead = is.read(buffer)) != -1) {
+        os.write(buffer, 0, bytesRead);
     }
 }
 ```
 
-## Others
+### File Monitoring
+```java
+import org.codelibs.jcifs.smb.SmbWatchHandle;
 
-### Choosing Between This JCIFS and jcifs-ng
+// Monitor directory for changes
+try (SmbFile dir = new SmbFile("smb://server/share/monitored/", context);
+     SmbWatchHandle watch = dir.watch(
+         SmbConstants.FILE_NOTIFY_CHANGE_FILE_NAME |
+         SmbConstants.FILE_NOTIFY_CHANGE_SIZE, true)) {
 
-**Use CodeLibs JCIFS when:**
-- You need maximum compatibility with legacy SMB devices
-- You require SMB3 encryption and security features (AES-CCM/GCM, AES-CMAC)
-- You need to support a wide variety of SMB implementations
-- Your application (like [Fess](https://github.com/codelibs/fess)) needs to connect to many different SMB devices
+    FileNotifyInformation[] notifications = watch.read();
+    for (FileNotifyInformation info : notifications) {
+        System.out.println("File changed: " + info.getFileName());
+    }
+}
+```
 
-**Use jcifs-ng when:**
-- You only need to connect to modern SMB servers
-- You don't require SMB3 encryption features
-- You have a controlled environment with specific SMB devices
+### Custom Configuration
+```java
+// Advanced configuration
+Properties config = new Properties();
+config.setProperty("jcifs.smb.client.minVersion", "SMB300");  // Require SMB3+
+config.setProperty("jcifs.smb.client.maxVersion", "SMB311");
+config.setProperty("jcifs.smb.client.enableSMB2Signing", "true");  // Enable signing
+config.setProperty("jcifs.smb.client.signingPreferred", "true");
+config.setProperty("jcifs.resolveOrder", "LMHOSTS,DNS,WINS,BCAST");
 
-### Contributing
+CIFSContext customContext = new BaseContext(new PropertyConfiguration(config));
+```
 
-We welcome contributions! Please:
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes with appropriate tests
-4. Run `mvn clean test` to ensure all tests pass
-5. Submit a pull request
+## 🏗️ Architecture Overview
 
-### License
+JCIFS follows a layered architecture designed for flexibility and performance:
 
-JCIFS is licensed under the GNU Lesser General Public License (LGPL). See the LICENSE file for details.
+### Core Components
+
+**Context Layer (`org.codelibs.jcifs.smb.context`)**
+- `CIFSContext`: Main entry point encapsulating configuration and credentials
+- `BaseContext`: Primary implementation with full feature support
+- Context wrappers for credential management and configuration isolation
+
+**Resource Layer (`org.codelibs.jcifs.smb.impl`)**
+- `SmbFile`: Primary implementation for files and directories
+- `SmbResource`: Interface for all SMB network resources
+- Resource locators and handles for connection management
+
+**Protocol Implementation (`org.codelibs.jcifs.smb.internal`)**
+- `smb1/`: Legacy SMB1/CIFS protocol support
+- `smb2/`: Modern SMB2/SMB3 protocol implementation
+- Protocol-specific message handling and transport
+
+**Authentication (`org.codelibs.jcifs.smb.ntlmssp`, `org.codelibs.jcifs.smb.pac`, `org.codelibs.jcifs.smb.spnego`)**
+- Multiple authentication mechanisms with automatic negotiation
+- Credential management and renewal capabilities
+- Enterprise security integration
+
+## 🔨 Development
+
+### Build Requirements
+- **Java 17+**: JDK 17 or higher for building
+- **Maven 3.6+**: Build system and dependency management
+
+### Building from Source
+```bash
+# Clone the repository
+git clone https://github.com/codelibs/jcifs.git
+cd jcifs
+
+# Compile the project
+mvn clean compile
+
+# Run tests
+mvn test
+
+# Create JAR file
+mvn package
+
+# Install to local repository
+mvn install
+```
+
+### Code Quality
+```bash
+# Format code according to project standards
+mvn formatter:format
+
+# Check license headers
+mvn apache-rat:check
+
+# Generate test coverage report
+mvn jacoco:report
+
+# Check API compatibility
+mvn clirr:check
+```
+
+### Testing
+The project includes comprehensive test coverage:
+
+```bash
+# Run all tests
+mvn test
+
+# Run specific test class
+mvn test -Dtest=SmbFileTest
+
+# Run integration tests
+mvn verify
+
+# Generate coverage report (target/site/jacoco/index.html)
+mvn jacoco:report
+```
+
+## ⚡ Performance Considerations
+
+### Connection Management
+- **Reuse contexts**: Create one context per configuration, reuse across operations
+- **Connection pooling**: JCIFS automatically pools and reuses connections
+- **Proper cleanup**: Always use try-with-resources for automatic resource management
+
+### Large File Operations
+```java
+// Use appropriate buffer sizes for your use case
+byte[] buffer = new byte[1024 * 1024]; // 1MB for large files
+byte[] buffer = new byte[64 * 1024];   // 64KB for general use
+
+// For very large files, consider streaming
+try (InputStream is = smbFile.getInputStream()) {
+    // Process in chunks to avoid memory issues
+}
+```
+
+### Protocol Selection
+```java
+// For maximum performance on modern servers
+props.setProperty("jcifs.smb.client.minVersion", "SMB300");
+props.setProperty("jcifs.smb.client.maxVersion", "SMB311");
+
+// For maximum compatibility (default)
+props.setProperty("jcifs.smb.client.minVersion", "SMB1");
+props.setProperty("jcifs.smb.client.maxVersion", "SMB311");
+```
+
+## 🔒 Security Best Practices
+
+### Authentication
+- **Use domain authentication** when possible for better security
+- **Enable SMB signing** for data integrity: `jcifs.smb.client.signingPreferred=true`
+- **Prefer SMB3** for encryption: `jcifs.smb.client.minVersion=SMB300`
+- **Rotate credentials** regularly and implement credential renewal
+
+### Network Security
+- **Use encrypted connections** when available (SMB3 encryption is automatic)
+- **Limit protocol versions** to minimum required for your environment
+- **Monitor failed authentication** attempts in logs
+- **Use VPN or secure networks** when accessing SMB over public networks
+
+### Configuration Security
+```java
+// Secure configuration example
+Properties secureConfig = new Properties();
+secureConfig.setProperty("jcifs.smb.client.minVersion", "SMB300");
+secureConfig.setProperty("jcifs.smb.client.enableSMB2Signing", "true");
+secureConfig.setProperty("jcifs.smb.client.signingPreferred", "true");
+secureConfig.setProperty("jcifs.smb.client.ipcSigningEnforced", "true");
+```
+
+## 🛠️ Troubleshooting
+
+### Common Issues
+
+**Connection Timeouts**
+```java
+// Increase timeout values
+props.setProperty("jcifs.smb.client.soTimeout", "35000");      // 35 seconds
+props.setProperty("jcifs.smb.client.connTimeout", "10000");    // 10 seconds
+props.setProperty("jcifs.smb.client.responseTimeout", "30000"); // 30 seconds
+```
+
+**Authentication Failures**
+- Verify domain name, username, and password
+- Check if the account has necessary permissions
+- Ensure the server allows the authentication method
+- For Kerberos, verify proper DNS and time synchronization
+
+**Protocol Negotiation Issues**
+```java
+// Debug protocol negotiation
+props.setProperty("jcifs.util.loglevel", "3");  // Enable debug logging
+
+// Force specific protocol version if needed
+props.setProperty("jcifs.smb.client.minVersion", "SMB202");
+props.setProperty("jcifs.smb.client.maxVersion", "SMB202");
+```
+
+**Performance Issues**
+- Use connection pooling (enabled by default)
+- Adjust buffer sizes for your use case
+- Consider enabling SMB3 for better performance
+- Monitor network latency and bandwidth
+
+### Logging Configuration
+JCIFS uses SLF4J for logging. Configure your logging framework accordingly:
+
+```xml
+<!-- logback.xml example -->
+<configuration>
+    <logger name="org.codelibs.jcifs.smb" level="INFO"/>
+    <logger name="org.codelibs.jcifs.smb.internal" level="WARN"/>
+    <!-- Enable debug for troubleshooting -->
+    <logger name="org.codelibs.jcifs.smb.internal.smb2" level="DEBUG"/>
+</configuration>
+```
+
+## 🔄 Migration Guide
+
+### From JCIFS 2.x to 3.x
+- **Java 17+ required**: Update your runtime environment
+- **Package changes**: All classes moved to `org.codelibs.jcifs.smb`
+- **Enhanced SMB3 support**: New encryption and signing capabilities
+- **Improved authentication**: Enhanced credential management
+
+### From Original JCIFS
+- **Context-based API**: Replace global configuration with contexts
+- **Modern authentication**: Update to new credential classes
+- **Resource management**: Use try-with-resources patterns
+
+## 🆚 JCIFS vs jcifs-ng
+
+### Choose JCIFS when:
+- Maximum compatibility with legacy SMB devices is required
+- SMB3 encryption and security features are needed
+- Connecting to diverse SMB implementations
+- Using in applications like [Fess](https://github.com/codelibs/fess) that need broad SMB support
+
+### Choose jcifs-ng when:
+- Only connecting to modern SMB servers
+- SMB3 encryption features are not required
+- Working in controlled environments with specific SMB devices
+
+## 🤝 Contributing
+
+We welcome contributions! Please follow these steps:
+
+1. **Fork the repository** and create a feature branch
+2. **Make your changes** with appropriate tests
+3. **Follow coding standards**: Use `mvn formatter:format`
+4. **Run tests**: Ensure `mvn clean test` passes
+5. **Update documentation** if needed
+6. **Submit a pull request** with a clear description
+
+### Development Setup
+```bash
+git clone https://github.com/your-username/jcifs.git
+cd jcifs
+mvn clean compile
+mvn test
+```
+
+### Coding Standards
+- Follow existing code style and patterns
+- Add JavaDoc comments for public APIs
+- Include unit tests for new functionality
+- Ensure all tests pass before submitting
+
+## 📜 License
+
+JCIFS is licensed under the [GNU Lesser General Public License (LGPL) v2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html).
+

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ CIFSContext kerbContext = baseContext.withCredentials(kerbCreds);
 ### Guest Access
 ```java
 // Guest access for servers that allow it
-CIFSContext guestContext = baseContext.withGuestCrendentials();
+CIFSContext guestContext = baseContext.withGuestCredentials();
 ```
 
 ## 🔧 Advanced Usage

--- a/pom.xml
+++ b/pom.xml
@@ -183,24 +183,6 @@
 				</dependencies>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>3.5.0</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>integration-test</goal>
-							<goal>verify</goal>
-						</goals>
-						<configuration>
-							<includes>
-								<include>**/*Test.java</include>
-							</includes>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
 				<version>0.8.13</version>
@@ -234,11 +216,10 @@
 				<configuration>
 					<addDefaultLicenseMatchers>true</addDefaultLicenseMatchers>
 					<excludes>
-						<exclude>pom.xml</exclude>
-						<exclude>breaking-changes.xml</exclude>
-						<exclude>README.md</exclude>
+						<exclude>*.xml</exclude>
+						<exclude>*.md</exclude>
 						<exclude>build.properties</exclude>
-						<exclude>src/test/resources/**</exclude>
+						<exclude>src/test/**</exclude>
 						<exclude>**/*.idl</exclude>
 						<exclude>**/*.css</exclude>
 						<exclude>.*</exclude>
@@ -250,7 +231,8 @@
 						<exclude>src/main/java/org/codelibs/jcifs/smb/dcerpc/msrpc/lsarpc.java</exclude>
 						<exclude>src/main/java/org/codelibs/jcifs/smb/dcerpc/rpc.java</exclude>
 						<exclude>src/main/java/org/codelibs/jcifs/smb1/**</exclude>
-						<exclude>src/test/java/**</exclude>
+						<exclude>src/main/resources/**</exclude>
+						<exclude>docs/**</exclude>
 					</excludes>
 					<licenses>
 						<license implementation="org.apache.rat.analysis.license.SimplePatternBasedLicense">

--- a/src/main/java/org/codelibs/jcifs/smb/CIFSContext.java
+++ b/src/main/java/org/codelibs/jcifs/smb/CIFSContext.java
@@ -150,7 +150,7 @@ public interface CIFSContext {
      *
      * @return a child context using guest credentials
      */
-    CIFSContext withGuestCrendentials();
+    CIFSContext withGuestCredentials();
 
     /**
      * Create a child context with specified credentials

--- a/src/main/java/org/codelibs/jcifs/smb/context/AbstractCIFSContext.java
+++ b/src/main/java/org/codelibs/jcifs/smb/context/AbstractCIFSContext.java
@@ -76,10 +76,10 @@ public abstract class AbstractCIFSContext extends Thread implements CIFSContext 
     /**
      * {@inheritDoc}
      *
-     * @see org.codelibs.jcifs.smb.CIFSContext#withGuestCrendentials()
+     * @see org.codelibs.jcifs.smb.CIFSContext#withGuestCredentials()
      */
     @Override
-    public CIFSContext withGuestCrendentials() {
+    public CIFSContext withGuestCredentials() {
         return withCredentials(new NtlmPasswordAuthenticator(null, null, null, AuthenticationType.GUEST));
     }
 

--- a/src/main/java/org/codelibs/jcifs/smb/context/CIFSContextWrapper.java
+++ b/src/main/java/org/codelibs/jcifs/smb/context/CIFSContextWrapper.java
@@ -147,8 +147,8 @@ public class CIFSContextWrapper implements CIFSContext {
     }
 
     @Override
-    public CIFSContext withGuestCrendentials() {
-        return wrap(this.delegate.withGuestCrendentials());
+    public CIFSContext withGuestCredentials() {
+        return wrap(this.delegate.withGuestCredentials());
     }
 
     @Override

--- a/src/test/java/org/codelibs/jcifs/smb/CIFSContextTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/CIFSContextTest.java
@@ -41,7 +41,7 @@ class CIFSContextTest extends BaseTest {
             mockContext.hasDefaultCredentials();
             mockContext.withDefaultCredentials();
             mockContext.withAnonymousCredentials();
-            mockContext.withGuestCrendentials();
+            mockContext.withGuestCredentials();
             mockContext.withCredentials(mock(Credentials.class));
             mockContext.renewCredentials("hint", new Exception());
         });
@@ -259,14 +259,14 @@ class CIFSContextTest extends BaseTest {
     void testWithGuestCrendentials() {
         // Given
         CIFSContext newContext = mock(CIFSContext.class);
-        when(mockContext.withGuestCrendentials()).thenReturn(newContext);
+        when(mockContext.withGuestCredentials()).thenReturn(newContext);
 
         // When
-        CIFSContext context = mockContext.withGuestCrendentials();
+        CIFSContext context = mockContext.withGuestCredentials();
 
         // Then
         assertEquals(newContext, context);
-        verify(mockContext).withGuestCrendentials();
+        verify(mockContext).withGuestCredentials();
     }
 
     @Test

--- a/src/test/java/org/codelibs/jcifs/smb/SmbConnectionTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/SmbConnectionTest.java
@@ -20,7 +20,7 @@ public class SmbConnectionTest {
      */
     @Test
     @DisplayName("getBatchLimit returns correct values for different SMB commands")
-    public void testBatchLimitForDifferentCommands() throws CIFSException {
+    public void batchLimitForDifferentCommandsShouldReturnCorrectValues() throws CIFSException {
         Properties props = new Properties();
         props.setProperty("jcifs.client.useBatching", "true");
         props.setProperty("jcifs.client.useUnicode", "true");
@@ -43,7 +43,7 @@ public class SmbConnectionTest {
      */
     @Test
     @DisplayName("Batch limit configuration with Unicode enabled")
-    public void testBatchLimitWithUnicodeEnabled() throws CIFSException {
+    public void batchLimitWithUnicodeEnabledShouldWork() throws CIFSException {
         Properties props = new Properties();
         props.setProperty("jcifs.client.useUnicode", "true");
         props.setProperty("jcifs.client.useBatching", "true");
@@ -63,7 +63,7 @@ public class SmbConnectionTest {
      */
     @Test
     @DisplayName("Batch limit configuration with batching disabled")
-    public void testBatchLimitWithBatchingDisabled() throws CIFSException {
+    public void batchLimitWithBatchingDisabledShouldWork() throws CIFSException {
         Properties props = new Properties();
         props.setProperty("jcifs.client.useUnicode", "true");
         props.setProperty("jcifs.client.useBatching", "false");
@@ -83,7 +83,7 @@ public class SmbConnectionTest {
      */
     @Test
     @DisplayName("Batch limit configuration with Unicode disabled")
-    public void testBatchLimitWithUnicodeDisabled() throws CIFSException {
+    public void batchLimitWithUnicodeDisabledShouldWork() throws CIFSException {
         Properties props = new Properties();
         props.setProperty("jcifs.client.useUnicode", "false");
         props.setProperty("jcifs.client.useBatching", "true");

--- a/src/test/java/org/codelibs/jcifs/smb/SmbPipeHandleTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/SmbPipeHandleTest.java
@@ -15,6 +15,7 @@ import java.io.OutputStream;
 
 import org.codelibs.jcifs.smb.impl.SmbPipeHandleInternal;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -53,29 +54,21 @@ public class SmbPipeHandleTest {
         when(smbPipeHandle.getOutput()).thenReturn(mockOutputStream);
     }
 
-    /**
-     * Tests that the getter for the underlying pipe resource returns the correct instance.
-     */
     @Test
-    public void testGetPipe() {
+    @DisplayName("Verify getPipe returns the correct underlying pipe resource")
+    public void shouldReturnCorrectPipeResource() {
         assertEquals(mockPipeResource, smbPipeHandle.getPipe(), "getPipe() should return the underlying pipe resource.");
     }
 
-    /**
-     * Tests that the getter for the input stream returns the correct stream.
-     * @throws CIFSException if an error occurs while getting the stream.
-     */
     @Test
-    public void testGetInputStream() throws CIFSException {
+    @DisplayName("Verify getInput returns the correct input stream")
+    public void shouldReturnCorrectInputStream() throws CIFSException {
         assertEquals(mockInputStream, smbPipeHandle.getInput(), "getInput() should return the correct input stream.");
     }
 
-    /**
-     * Tests that the getter for the output stream returns the correct stream.
-     * @throws CIFSException if an error occurs while getting the stream.
-     */
     @Test
-    public void testGetOutputStream() throws CIFSException {
+    @DisplayName("Verify getOutput returns the correct output stream")
+    public void shouldReturnCorrectOutputStream() throws CIFSException {
         assertEquals(mockOutputStream, smbPipeHandle.getOutput(), "getOutput() should return the correct output stream.");
     }
 
@@ -85,31 +78,24 @@ public class SmbPipeHandleTest {
     @Nested
     public class LifecycleManagementTest {
 
-        /**
-         * Verifies that the close method can be called without throwing an exception.
-         * @throws CIFSException if an error occurs during close.
-         */
         @Test
-        public void testClose() throws CIFSException {
+        @DisplayName("Verify close method can be called without throwing exception")
+        public void shouldCloseWithoutException() throws CIFSException {
             assertDoesNotThrow(() -> smbPipeHandle.close(), "close() should not throw an exception on a mock object.");
             // Verify that the close method was called
             Mockito.verify(smbPipeHandle).close();
         }
 
-        /**
-         * Verifies that the isOpen method returns true for an open handle.
-         */
         @Test
-        public void testIsOpen_ReturnsTrueWhenOpen() {
+        @DisplayName("Verify isOpen returns true when handle is open")
+        public void shouldReturnTrueWhenOpen() {
             when(smbPipeHandle.isOpen()).thenReturn(true);
             assertTrue(smbPipeHandle.isOpen(), "isOpen() should return true when the handle is open.");
         }
 
-        /**
-         * Verifies that the isOpen method returns false for a closed handle.
-         */
         @Test
-        public void testIsOpen_ReturnsFalseWhenClosed() {
+        @DisplayName("Verify isOpen returns false when handle is closed")
+        public void shouldReturnFalseWhenClosed() {
             when(smbPipeHandle.isOpen()).thenReturn(false);
             assertFalse(smbPipeHandle.isOpen(), "isOpen() should return false when the handle is closed.");
         }
@@ -121,20 +107,16 @@ public class SmbPipeHandleTest {
     @Nested
     public class HandleStateTest {
 
-        /**
-         * Verifies that isStale returns false for a fresh handle.
-         */
         @Test
-        public void testIsStale_ReturnsFalseWhenNotStale() {
+        @DisplayName("Verify isStale returns false for fresh handle")
+        public void shouldReturnFalseWhenNotStale() {
             when(smbPipeHandle.isStale()).thenReturn(false);
             assertFalse(smbPipeHandle.isStale(), "isStale() should return false for a fresh handle.");
         }
 
-        /**
-         * Verifies that isStale returns true for a stale handle.
-         */
         @Test
-        public void testIsStale_ReturnsTrueWhenStale() {
+        @DisplayName("Verify isStale returns true for stale handle")
+        public void shouldReturnTrueWhenStale() {
             when(smbPipeHandle.isStale()).thenReturn(true);
             assertTrue(smbPipeHandle.isStale(), "isStale() should return true for a stale handle.");
         }
@@ -146,21 +128,17 @@ public class SmbPipeHandleTest {
     @Nested
     public class UnwrapFunctionalityTest {
 
-        /**
-         * Verifies that unwrap returns the expected underlying object.
-         */
         @Test
-        public void testUnwrap() {
+        @DisplayName("Verify unwrap returns expected underlying object")
+        public void shouldUnwrapToExpectedType() {
             when(smbPipeHandle.unwrap(SmbPipeHandleInternal.class)).thenReturn(mockSmbPipeHandleInternal);
             SmbPipeHandleInternal unwrapped = smbPipeHandle.unwrap(SmbPipeHandleInternal.class);
             assertSame(mockSmbPipeHandleInternal, unwrapped, "Unwrap should return the underlying handle implementation.");
         }
 
-        /**
-         * Verifies that unwrap returns null if the requested type is not available.
-         */
         @Test
-        public void testUnwrap_ReturnsNullForUnsupportedType() {
+        @DisplayName("Verify unwrap returns null for unsupported type")
+        public void shouldReturnNullForUnsupportedType() {
             when(smbPipeHandle.unwrap(SmbPipeHandle.class)).thenReturn(null);
             assertNull(smbPipeHandle.unwrap(SmbPipeHandle.class), "Unwrap should return null for an unsupported type.");
         }
@@ -172,12 +150,9 @@ public class SmbPipeHandleTest {
     @Nested
     public class AutoCloseableContractTest {
 
-        /**
-         * Verifies that the handle is automatically closed in a try-with-resources statement.
-         * @throws Exception if an error occurs.
-         */
         @Test
-        public void testTryWithResources() throws Exception {
+        @DisplayName("Verify handle is automatically closed in try-with-resources")
+        public void shouldAutoCloseInTryWithResources() throws Exception {
             // This test ensures that any implementation of SmbPipeHandle can be used in a try-with-resources block.
             try (SmbPipeHandle handle = smbPipeHandle) {
                 // Perform operations with the handle

--- a/src/test/java/org/codelibs/jcifs/smb/context/AbstractCIFSContextTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/context/AbstractCIFSContextTest.java
@@ -144,7 +144,7 @@ class AbstractCIFSContextTest {
 
     @Test
     void testWithGuestCredentials() {
-        CIFSContext wrappedContext = context.withGuestCrendentials();
+        CIFSContext wrappedContext = context.withGuestCredentials();
 
         assertNotNull(wrappedContext);
         assertTrue(wrappedContext instanceof CIFSContextCredentialWrapper);

--- a/src/test/java/org/codelibs/jcifs/smb/context/CIFSContextWrapperTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/context/CIFSContextWrapperTest.java
@@ -200,11 +200,11 @@ class CIFSContextWrapperTest {
 
     @Test
     void testWithGuestCrendentials() {
-        // Test withGuestCrendentials() method
+        // Test withGuestCredentials() method
         CIFSContext mockNewContext = mock(CIFSContext.class);
-        when(mockDelegate.withGuestCrendentials()).thenReturn(mockNewContext);
-        assertEquals(mockNewContext, cifsContextWrapper.withGuestCrendentials());
-        verify(mockDelegate).withGuestCrendentials();
+        when(mockDelegate.withGuestCredentials()).thenReturn(mockNewContext);
+        assertEquals(mockNewContext, cifsContextWrapper.withGuestCredentials());
+        verify(mockDelegate).withGuestCredentials();
     }
 
     @Test

--- a/src/test/java/org/codelibs/jcifs/smb/http/NtlmSspTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/http/NtlmSspTest.java
@@ -21,6 +21,7 @@ import org.codelibs.jcifs.smb.NameServiceClient;
 import org.codelibs.jcifs.smb.NetbiosAddress;
 import org.codelibs.jcifs.smb.impl.NtlmPasswordAuthentication;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -210,7 +211,8 @@ public class NtlmSspTest {
      * @throws IOException
      */
     @Test
-    public void testAuthenticate_NoAuthorizationHeader() throws IOException {
+    @DisplayName("authenticate should return null and set WWW-Authenticate header when no authorization header")
+    public void authenticateWithNoAuthorizationHeader() throws IOException {
         // Setup: No "Authorization" header
         when(mockRequest.getHeader("Authorization")).thenReturn(null);
 
@@ -231,7 +233,8 @@ public class NtlmSspTest {
      * @throws IOException
      */
     @Test
-    public void testAuthenticate_Type1Message() throws IOException {
+    @DisplayName("authenticate should return null and set Type 2 message when Type 1 message provided")
+    public void authenticateWithType1Message() throws IOException {
         // Setup: "Authorization" header with a Type 1 message
         when(mockRequest.getHeader("Authorization")).thenReturn("NTLM " + type1MessageBase64);
 
@@ -272,7 +275,8 @@ public class NtlmSspTest {
      * @throws IOException
      */
     @Test
-    public void testAuthenticate_Type3Message() throws IOException {
+    @DisplayName("authenticate should return authentication when Type 3 message provided")
+    public void authenticateWithType3Message() throws IOException {
         // Setup: "Authorization" header with a Type 3 message
         when(mockRequest.getHeader("Authorization")).thenReturn("NTLM " + type3MessageBase64);
 
@@ -296,7 +300,8 @@ public class NtlmSspTest {
      * @throws IOException
      */
     @Test
-    public void testDoAuthentication() throws IOException {
+    @DisplayName("doAuthentication should handle authentication flow correctly")
+    public void doAuthenticationShouldHandleFlow() throws IOException {
         // Setup: No "Authorization" header to follow a simple path
         when(mockRequest.getHeader("Authorization")).thenReturn(null);
 

--- a/src/test/java/org/codelibs/jcifs/smb/internal/dfs/ReferralTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/dfs/ReferralTest.java
@@ -14,6 +14,7 @@ import java.nio.charset.StandardCharsets;
 import org.codelibs.jcifs.smb.RuntimeCIFSException;
 import org.codelibs.jcifs.smb.internal.smb1.trans2.Trans2GetDfsReferralResponse;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -33,7 +34,8 @@ public class ReferralTest {
     // Version 3 Referral Tests
 
     @Test
-    public void testDecodeVersion3WithoutNameList() {
+    @DisplayName("Decode version 3 referral without name list")
+    public void shouldDecodeVersion3WithoutNameList() {
         // Prepare test data
         ByteBuffer bb = ByteBuffer.wrap(testBuffer).order(ByteOrder.LITTLE_ENDIAN);
 
@@ -85,7 +87,8 @@ public class ReferralTest {
     }
 
     @Test
-    public void testDecodeVersion3WithNameList() {
+    @DisplayName("Decode version 3 referral with name list")
+    public void shouldDecodeVersion3WithNameList() {
         // Prepare test data
         ByteBuffer bb = ByteBuffer.wrap(testBuffer).order(ByteOrder.LITTLE_ENDIAN);
 
@@ -133,7 +136,8 @@ public class ReferralTest {
     }
 
     @Test
-    public void testVersion3WithZeroOffsets() {
+    @DisplayName("Handle version 3 referral with zero offsets")
+    public void shouldHandleVersion3WithZeroOffsets() {
         // Prepare test data with zero offsets
         ByteBuffer bb = ByteBuffer.wrap(testBuffer).order(ByteOrder.LITTLE_ENDIAN);
 
@@ -158,7 +162,8 @@ public class ReferralTest {
     }
 
     @Test
-    public void testVersion3WithEmptyExpandedNames() {
+    @DisplayName("Handle version 3 referral with empty expanded names")
+    public void shouldHandleVersion3WithEmptyExpandedNames() {
         ByteBuffer bb = ByteBuffer.wrap(testBuffer).order(ByteOrder.LITTLE_ENDIAN);
 
         bb.putShort((short) 3); // version
@@ -183,7 +188,8 @@ public class ReferralTest {
     // Version 1 Referral Tests
 
     @Test
-    public void testDecodeVersion1() {
+    @DisplayName("Decode version 1 referral correctly")
+    public void shouldDecodeVersion1Correctly() {
         // Prepare test data
         ByteBuffer bb = ByteBuffer.wrap(testBuffer).order(ByteOrder.LITTLE_ENDIAN);
 
@@ -219,7 +225,8 @@ public class ReferralTest {
     // Unsupported Version Tests
 
     @Test
-    public void testUnsupportedVersions() {
+    @DisplayName("Throw exception for unsupported versions")
+    public void shouldThrowExceptionForUnsupportedVersions() {
         int[] versions = { 0, 2, 4, 5, 100, 65535 };
         for (int version : versions) {
             ByteBuffer bb = ByteBuffer.wrap(testBuffer).order(ByteOrder.LITTLE_ENDIAN);
@@ -241,7 +248,8 @@ public class ReferralTest {
     // String Reading Tests
 
     @Test
-    public void testOddBufferIndexAlignment() {
+    @DisplayName("Handle odd buffer index alignment correctly")
+    public void shouldHandleOddBufferIndexAlignment() {
         // Create buffer with odd starting position
         ByteBuffer bb = ByteBuffer.wrap(testBuffer).order(ByteOrder.LITTLE_ENDIAN);
 
@@ -272,7 +280,8 @@ public class ReferralTest {
     }
 
     @Test
-    public void testUnicodeStringHandling() {
+    @DisplayName("Handle Unicode strings correctly")
+    public void shouldHandleUnicodeStrings() {
         ByteBuffer bb = ByteBuffer.wrap(testBuffer).order(ByteOrder.LITTLE_ENDIAN);
 
         bb.putShort((short) 3); // version
@@ -301,7 +310,8 @@ public class ReferralTest {
     // Debug Test
 
     @Test
-    public void testSimpleVersion3() {
+    @DisplayName("Decode simple version 3 referral")
+    public void shouldDecodeSimpleVersion3() {
         ByteBuffer bb = ByteBuffer.wrap(testBuffer).order(ByteOrder.LITTLE_ENDIAN);
 
         // Write the header
@@ -335,7 +345,8 @@ public class ReferralTest {
     // Getter Tests
 
     @Test
-    public void testGetters() {
+    @DisplayName("Verify all getter methods return correct values")
+    public void shouldReturnCorrectValuesFromGetters() {
         // Setup a complete referral
         ByteBuffer bb = ByteBuffer.wrap(testBuffer).order(ByteOrder.LITTLE_ENDIAN);
 
@@ -377,7 +388,8 @@ public class ReferralTest {
     // ToString Tests
 
     @Test
-    public void testToString() {
+    @DisplayName("Generate properly formatted toString output")
+    public void shouldGenerateProperToString() {
         ByteBuffer bb = ByteBuffer.wrap(testBuffer).order(ByteOrder.LITTLE_ENDIAN);
 
         bb.putShort((short) 3);
@@ -429,7 +441,8 @@ public class ReferralTest {
     }
 
     @Test
-    public void testToStringWithNulls() {
+    @DisplayName("Generate toString with null values")
+    public void shouldGenerateToStringWithNulls() {
         // Create minimal referral
         ByteBuffer bb = ByteBuffer.wrap(testBuffer).order(ByteOrder.LITTLE_ENDIAN);
 
@@ -452,7 +465,8 @@ public class ReferralTest {
     // Edge Cases and Boundary Tests
 
     @Test
-    public void testMaximumValues() {
+    @DisplayName("Handle maximum field values correctly")
+    public void shouldHandleMaximumValues() {
         ByteBuffer bb = ByteBuffer.wrap(testBuffer).order(ByteOrder.LITTLE_ENDIAN);
 
         bb.putShort((short) 3);
@@ -476,7 +490,8 @@ public class ReferralTest {
     }
 
     @Test
-    public void testEmptyStrings() {
+    @DisplayName("Handle empty string fields correctly")
+    public void shouldHandleEmptyStrings() {
         ByteBuffer bb = ByteBuffer.wrap(testBuffer).order(ByteOrder.LITTLE_ENDIAN);
 
         bb.putShort((short) 3);
@@ -505,7 +520,8 @@ public class ReferralTest {
     }
 
     @Test
-    public void testVariousFieldValues() {
+    @DisplayName("Handle various field value combinations")
+    public void shouldHandleVariousFieldValues() {
         int[][] testCases = { { 0, 0, 0 }, { 100, 200, 300 }, { 32767, 32767, 32767 }, { 65535, 65535, 65535 } };
 
         for (int[] testCase : testCases) {
@@ -537,7 +553,8 @@ public class ReferralTest {
     // Buffer Offset Tests
 
     @Test
-    public void testDecodeFromNonZeroIndex() {
+    @DisplayName("Decode referral from non-zero buffer index")
+    public void shouldDecodeFromNonZeroIndex() {
         int offset = 100;
         ByteBuffer bb = ByteBuffer.wrap(testBuffer).order(ByteOrder.LITTLE_ENDIAN);
 
@@ -557,7 +574,8 @@ public class ReferralTest {
     }
 
     @Test
-    public void testDifferentBufferLengths() {
+    @DisplayName("Handle different buffer lengths correctly")
+    public void shouldHandleDifferentBufferLengths() {
         ByteBuffer bb = ByteBuffer.wrap(testBuffer).order(ByteOrder.LITTLE_ENDIAN);
 
         bb.putShort((short) 1);
@@ -580,7 +598,8 @@ public class ReferralTest {
     // Multiple Expanded Names Tests
 
     @Test
-    public void testSingleExpandedName() {
+    @DisplayName("Handle single expanded name correctly")
+    public void shouldHandleSingleExpandedName() {
         ByteBuffer bb = ByteBuffer.wrap(testBuffer).order(ByteOrder.LITTLE_ENDIAN);
 
         bb.putShort((short) 3);
@@ -605,7 +624,8 @@ public class ReferralTest {
     }
 
     @Test
-    public void testManyExpandedNames() {
+    @DisplayName("Handle multiple expanded names correctly")
+    public void shouldHandleMultipleExpandedNames() {
         ByteBuffer bb = ByteBuffer.wrap(testBuffer).order(ByteOrder.LITTLE_ENDIAN);
 
         bb.putShort((short) 3);

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb1/com/ServerDataTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb1/com/ServerDataTest.java
@@ -34,7 +34,7 @@ public class ServerDataTest {
      */
     @Test
     @DisplayName("Test default constructor initializes fields with default values")
-    public void testDefaultConstructor() {
+    public void shouldInitializeFieldsWithDefaultValues() {
         // Then - verify all fields have default values
         assertEquals((byte) 0, serverData.sflags);
         assertEquals(0, serverData.sflags2);
@@ -63,7 +63,7 @@ public class ServerDataTest {
     @ParameterizedTest
     @ValueSource(bytes = { 0x00, 0x01, 0x7F, (byte) 0x80, (byte) 0xFF })
     @DisplayName("Test sflags field with various byte values")
-    public void testSflagsField(byte value) {
+    public void shouldHandleVariousByteValuesForSflags(byte value) {
         // When
         serverData.sflags = value;
 
@@ -76,7 +76,7 @@ public class ServerDataTest {
      */
     @Test
     @DisplayName("Test int fields with various values")
-    public void testIntFields() {
+    public void shouldHandleVariousIntFieldValues() {
         // When
         serverData.sflags2 = 0x12345678;
         serverData.smaxMpxCount = 50;
@@ -109,7 +109,7 @@ public class ServerDataTest {
      */
     @Test
     @DisplayName("Test boolean fields")
-    public void testBooleanFields() {
+    public void shouldHandleBooleanFields() {
         // When - set all to true
         serverData.encryptedPasswords = true;
         serverData.signaturesEnabled = true;
@@ -136,7 +136,7 @@ public class ServerDataTest {
      */
     @Test
     @DisplayName("Test oemDomainName field with various string values")
-    public void testOemDomainNameField() {
+    public void shouldHandleVariousStringValuesForOemDomainName() {
         // Test with normal string
         serverData.oemDomainName = "WORKGROUP";
         assertEquals("WORKGROUP", serverData.oemDomainName);
@@ -163,7 +163,7 @@ public class ServerDataTest {
      */
     @Test
     @DisplayName("Test serverTime field with various long values")
-    public void testServerTimeField() {
+    public void shouldHandleVariousLongValuesForServerTime() {
         // Test with zero
         serverData.serverTime = 0L;
         assertEquals(0L, serverData.serverTime);
@@ -190,7 +190,7 @@ public class ServerDataTest {
      */
     @Test
     @DisplayName("Test byte array fields (encryptionKey and guid)")
-    public void testByteArrayFields() {
+    public void shouldHandleByteArrayFields() {
         // Test encryptionKey
         byte[] key = new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
         serverData.encryptionKey = key;
@@ -220,7 +220,7 @@ public class ServerDataTest {
      */
     @Test
     @DisplayName("Test byte array reference behavior")
-    public void testByteArrayReference() {
+    public void shouldMaintainByteArrayReferenceBehavior() {
         // Given
         byte[] originalKey = new byte[] { 0x01, 0x02, 0x03, 0x04 };
         serverData.encryptionKey = originalKey;
@@ -238,7 +238,7 @@ public class ServerDataTest {
      */
     @Test
     @DisplayName("Test multiple instances are independent")
-    public void testMultipleInstancesIndependence() {
+    public void shouldMaintainInstanceIndependence() {
         // Given
         ServerData serverData1 = new ServerData();
         ServerData serverData2 = new ServerData();
@@ -270,7 +270,7 @@ public class ServerDataTest {
      */
     @Test
     @DisplayName("Test all fields are public")
-    public void testAllFieldsArePublic() {
+    public void shouldHaveAllFieldsPublic() {
         // Get all declared fields
         Field[] fields = ServerData.class.getDeclaredFields();
 
@@ -288,7 +288,7 @@ public class ServerDataTest {
      */
     @Test
     @DisplayName("Test typical server configuration scenario")
-    public void testTypicalServerConfiguration() {
+    public void shouldHandleTypicalServerConfiguration() {
         // Given - typical SMB server configuration
         serverData.sflags = (byte) 0x98;
         serverData.sflags2 = 0xC853; // Unicode, extended security, etc.
@@ -337,7 +337,7 @@ public class ServerDataTest {
      */
     @Test
     @DisplayName("Test edge cases for numeric fields")
-    public void testNumericFieldsEdgeCases() {
+    public void shouldHandleNumericFieldsEdgeCases() {
         // Test maximum values for int fields
         serverData.sflags2 = Integer.MAX_VALUE;
         serverData.smaxMpxCount = Integer.MAX_VALUE;
@@ -370,7 +370,7 @@ public class ServerDataTest {
      */
     @Test
     @DisplayName("Test large byte arrays")
-    public void testLargeByteArrays() {
+    public void shouldHandleLargeByteArrays() {
         // Test with large encryption key
         byte[] largeKey = new byte[256];
         for (int i = 0; i < largeKey.length; i++) {
@@ -399,7 +399,7 @@ public class ServerDataTest {
      */
     @Test
     @DisplayName("Test ServerData can be used in collections")
-    public void testUseInCollections() {
+    public void shouldWorkInCollections() {
         // Given
         java.util.List<ServerData> serverList = new java.util.ArrayList<>();
 
@@ -423,7 +423,7 @@ public class ServerDataTest {
      */
     @Test
     @DisplayName("Test field types are correct")
-    public void testFieldTypes() throws NoSuchFieldException {
+    public void shouldHaveCorrectFieldTypes() throws NoSuchFieldException {
         // Verify field types
         assertEquals(byte.class, ServerData.class.getDeclaredField("sflags").getType());
         assertEquals(int.class, ServerData.class.getDeclaredField("sflags2").getType());

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb1/com/SmbComCloseTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb1/com/SmbComCloseTest.java
@@ -15,6 +15,7 @@ import org.codelibs.jcifs.smb.internal.smb1.SMB1SigningDigest;
 import org.codelibs.jcifs.smb.internal.smb1.ServerMessageBlock;
 import org.codelibs.jcifs.smb.internal.util.SMBUtil;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -34,11 +35,9 @@ public class SmbComCloseTest {
         when(context.getConfig()).thenReturn(config);
     }
 
-    /**
-     * Test method for {@link org.codelibs.jcifs.smb.internal.smb1.com.SmbComClose#SmbComClose(org.codelibs.jcifs.smb.Configuration, int, long)}.
-     */
     @Test
-    public void testConstructor() {
+    @DisplayName("Verify constructor initializes SmbComClose with correct command")
+    public void shouldInitializeWithCorrectCommand() {
         // Given
         int fid = 123;
         long lastWriteTime = System.currentTimeMillis();
@@ -51,11 +50,9 @@ public class SmbComCloseTest {
         // Private fields are not directly accessible, but we can check their effect in other methods.
     }
 
-    /**
-     * Test method for {@link org.codelibs.jcifs.smb.internal.smb1.com.SmbComClose#writeParameterWordsWireFormat(byte[], int)}.
-     */
     @Test
-    public void testWriteParameterWordsWireFormat() {
+    @DisplayName("Verify writeParameterWordsWireFormat writes FID correctly")
+    public void shouldWriteFidCorrectly() {
         // Given
         int fid = 456;
         long lastWriteTime = System.currentTimeMillis();
@@ -72,11 +69,9 @@ public class SmbComCloseTest {
         assertEquals(0, SMBUtil.readInt4(dst, 2));
     }
 
-    /**
-     * Test method for {@link org.codelibs.jcifs.smb.internal.smb1.com.SmbComClose#writeParameterWordsWireFormat(byte[], int)} with a signing digest.
-     */
     @Test
-    public void testWriteParameterWordsWireFormatWithDigest() {
+    @DisplayName("Verify writeParameterWordsWireFormat handles signing digest correctly")
+    public void shouldHandleSigningDigestCorrectly() {
         // Given
         int fid = 789;
         long lastWriteTime = System.currentTimeMillis();
@@ -99,11 +94,9 @@ public class SmbComCloseTest {
         assertTrue(writtenTime != 0 || lastWriteTime == 0);
     }
 
-    /**
-     * Test method for {@link org.codelibs.jcifs.smb.internal.smb1.com.SmbComClose#writeBytesWireFormat(byte[], int)}.
-     */
     @Test
-    public void testWriteBytesWireFormat() {
+    @DisplayName("Verify writeBytesWireFormat returns zero bytes written")
+    public void shouldReturnZeroBytesWritten() {
         // Given
         SmbComClose smbComClose = new SmbComClose(config, 1, 1L);
         byte[] dst = new byte[0];
@@ -115,11 +108,9 @@ public class SmbComCloseTest {
         assertEquals(0, bytesWritten);
     }
 
-    /**
-     * Test method for {@link org.codelibs.jcifs.smb.internal.smb1.com.SmbComClose#readParameterWordsWireFormat(byte[], int)}.
-     */
     @Test
-    public void testReadParameterWordsWireFormat() {
+    @DisplayName("Verify readParameterWordsWireFormat returns zero bytes read")
+    public void shouldReturnZeroBytesReadFromParameters() {
         // Given
         SmbComClose smbComClose = new SmbComClose(config, 1, 1L);
         byte[] buffer = new byte[0];
@@ -131,11 +122,9 @@ public class SmbComCloseTest {
         assertEquals(0, bytesRead);
     }
 
-    /**
-     * Test method for {@link org.codelibs.jcifs.smb.internal.smb1.com.SmbComClose#readBytesWireFormat(byte[], int)}.
-     */
     @Test
-    public void testReadBytesWireFormat() {
+    @DisplayName("Verify readBytesWireFormat returns zero bytes read")
+    public void shouldReturnZeroBytesReadFromBytes() {
         // Given
         SmbComClose smbComClose = new SmbComClose(config, 1, 1L);
         byte[] buffer = new byte[0];
@@ -147,11 +136,9 @@ public class SmbComCloseTest {
         assertEquals(0, bytesRead);
     }
 
-    /**
-     * Test method for {@link org.codelibs.jcifs.smb.internal.smb1.com.SmbComClose#toString()}.
-     */
     @Test
-    public void testToString() {
+    @DisplayName("Verify toString returns formatted string with FID and lastWriteTime")
+    public void shouldReturnFormattedString() {
         // Given
         int fid = 999;
         long lastWriteTime = 1672531200000L; // 2023-01-01 00:00:00 UTC
@@ -167,11 +154,9 @@ public class SmbComCloseTest {
         assertTrue(result.endsWith("]"));
     }
 
-    /**
-     * Test method for {@link org.codelibs.jcifs.smb.internal.smb1.com.SmbComClose#getResponse()}.
-     */
     @Test
-    public void testGetResponse() {
+    @DisplayName("Verify getResponse returns the set response object")
+    public void shouldReturnSetResponseObject() {
         // Given
         SmbComClose smbComClose = new SmbComClose(config, 1, 1L);
         SmbComBlankResponse expectedResponse = new SmbComBlankResponse(config);
@@ -184,11 +169,9 @@ public class SmbComCloseTest {
         assertEquals(expectedResponse, actualResponse);
     }
 
-    /**
-     * Test method for {@link org.codelibs.jcifs.smb.internal.smb1.com.SmbComClose#initResponse(org.codelibs.jcifs.smb.CIFSContext)}.
-     */
     @Test
-    public void testInitResponse() {
+    @DisplayName("Verify initResponse creates and sets new blank response")
+    public void shouldCreateAndSetNewBlankResponse() {
         // Given
         SmbComClose smbComClose = new SmbComClose(config, 1, 1L);
 

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb1/com/SmbComNegotiateResponseTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb1/com/SmbComNegotiateResponseTest.java
@@ -21,6 +21,7 @@ import org.codelibs.jcifs.smb.internal.SmbNegotiationRequest;
 import org.codelibs.jcifs.smb.internal.util.SMBUtil;
 import org.codelibs.jcifs.smb.util.Hexdump;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
@@ -43,13 +44,15 @@ public class SmbComNegotiateResponseTest {
     }
 
     @Test
-    public void testConstructor() {
+    @DisplayName("Verify constructor initializes response with correct dialect")
+    public void shouldInitializeWithCorrectDialect() {
         assertNotNull(response);
         assertEquals(DialectVersion.SMB1, response.getSelectedDialect());
     }
 
     @Test
-    public void testReadParameterWordsWireFormat() {
+    @DisplayName("Verify readParameterWordsWireFormat parses negotiate response parameters")
+    public void shouldParseNegotiateResponseParameters() {
         byte[] buffer = new byte[34];
         int bufferIndex = 0;
 
@@ -109,7 +112,8 @@ public class SmbComNegotiateResponseTest {
     }
 
     @Test
-    public void testReadBytesWireFormatWithoutExtendedSecurity() throws UnsupportedEncodingException {
+    @DisplayName("Verify readBytesWireFormat handles non-extended security mode")
+    public void shouldHandleNonExtendedSecurityMode() throws UnsupportedEncodingException {
         response.getServerData().scapabilities = 0;
         response.getServerData().encryptionKeyLength = 8;
         // Domain name in OEM encoding (ASCII) with null terminator
@@ -131,7 +135,8 @@ public class SmbComNegotiateResponseTest {
     }
 
     @Test
-    public void testReadBytesWireFormatWithUnicode() throws UnsupportedEncodingException {
+    @DisplayName("Verify readBytesWireFormat handles Unicode encoding")
+    public void shouldHandleUnicodeEncoding() throws UnsupportedEncodingException {
         response.getServerData().scapabilities = SmbConstants.CAP_UNICODE;
         response.getServerData().encryptionKeyLength = 8;
         // Set Unicode flag to use Unicode encoding
@@ -155,7 +160,8 @@ public class SmbComNegotiateResponseTest {
     }
 
     @Test
-    public void testReadBytesWireFormatWithExtendedSecurity() {
+    @DisplayName("Verify readBytesWireFormat handles extended security mode")
+    public void shouldHandleExtendedSecurityMode() {
         response.getServerData().scapabilities = SmbConstants.CAP_EXTENDED_SECURITY;
         // Use reflection to set protected byteCount field
         int byteCountValue = 16 + 10; // guid + token
@@ -181,7 +187,8 @@ public class SmbComNegotiateResponseTest {
     }
 
     @Test
-    public void testIsValid() {
+    @DisplayName("Verify isValid returns true for valid response with signing")
+    public void shouldReturnTrueForValidResponseWithSigning() {
         SmbNegotiationRequest request = mock(SmbNegotiationRequest.class);
         when(request.isSigningEnforced()).thenReturn(true);
         response.getServerData().signaturesEnabled = true;
@@ -192,7 +199,8 @@ public class SmbComNegotiateResponseTest {
     }
 
     @Test
-    public void testIsValidWithUnicode() {
+    @DisplayName("Verify isValid handles Unicode capability correctly")
+    public void shouldHandleUnicodeCapabilityCorrectly() {
         SmbNegotiationRequest request = mock(SmbNegotiationRequest.class);
         response.getServerData().scapabilities = SmbConstants.CAP_UNICODE;
         // Set some required server data for valid response
@@ -205,7 +213,8 @@ public class SmbComNegotiateResponseTest {
     }
 
     @Test
-    public void testIsValidWithInvalidDialect() {
+    @DisplayName("Verify isValid returns false for invalid dialect index")
+    public void shouldReturnFalseForInvalidDialect() {
         SmbNegotiationRequest request = mock(SmbNegotiationRequest.class);
         // Use reflection to set private dialectIndex field
         setDialectIndex(response, 11);
@@ -213,7 +222,8 @@ public class SmbComNegotiateResponseTest {
     }
 
     @Test
-    public void testToString() {
+    @DisplayName("Verify toString returns properly formatted response string")
+    public void shouldReturnFormattedResponseString() {
         response.getServerData().securityMode = 1;
         response.getServerData().encryptedPasswords = true;
         response.getServerData().smaxMpxCount = 50;

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb1/com/SmbComRenameTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb1/com/SmbComRenameTest.java
@@ -39,7 +39,7 @@ public class SmbComRenameTest {
      */
     @Test
     @DisplayName("Test constructor initializes fields correctly")
-    public void testConstructor() throws Exception {
+    public void shouldInitializeFieldsCorrectly() throws Exception {
         // Given
         String oldFileName = "oldFile.txt";
         String newFileName = "newFile.txt";
@@ -70,7 +70,7 @@ public class SmbComRenameTest {
      */
     @Test
     @DisplayName("Test writeParameterWordsWireFormat writes search attributes correctly")
-    public void testWriteParameterWordsWireFormat() {
+    public void shouldWriteSearchAttributesCorrectly() {
         // Given
         byte[] dst = new byte[10];
         smbComRename = new SmbComRename(config, "old.txt", "new.txt");
@@ -93,7 +93,7 @@ public class SmbComRenameTest {
      */
     @Test
     @DisplayName("Test writeBytesWireFormat writes file names correctly in ASCII")
-    public void testWriteBytesWireFormatAscii() throws Exception {
+    public void shouldWriteFileNamesInAscii() throws Exception {
         // Given
         String oldFileName = "oldFile.txt";
         String newFileName = "newFile.txt";
@@ -124,7 +124,7 @@ public class SmbComRenameTest {
      */
     @Test
     @DisplayName("Test writeBytesWireFormat writes file names correctly in Unicode")
-    public void testWriteBytesWireFormatUnicode() throws Exception {
+    public void shouldWriteFileNamesInUnicode() throws Exception {
         // Given
         String oldFileName = "oldFile.txt";
         String newFileName = "newFile.txt";
@@ -165,7 +165,7 @@ public class SmbComRenameTest {
      */
     @Test
     @DisplayName("Test writeBytesWireFormat with empty file names")
-    public void testWriteBytesWireFormatEmptyFileNames() {
+    public void shouldHandleEmptyFileNames() {
         // Given
         byte[] dst = new byte[100];
         smbComRename = new SmbComRename(config, "", "");
@@ -186,7 +186,7 @@ public class SmbComRenameTest {
      */
     @Test
     @DisplayName("Test writeBytesWireFormat with special characters in file names")
-    public void testWriteBytesWireFormatSpecialCharacters() {
+    public void shouldHandleSpecialCharactersInFileNames() {
         // Given
         String oldFileName = "file with spaces.txt";
         String newFileName = "file@#$%.doc";
@@ -207,7 +207,7 @@ public class SmbComRenameTest {
      */
     @Test
     @DisplayName("Test readParameterWordsWireFormat always returns 0")
-    public void testReadParameterWordsWireFormat() {
+    public void shouldAlwaysReturnZeroForReadParameterWords() {
         // Given
         byte[] buffer = new byte[10];
         smbComRename = new SmbComRename(config, "old.txt", "new.txt");
@@ -224,7 +224,7 @@ public class SmbComRenameTest {
      */
     @Test
     @DisplayName("Test readBytesWireFormat always returns 0")
-    public void testReadBytesWireFormat() {
+    public void shouldAlwaysReturnZeroForReadBytes() {
         // Given
         byte[] buffer = new byte[10];
         smbComRename = new SmbComRename(config, "old.txt", "new.txt");
@@ -241,7 +241,7 @@ public class SmbComRenameTest {
      */
     @Test
     @DisplayName("Test toString returns properly formatted string")
-    public void testToString() {
+    public void shouldReturnProperlyFormattedString() {
         // Given
         String oldFileName = "oldFile.txt";
         String newFileName = "newFile.txt";
@@ -263,7 +263,7 @@ public class SmbComRenameTest {
      */
     @Test
     @DisplayName("Test constructor with null configuration throws NullPointerException")
-    public void testConstructorWithNullConfig() {
+    public void shouldThrowNullPointerExceptionForNullConfig() {
         // Given
         String oldFileName = "old.txt";
         String newFileName = "new.txt";
@@ -279,7 +279,7 @@ public class SmbComRenameTest {
      */
     @Test
     @DisplayName("Test constructor with null file names")
-    public void testConstructorWithNullFileNames() {
+    public void shouldAcceptNullFileNames() {
         // When & Then - should not throw exception during construction
         assertDoesNotThrow(() -> {
             new SmbComRename(config, null, null);
@@ -291,7 +291,7 @@ public class SmbComRenameTest {
      */
     @Test
     @DisplayName("Test writeBytesWireFormat with very long file names")
-    public void testWriteBytesWireFormatLongFileNames() {
+    public void shouldHandleLongFileNames() {
         // Given
         String longOldFileName = "a".repeat(255); // Max filename length
         String longNewFileName = "b".repeat(255);
@@ -313,7 +313,7 @@ public class SmbComRenameTest {
      */
     @Test
     @DisplayName("Test writeBytesWireFormat with different buffer offsets")
-    public void testWriteBytesWireFormatWithOffset() {
+    public void shouldHandleDifferentBufferOffsets() {
         // Given
         String oldFileName = "old.txt";
         String newFileName = "new.txt";
@@ -334,7 +334,7 @@ public class SmbComRenameTest {
      */
     @Test
     @DisplayName("Test search attributes include HIDDEN, SYSTEM, and DIRECTORY")
-    public void testSearchAttributesValue() throws Exception {
+    public void shouldIncludeRequiredSearchAttributes() throws Exception {
         // Given
         smbComRename = new SmbComRename(config, "old.txt", "new.txt");
 
@@ -354,7 +354,7 @@ public class SmbComRenameTest {
      */
     @Test
     @DisplayName("Test writeString handles path separators correctly")
-    public void testWriteStringWithPathSeparators() {
+    public void shouldHandlePathSeparatorsCorrectly() {
         // Given
         String oldFileName = "folder\\oldFile.txt";
         String newFileName = "folder\\newFile.txt";

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb1/com/SmbComTreeDisconnectTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb1/com/SmbComTreeDisconnectTest.java
@@ -44,7 +44,7 @@ public class SmbComTreeDisconnectTest {
      */
     @Test
     @DisplayName("Test constructor initializes with correct command")
-    public void testConstructorWithValidConfig() {
+    public void shouldInitializeWithCorrectCommand() {
         // When
         smbComTreeDisconnect = new SmbComTreeDisconnect(config);
 
@@ -58,7 +58,7 @@ public class SmbComTreeDisconnectTest {
      */
     @Test
     @DisplayName("Test constructor throws NullPointerException with null configuration")
-    public void testConstructorWithNullConfig() {
+    public void shouldThrowNullPointerExceptionWithNullConfig() {
         // When & Then - should throw NullPointerException since ServerMessageBlock calls config.getPid()
         NullPointerException exception = assertThrows(NullPointerException.class, () -> {
             smbComTreeDisconnect = new SmbComTreeDisconnect(null);
@@ -73,7 +73,7 @@ public class SmbComTreeDisconnectTest {
      */
     @Test
     @DisplayName("Test constructor with mock configuration")
-    public void testConstructorWithMockConfig() {
+    public void shouldWorkWithMockConfiguration() {
         // Setup mock to return a valid PID
         when(mockConfig.getPid()).thenReturn(1234);
 
@@ -91,7 +91,7 @@ public class SmbComTreeDisconnectTest {
      */
     @Test
     @DisplayName("Test writeParameterWordsWireFormat always returns 0")
-    public void testWriteParameterWordsWireFormat() {
+    public void shouldAlwaysReturnZeroForWriteParameterWords() {
         // Given
         smbComTreeDisconnect = new SmbComTreeDisconnect(config);
         byte[] dst = new byte[100];
@@ -109,7 +109,7 @@ public class SmbComTreeDisconnectTest {
      */
     @Test
     @DisplayName("Test writeParameterWordsWireFormat with different buffer sizes")
-    public void testWriteParameterWordsWireFormatWithDifferentBufferSizes() {
+    public void shouldHandleDifferentBufferSizesForWriteParameterWords() {
         // Given
         smbComTreeDisconnect = new SmbComTreeDisconnect(config);
         int[] bufferSizes = { 0, 10, 50, 100, 1024 };
@@ -130,7 +130,7 @@ public class SmbComTreeDisconnectTest {
      */
     @Test
     @DisplayName("Test writeParameterWordsWireFormat with different offsets")
-    public void testWriteParameterWordsWireFormatWithDifferentOffsets() {
+    public void shouldHandleDifferentOffsetsForWriteParameterWords() {
         // Given
         smbComTreeDisconnect = new SmbComTreeDisconnect(config);
         byte[] dst = new byte[200];
@@ -150,7 +150,7 @@ public class SmbComTreeDisconnectTest {
      */
     @Test
     @DisplayName("Test writeBytesWireFormat always returns 0")
-    public void testWriteBytesWireFormat() {
+    public void shouldAlwaysReturnZeroForWriteBytes() {
         // Given
         smbComTreeDisconnect = new SmbComTreeDisconnect(config);
         byte[] dst = new byte[100];
@@ -168,7 +168,7 @@ public class SmbComTreeDisconnectTest {
      */
     @Test
     @DisplayName("Test writeBytesWireFormat with different buffer sizes")
-    public void testWriteBytesWireFormatWithDifferentBufferSizes() {
+    public void shouldHandleDifferentBufferSizesForWriteBytes() {
         // Given
         smbComTreeDisconnect = new SmbComTreeDisconnect(config);
         int[] bufferSizes = { 0, 10, 50, 100, 1024 };
@@ -189,7 +189,7 @@ public class SmbComTreeDisconnectTest {
      */
     @Test
     @DisplayName("Test writeBytesWireFormat with different offsets")
-    public void testWriteBytesWireFormatWithDifferentOffsets() {
+    public void shouldHandleDifferentOffsetsForWriteBytes() {
         // Given
         smbComTreeDisconnect = new SmbComTreeDisconnect(config);
         byte[] dst = new byte[200];
@@ -209,7 +209,7 @@ public class SmbComTreeDisconnectTest {
      */
     @Test
     @DisplayName("Test readParameterWordsWireFormat always returns 0")
-    public void testReadParameterWordsWireFormat() {
+    public void shouldAlwaysReturnZeroForReadParameterWords() {
         // Given
         smbComTreeDisconnect = new SmbComTreeDisconnect(config);
         byte[] buffer = new byte[100];
@@ -227,7 +227,7 @@ public class SmbComTreeDisconnectTest {
      */
     @Test
     @DisplayName("Test readParameterWordsWireFormat with different buffer sizes")
-    public void testReadParameterWordsWireFormatWithDifferentBufferSizes() {
+    public void shouldHandleDifferentBufferSizesForReadParameterWords() {
         // Given
         smbComTreeDisconnect = new SmbComTreeDisconnect(config);
         int[] bufferSizes = { 0, 10, 50, 100, 1024 };
@@ -248,7 +248,7 @@ public class SmbComTreeDisconnectTest {
      */
     @Test
     @DisplayName("Test readBytesWireFormat always returns 0")
-    public void testReadBytesWireFormat() {
+    public void shouldAlwaysReturnZeroForReadBytes() {
         // Given
         smbComTreeDisconnect = new SmbComTreeDisconnect(config);
         byte[] buffer = new byte[100];
@@ -266,7 +266,7 @@ public class SmbComTreeDisconnectTest {
      */
     @Test
     @DisplayName("Test readBytesWireFormat with different buffer sizes")
-    public void testReadBytesWireFormatWithDifferentBufferSizes() {
+    public void shouldHandleDifferentBufferSizesForReadBytes() {
         // Given
         smbComTreeDisconnect = new SmbComTreeDisconnect(config);
         int[] bufferSizes = { 0, 10, 50, 100, 1024 };
@@ -287,7 +287,7 @@ public class SmbComTreeDisconnectTest {
      */
     @Test
     @DisplayName("Test toString returns properly formatted string")
-    public void testToString() {
+    public void shouldReturnProperlyFormattedString() {
         // Given
         smbComTreeDisconnect = new SmbComTreeDisconnect(config);
 
@@ -306,7 +306,7 @@ public class SmbComTreeDisconnectTest {
      */
     @Test
     @DisplayName("Test toString requires valid configuration")
-    public void testToStringRequiresValidConfig() {
+    public void shouldRequireValidConfigurationForToString() {
         // Constructor with null config throws exception, so we can't test toString with null config
         // Instead, test that toString works with a valid config
 
@@ -328,7 +328,7 @@ public class SmbComTreeDisconnectTest {
      */
     @Test
     @DisplayName("Test SMB_COM_TREE_DISCONNECT command value is 0x71")
-    public void testCommandValue() {
+    public void shouldHaveCorrectCommandValue() {
         // Given
         smbComTreeDisconnect = new SmbComTreeDisconnect(config);
 
@@ -349,7 +349,7 @@ public class SmbComTreeDisconnectTest {
 
         @Test
         @DisplayName("Test write operations with empty buffer")
-        public void testWriteOperationsWithEmptyBuffer() {
+        public void shouldHandleWriteOperationsWithEmptyBuffer() {
             // Given
             smbComTreeDisconnect = new SmbComTreeDisconnect(config);
             byte[] emptyBuffer = new byte[0];
@@ -363,7 +363,7 @@ public class SmbComTreeDisconnectTest {
 
         @Test
         @DisplayName("Test read operations with empty buffer")
-        public void testReadOperationsWithEmptyBuffer() {
+        public void shouldHandleReadOperationsWithEmptyBuffer() {
             // Given
             smbComTreeDisconnect = new SmbComTreeDisconnect(config);
             byte[] emptyBuffer = new byte[0];
@@ -377,7 +377,7 @@ public class SmbComTreeDisconnectTest {
 
         @Test
         @DisplayName("Test operations with null buffer")
-        public void testOperationsWithNullBuffer() {
+        public void shouldHandleOperationsWithNullBuffer() {
             // Given
             smbComTreeDisconnect = new SmbComTreeDisconnect(config);
 
@@ -390,7 +390,7 @@ public class SmbComTreeDisconnectTest {
 
         @Test
         @DisplayName("Test buffer operations do not modify buffer contents")
-        public void testBufferContentsNotModified() {
+        public void shouldNotModifyBufferContents() {
             // Given
             smbComTreeDisconnect = new SmbComTreeDisconnect(config);
             byte[] originalBuffer = new byte[100];
@@ -415,7 +415,7 @@ public class SmbComTreeDisconnectTest {
      */
     @Test
     @DisplayName("Test inheritance from ServerMessageBlock")
-    public void testInheritance() {
+    public void shouldInheritFromServerMessageBlock() {
         // Given
         smbComTreeDisconnect = new SmbComTreeDisconnect(config);
 
@@ -428,7 +428,7 @@ public class SmbComTreeDisconnectTest {
      */
     @Test
     @DisplayName("Test multiple instances are independent")
-    public void testMultipleInstancesIndependence() {
+    public void shouldMaintainIndependentInstances() {
         // Setup mock to return a valid PID
         when(mockConfig.getPid()).thenReturn(5678);
 
@@ -447,7 +447,7 @@ public class SmbComTreeDisconnectTest {
      */
     @Test
     @DisplayName("Test thread safety of operations")
-    public void testThreadSafety() throws InterruptedException {
+    public void shouldBeThreadSafe() throws InterruptedException {
         // Given
         smbComTreeDisconnect = new SmbComTreeDisconnect(config);
         byte[] buffer = new byte[1000];
@@ -484,7 +484,7 @@ public class SmbComTreeDisconnectTest {
      */
     @Test
     @DisplayName("Test consistency across multiple calls")
-    public void testConsistencyAcrossMultipleCalls() {
+    public void shouldMaintainConsistencyAcrossMultipleCalls() {
         // Given
         smbComTreeDisconnect = new SmbComTreeDisconnect(config);
         byte[] buffer = new byte[100];
@@ -503,7 +503,7 @@ public class SmbComTreeDisconnectTest {
      */
     @Test
     @DisplayName("Test boundary conditions for buffer indices")
-    public void testBoundaryConditions() {
+    public void shouldHandleBoundaryConditions() {
         // Given
         smbComTreeDisconnect = new SmbComTreeDisconnect(config);
         byte[] buffer = new byte[100];
@@ -526,7 +526,7 @@ public class SmbComTreeDisconnectTest {
      */
     @Test
     @DisplayName("Test methods are properly overridden from parent class")
-    public void testMethodOverrides() throws NoSuchMethodException {
+    public void shouldProperlyOverrideMethods() throws NoSuchMethodException {
         // Given
         Class<?> clazz = SmbComTreeDisconnect.class;
 

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb1/com/SmbComWriteAndXResponseTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb1/com/SmbComWriteAndXResponseTest.java
@@ -10,6 +10,7 @@ import org.codelibs.jcifs.smb.CIFSException;
 import org.codelibs.jcifs.smb.Configuration;
 import org.codelibs.jcifs.smb.config.PropertyConfiguration;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class SmbComWriteAndXResponseTest {
@@ -21,11 +22,9 @@ public class SmbComWriteAndXResponseTest {
         config = new PropertyConfiguration(new Properties());
     }
 
-    /**
-     * Test of readParameterWordsWireFormat method
-     */
     @Test
-    public void testReadParameterWordsWireFormat() {
+    @DisplayName("readParameterWordsWireFormat should read count correctly")
+    public void readParameterWordsWireFormatShouldReadCount() {
         // Given
         byte[] buffer = new byte[] { (byte) 0xff, (byte) 0xff, 0, 0, 0, 0, 0, 0 };
         SmbComWriteAndXResponse instance = new SmbComWriteAndXResponse(config);
@@ -38,11 +37,9 @@ public class SmbComWriteAndXResponseTest {
         assertEquals(0xffffL, instance.getCount());
     }
 
-    /**
-     * Test of readParameterWordsWireFormat with zero count
-     */
     @Test
-    public void testReadParameterWordsWireFormatZeroCount() {
+    @DisplayName("readParameterWordsWireFormat should handle zero count")
+    public void readParameterWordsWireFormatShouldHandleZeroCount() {
         // Given
         byte[] buffer = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 };
         SmbComWriteAndXResponse instance = new SmbComWriteAndXResponse(config);
@@ -55,11 +52,9 @@ public class SmbComWriteAndXResponseTest {
         assertEquals(0L, instance.getCount());
     }
 
-    /**
-     * Test of writeParameterWordsWireFormat method
-     */
     @Test
-    public void testWriteParameterWordsWireFormat() {
+    @DisplayName("writeParameterWordsWireFormat should return 0")
+    public void writeParameterWordsWireFormatShouldReturnZero() {
         // Given
         byte[] buffer = new byte[10];
         SmbComWriteAndXResponse instance = new SmbComWriteAndXResponse(config);
@@ -71,11 +66,9 @@ public class SmbComWriteAndXResponseTest {
         assertEquals(0, result);
     }
 
-    /**
-     * Test of writeBytesWireFormat method
-     */
     @Test
-    public void testWriteBytesWireFormat() {
+    @DisplayName("writeBytesWireFormat should return 0")
+    public void writeBytesWireFormatShouldReturnZero() {
         // Given
         byte[] buffer = new byte[10];
         SmbComWriteAndXResponse instance = new SmbComWriteAndXResponse(config);
@@ -87,11 +80,9 @@ public class SmbComWriteAndXResponseTest {
         assertEquals(0, result);
     }
 
-    /**
-     * Test of readBytesWireFormat method
-     */
     @Test
-    public void testReadBytesWireFormat() {
+    @DisplayName("readBytesWireFormat should return 0")
+    public void readBytesWireFormatShouldReturnZero() {
         // Given
         byte[] buffer = new byte[10];
         SmbComWriteAndXResponse instance = new SmbComWriteAndXResponse(config);
@@ -103,11 +94,9 @@ public class SmbComWriteAndXResponseTest {
         assertEquals(0, result);
     }
 
-    /**
-     * Test of toString method
-     */
     @Test
-    public void testToString() {
+    @DisplayName("toString should contain class name and count")
+    public void toStringShouldContainClassNameAndCount() {
         // Given
         SmbComWriteAndXResponse instance = new SmbComWriteAndXResponse(config);
 

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb1/com/SmbComWriteResponseTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb1/com/SmbComWriteResponseTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 
 import org.codelibs.jcifs.smb.Configuration;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -24,12 +25,14 @@ public class SmbComWriteResponseTest {
     }
 
     @Test
-    public void testInitialCountIsZero() {
+    @DisplayName("Initial count should be zero")
+    public void initialCountShouldBeZero() {
         assertEquals(0, resp.getCount(), "Initial count should be zero");
     }
 
     @Test
-    public void testReadParameterWordsUpdatesCount() {
+    @DisplayName("readParameterWords should update count from buffer")
+    public void readParameterWordsShouldUpdateCount() {
         // create a buffer with count = 0x1234 (4660 decimal)
         // Using little-endian byte order as per SMBUtil.readInt2
         byte[] buf = new byte[12];
@@ -42,7 +45,8 @@ public class SmbComWriteResponseTest {
     }
 
     @Test
-    public void testToStringContainsCount() {
+    @DisplayName("toString should include numeric count value")
+    public void toStringShouldIncludeCount() {
         // Little-endian: count = 512 (0x0200)
         byte[] buf = new byte[12];
         buf[0] = 0x00;
@@ -53,7 +57,8 @@ public class SmbComWriteResponseTest {
     }
 
     @Test
-    public void testReturnFromReadParameterWordsWireFormatIs8() {
+    @DisplayName("readParameterWordsWireFormat should return 8 bytes processed")
+    public void readParameterWordsWireFormatShouldReturn8() {
         // ensure the method returns 8 as claimed
         byte[] buf = new byte[12];
         buf[0] = 0x00;

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb1/net/TestSmbComTransactionResponseReader.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb1/net/TestSmbComTransactionResponseReader.java
@@ -10,6 +10,7 @@ import org.codelibs.jcifs.smb.Configuration;
 import org.codelibs.jcifs.smb.SmbConstants;
 import org.codelibs.jcifs.smb.config.BaseConfiguration;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -43,19 +44,22 @@ public class TestSmbComTransactionResponseReader {
     }
 
     @Test
-    public void testUnicodeConfiguration() throws Exception {
+    @DisplayName("Verify Unicode configuration is enabled by default")
+    public void shouldHaveUnicodeEnabledByDefault() throws Exception {
         // Test Unicode configuration is enabled by default
         assertTrue(cfg.isUseUnicode(), "Unicode should be enabled by default");
     }
 
     @Test
-    public void testAsciiConfiguration() throws Exception {
+    @DisplayName("Verify ASCII configuration disables Unicode support")
+    public void shouldDisableUnicodeInAsciiConfig() throws Exception {
         Configuration asciiCfg = new OffUnicodeConfig();
         assertFalse(asciiCfg.isUseUnicode(), "Unicode should be disabled in ASCII config");
     }
 
     @Test
-    public void testUnicodeEncoding() {
+    @DisplayName("Verify Unicode string encoding uses little-endian format")
+    public void shouldEncodeUnicodeInLittleEndian() {
         // Test Unicode string encoding
         String msg = "\u00A1\u00A2"; // two Unicode characters
         byte[] encoded = encodeUnicode(msg);
@@ -69,14 +73,16 @@ public class TestSmbComTransactionResponseReader {
     }
 
     @Test
-    public void testAsciiEncoding() throws Exception {
+    @DisplayName("Verify ASCII encoding produces valid byte output")
+    public void shouldProduceValidAsciiBytes() throws Exception {
         String msg = "\u00A1\u00A2"; // same Unicode string
         byte[] asciiBytes = msg.getBytes(SmbConstants.DEFAULT_OEM_ENCODING);
         assertTrue(asciiBytes.length > 0, "ASCII encoding should produce bytes");
     }
 
     @Test
-    public void testBufferCreation() throws UnsupportedEncodingException {
+    @DisplayName("Verify buffer creation includes header, params and data")
+    public void shouldCreateBufferWithHeaderParamsAndData() throws UnsupportedEncodingException {
         byte[] dataBytes = { 1, 2, 3, 4 };
         String params = "test";
         byte[] buffer = createBuffer(10, dataBytes, params);
@@ -86,7 +92,8 @@ public class TestSmbComTransactionResponseReader {
     }
 
     @Test
-    public void testByteOperations() {
+    @DisplayName("Verify byte operations handle unsigned conversion correctly")
+    public void shouldHandleUnsignedByteConversion() {
         // Test byte operations that were used in the original test
         byte b = (byte) 0xFF;
         int value = b & 0xFF;

--- a/src/test/java/org/codelibs/jcifs/smb/ntlmssp/av/AvTimestampTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/ntlmssp/av/AvTimestampTest.java
@@ -5,15 +5,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.codelibs.jcifs.smb.internal.util.SMBUtil;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class AvTimestampTest {
 
-    /**
-     * Test constructor with raw bytes.
-     */
     @Test
-    public void testConstructorWithRawBytes() {
+    @DisplayName("Constructor with raw bytes should create AvTimestamp correctly")
+    public void constructorWithRawBytesShouldCreateCorrectly() {
         byte[] rawBytes = new byte[8];
         SMBUtil.writeInt8(1234567890L, rawBytes, 0); // Example timestamp
         AvTimestamp avTimestamp = new AvTimestamp(rawBytes);
@@ -23,11 +22,9 @@ public class AvTimestampTest {
         assertArrayEquals(rawBytes, avTimestamp.getRaw());
     }
 
-    /**
-     * Test constructor with long timestamp.
-     */
     @Test
-    public void testConstructorWithLongTimestamp() {
+    @DisplayName("Constructor with long timestamp should encode correctly")
+    public void constructorWithLongTimestampShouldEncodeCorrectly() {
         long timestamp = 9876543210L;
         AvTimestamp avTimestamp = new AvTimestamp(timestamp);
 
@@ -36,11 +33,9 @@ public class AvTimestampTest {
         assertEquals(timestamp, avTimestamp.getTimestamp()); // Verify encoding and decoding
     }
 
-    /**
-     * Test getTimestamp method with a positive timestamp.
-     */
     @Test
-    public void testGetTimestampPositive() {
+    @DisplayName("getTimestamp should return positive timestamp correctly")
+    public void getTimestampShouldReturnPositiveTimestampCorrectly() {
         long expectedTimestamp = 123456789012345L;
         byte[] rawBytes = new byte[8];
         SMBUtil.writeInt8(expectedTimestamp, rawBytes, 0);
@@ -49,11 +44,9 @@ public class AvTimestampTest {
         assertEquals(expectedTimestamp, avTimestamp.getTimestamp());
     }
 
-    /**
-     * Test getTimestamp method with zero timestamp.
-     */
     @Test
-    public void testGetTimestampZero() {
+    @DisplayName("getTimestamp should handle zero timestamp correctly")
+    public void getTimestampShouldHandleZeroCorrectly() {
         long expectedTimestamp = 0L;
         byte[] rawBytes = new byte[8];
         SMBUtil.writeInt8(expectedTimestamp, rawBytes, 0);
@@ -62,12 +55,9 @@ public class AvTimestampTest {
         assertEquals(expectedTimestamp, avTimestamp.getTimestamp());
     }
 
-    /**
-     * Test getTimestamp method with a negative timestamp (though timestamps are usually positive).
-     * This tests the underlying SMBUtil.readInt8 behavior.
-     */
     @Test
-    public void testGetTimestampNegative() {
+    @DisplayName("getTimestamp should handle negative timestamp correctly")
+    public void getTimestampShouldHandleNegativeCorrectly() {
         long expectedTimestamp = -1L; // Represents all bits set to 1 for an 8-byte long
         byte[] rawBytes = new byte[8];
         SMBUtil.writeInt8(expectedTimestamp, rawBytes, 0);
@@ -76,11 +66,9 @@ public class AvTimestampTest {
         assertEquals(expectedTimestamp, avTimestamp.getTimestamp());
     }
 
-    /**
-     * Test round-trip conversion: long -> bytes -> long.
-     */
     @Test
-    public void testRoundTripConversion() {
+    @DisplayName("Round-trip conversion should preserve timestamp value")
+    public void roundTripConversionShouldPreserveValue() {
         long originalTimestamp = 543210987654321L;
         AvTimestamp avTimestamp = new AvTimestamp(originalTimestamp);
 

--- a/src/test/java/org/codelibs/jcifs/smb/pac/PacDataInputStreamTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/pac/PacDataInputStreamTest.java
@@ -13,6 +13,7 @@ import java.util.Date;
 
 import org.codelibs.jcifs.smb.SmbConstants;
 import org.codelibs.jcifs.smb.impl.SID;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class PacDataInputStreamTest {
@@ -23,7 +24,8 @@ public class PacDataInputStreamTest {
     }
 
     @Test
-    public void testAlign() throws IOException {
+    @DisplayName("Verify align method correctly aligns stream position")
+    public void shouldAlignStreamPositionCorrectly() throws IOException {
         // Test alignment from position 1 to 4
         byte[] data = new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05 };
         PacDataInputStream pdis = createInputStream(data);
@@ -46,7 +48,8 @@ public class PacDataInputStreamTest {
     }
 
     @Test
-    public void testAvailable() throws IOException {
+    @DisplayName("Verify available returns correct number of bytes")
+    public void shouldReturnCorrectAvailableBytes() throws IOException {
         byte[] data = new byte[] { 0x01, 0x02, 0x03, 0x04 };
         PacDataInputStream pdis = createInputStream(data);
         assertEquals(4, pdis.available());
@@ -55,7 +58,8 @@ public class PacDataInputStreamTest {
     }
 
     @Test
-    public void testReadFully() throws IOException {
+    @DisplayName("Verify readFully reads entire buffer")
+    public void shouldReadEntireBuffer() throws IOException {
         byte[] data = new byte[] { 0x01, 0x02, 0x03, 0x04 };
         PacDataInputStream pdis = createInputStream(data);
         byte[] buffer = new byte[4];
@@ -64,7 +68,8 @@ public class PacDataInputStreamTest {
     }
 
     @Test
-    public void testReadFullyWithOffset() throws IOException {
+    @DisplayName("Verify readFully with offset reads correct bytes")
+    public void shouldReadCorrectBytesWithOffset() throws IOException {
         byte[] data = new byte[] { 0x01, 0x02, 0x03, 0x04 };
         PacDataInputStream pdis = createInputStream(data);
         byte[] buffer = new byte[6];
@@ -73,7 +78,8 @@ public class PacDataInputStreamTest {
     }
 
     @Test
-    public void testReadChar() throws IOException {
+    @DisplayName("Verify readChar returns correct character value")
+    public void shouldReadCharacterCorrectly() throws IOException {
         // 0x0041 is 'A'
         byte[] data = new byte[] { 0x00, 0x41, 0x00, 0x00 };
         PacDataInputStream pdis = createInputStream(data);
@@ -81,14 +87,16 @@ public class PacDataInputStreamTest {
     }
 
     @Test
-    public void testReadByte() throws IOException {
+    @DisplayName("Verify readByte returns correct byte value")
+    public void shouldReadByteCorrectly() throws IOException {
         byte[] data = new byte[] { 0x7F };
         PacDataInputStream pdis = createInputStream(data);
         assertEquals(0x7F, pdis.readByte());
     }
 
     @Test
-    public void testReadShort() throws IOException {
+    @DisplayName("Verify readShort returns correct short value in little-endian")
+    public void shouldReadShortInLittleEndian() throws IOException {
         // Little-endian 0x1234 -> 0x34 0x12
         byte[] data = new byte[] { 0x34, 0x12, 0x00, 0x00 };
         PacDataInputStream pdis = createInputStream(data);
@@ -96,7 +104,8 @@ public class PacDataInputStreamTest {
     }
 
     @Test
-    public void testReadInt() throws IOException {
+    @DisplayName("Verify readInt returns correct int value in little-endian")
+    public void shouldReadIntInLittleEndian() throws IOException {
         // Little-endian 0x12345678 -> 0x78 0x56 0x34 0x12
         byte[] data = new byte[] { 0x78, 0x56, 0x34, 0x12 };
         PacDataInputStream pdis = createInputStream(data);
@@ -104,7 +113,8 @@ public class PacDataInputStreamTest {
     }
 
     @Test
-    public void testReadLong() throws IOException {
+    @DisplayName("Verify readLong returns correct long value in little-endian")
+    public void shouldReadLongInLittleEndian() throws IOException {
         // Little-endian 0x123456789ABCDEF0 -> 0xF0 0xDE 0xBC 0x9A 0x78 0x56 0x34 0x12
         byte[] data = new byte[] { (byte) 0xF0, (byte) 0xDE, (byte) 0xBC, (byte) 0x9A, 0x78, 0x56, 0x34, 0x12 };
         PacDataInputStream pdis = createInputStream(data);
@@ -112,14 +122,16 @@ public class PacDataInputStreamTest {
     }
 
     @Test
-    public void testReadUnsignedByte() throws IOException {
+    @DisplayName("Verify readUnsignedByte returns correct unsigned byte value")
+    public void shouldReadUnsignedByteCorrectly() throws IOException {
         byte[] data = new byte[] { (byte) 0xFF };
         PacDataInputStream pdis = createInputStream(data);
         assertEquals(255, pdis.readUnsignedByte());
     }
 
     @Test
-    public void testReadUnsignedShort() throws IOException {
+    @DisplayName("Verify readUnsignedShort returns correct unsigned short value")
+    public void shouldReadUnsignedShortCorrectly() throws IOException {
         // Little-endian 0xFFFF -> 0xFF 0xFF
         byte[] data = new byte[] { (byte) 0xFF, (byte) 0xFF, 0x00, 0x00 };
         PacDataInputStream pdis = createInputStream(data);
@@ -127,7 +139,8 @@ public class PacDataInputStreamTest {
     }
 
     @Test
-    public void testReadUnsignedInt() throws IOException {
+    @DisplayName("Verify readUnsignedInt returns correct unsigned int value")
+    public void shouldReadUnsignedIntCorrectly() throws IOException {
         // Little-endian 0xFFFFFFFF -> 0xFF 0xFF 0xFF 0xFF
         byte[] data = new byte[] { (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF };
         PacDataInputStream pdis = createInputStream(data);
@@ -135,7 +148,8 @@ public class PacDataInputStreamTest {
     }
 
     @Test
-    public void testReadFiletime() throws IOException {
+    @DisplayName("Verify readFiletime converts Windows FILETIME to Date correctly")
+    public void shouldConvertFiletimeToDateCorrectly() throws IOException {
         // A non-null date
         long time = System.currentTimeMillis();
         BigInteger filetime = BigInteger.valueOf(time)
@@ -169,7 +183,8 @@ public class PacDataInputStreamTest {
     }
 
     @Test
-    public void testReadUnicodeString() throws IOException, PACDecodingException {
+    @DisplayName("Verify readUnicodeString parses Unicode string structure correctly")
+    public void shouldParseUnicodeStringCorrectly() throws IOException, PACDecodingException {
         // length=4, maxLength=4, pointer=0x1234
         byte[] data = new byte[] { 0x04, 0x00, 0x04, 0x00, 0x34, 0x12, 0x00, 0x00 };
         PacDataInputStream pdis = createInputStream(data);
@@ -180,7 +195,8 @@ public class PacDataInputStreamTest {
     }
 
     @Test
-    public void testReadUnicodeStringMalformed() throws IOException {
+    @DisplayName("Verify readUnicodeString throws exception for malformed data")
+    public void shouldThrowExceptionForMalformedUnicodeString() throws IOException {
         // length > maxLength
         byte[] data = new byte[] { 0x08, 0x00, 0x04, 0x00, 0x34, 0x12, 0x00, 0x00 };
         PacDataInputStream pdis = createInputStream(data);
@@ -188,7 +204,8 @@ public class PacDataInputStreamTest {
     }
 
     @Test
-    public void testReadString() throws IOException, PACDecodingException {
+    @DisplayName("Verify readString parses string with offset and length correctly")
+    public void shouldParseStringWithOffsetAndLength() throws IOException, PACDecodingException {
         // total=4, unused=1, used=2, string="AB"
         byte[] data = new byte[] { 0x04, 0x00, 0x00, 0x00, // total
                 0x01, 0x00, 0x00, 0x00, // unused
@@ -203,7 +220,8 @@ public class PacDataInputStreamTest {
     }
 
     @Test
-    public void testReadStringMalformed() throws IOException {
+    @DisplayName("Verify readString throws exception for malformed string data")
+    public void shouldThrowExceptionForMalformedString() throws IOException {
         // unused > total
         byte[] data = new byte[] { 0x02, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00 };
         PacDataInputStream pdis = createInputStream(data);
@@ -211,7 +229,8 @@ public class PacDataInputStreamTest {
     }
 
     @Test
-    public void testReadId() throws IOException, PACDecodingException {
+    @DisplayName("Verify readId creates SID from RID value correctly")
+    public void shouldCreateSidFromRidCorrectly() throws IOException, PACDecodingException {
         // RID = 0x12345678 (305419896 in decimal, little-endian)
         byte[] data = new byte[] { 0x78, 0x56, 0x34, 0x12 };
         PacDataInputStream pdis = createInputStream(data);
@@ -224,7 +243,8 @@ public class PacDataInputStreamTest {
     }
 
     @Test
-    public void testReadSid() throws IOException, PACDecodingException {
+    @DisplayName("Verify readSid parses SID structure correctly")
+    public void shouldParseSidStructureCorrectly() throws IOException, PACDecodingException {
         // A simple SID: S-1-1-0
         byte[] data = new byte[] { 0x01, 0x00, 0x00, 0x00, // sidSize = 1
                 0x01, // revision
@@ -238,7 +258,8 @@ public class PacDataInputStreamTest {
     }
 
     @Test
-    public void testSkipBytes() throws IOException {
+    @DisplayName("Verify skipBytes skips correct number of bytes")
+    public void shouldSkipCorrectNumberOfBytes() throws IOException {
         byte[] data = new byte[] { 0x01, 0x02, 0x03, 0x04 };
         PacDataInputStream pdis = createInputStream(data);
         int skipped = pdis.skipBytes(2);

--- a/src/test/java/org/codelibs/jcifs/smb/util/transport/TransportExceptionTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/util/transport/TransportExceptionTest.java
@@ -17,7 +17,7 @@ public class TransportExceptionTest {
 
     @Test
     @DisplayName("Test default constructor creates exception with null message")
-    public void testDefaultConstructor() {
+    public void shouldCreateExceptionWithNullMessage() {
         // Create exception with default constructor
         TransportException exception = new TransportException();
 
@@ -32,7 +32,7 @@ public class TransportExceptionTest {
 
     @Test
     @DisplayName("Test constructor with message creates exception with specified message")
-    public void testConstructorWithMessage() {
+    public void shouldCreateExceptionWithSpecifiedMessage() {
         // Test with various messages
         String message = "Test error message";
         TransportException exception = new TransportException(message);
@@ -53,7 +53,7 @@ public class TransportExceptionTest {
 
     @Test
     @DisplayName("Test constructor with cause creates exception with specified cause")
-    public void testConstructorWithCause() {
+    public void shouldCreateExceptionWithSpecifiedCause() {
         // Create a root cause exception
         RuntimeException rootCause = new RuntimeException("Root cause error");
         TransportException exception = new TransportException(rootCause);
@@ -70,7 +70,7 @@ public class TransportExceptionTest {
 
     @Test
     @DisplayName("Test constructor with message and cause creates exception with both")
-    public void testConstructorWithMessageAndCause() {
+    public void shouldCreateExceptionWithMessageAndCause() {
         // Create exception with both message and cause
         String message = "Transport error occurred";
         IllegalStateException rootCause = new IllegalStateException("State error");
@@ -100,7 +100,7 @@ public class TransportExceptionTest {
     @Test
     @DisplayName("Test deprecated getRootCause method returns the same as getCause")
     @SuppressWarnings("deprecation")
-    public void testGetRootCause() {
+    public void shouldReturnSameAsGetCause() {
         // Test with no cause
         TransportException noCauseException = new TransportException("No cause");
         assertNull(noCauseException.getRootCause());
@@ -121,7 +121,7 @@ public class TransportExceptionTest {
 
     @Test
     @DisplayName("Test exception inheritance and polymorphism")
-    public void testInheritance() {
+    public void shouldDemonstrateCorrectInheritance() {
         // Create exception
         TransportException exception = new TransportException("Test exception");
 
@@ -144,7 +144,7 @@ public class TransportExceptionTest {
 
     @Test
     @DisplayName("Test exception can be thrown and caught")
-    public void testThrowAndCatch() {
+    public void shouldBeThrownAndCaught() {
         // Test throwing and catching with message
         String expectedMessage = "Transport failed";
         assertThrows(TransportException.class, () -> {
@@ -168,7 +168,7 @@ public class TransportExceptionTest {
 
     @Test
     @DisplayName("Test serialization compatibility")
-    public void testSerialVersionUID() {
+    public void shouldBeSerializable() {
         // Verify that the serialVersionUID is set
         TransportException exception = new TransportException();
 

--- a/src/test/java/org/codelibs/jcifs/smb1/DosFileFilterTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb1/DosFileFilterTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class DosFileFilterTest {
@@ -21,7 +22,8 @@ public class DosFileFilterTest {
     }
 
     @Test
-    public void testAcceptReturnsTrueWhenAttributesMatch() throws Exception {
+    @DisplayName("accept should return true when file attributes match filter")
+    public void acceptShouldReturnTrueWhenAttributesMatch() throws Exception {
         SmbFile file = mock(SmbFile.class);
         when(file.getAttributes()).thenReturn(SmbFile.ATTR_NORMAL);
         assertTrue(filter.accept(file), "Attributes match should be accepted");
@@ -29,7 +31,8 @@ public class DosFileFilterTest {
     }
 
     @Test
-    public void testAcceptReturnsFalseWhenAttributesDoNotMatch() throws Exception {
+    @DisplayName("accept should return false when file attributes do not match filter")
+    public void acceptShouldReturnFalseWhenAttributesDoNotMatch() throws Exception {
         SmbFile file = mock(SmbFile.class);
         when(file.getAttributes()).thenReturn(SmbFile.ATTR_HIDDEN);
         assertFalse(filter.accept(file), "Attributes not matching should be rejected");
@@ -37,7 +40,8 @@ public class DosFileFilterTest {
     }
 
     @Test
-    public void testAcceptIgnoresWildcard() throws Exception {
+    @DisplayName("accept should ignore wildcard in filter pattern")
+    public void acceptShouldIgnoreWildcard() throws Exception {
         // Wildcard shouldn't affect accept logic.
         DosFileFilter customFilter = new DosFileFilter("*.txt", SmbFile.ATTR_DIRECTORY);
         SmbFile file = mock(SmbFile.class);
@@ -46,7 +50,8 @@ public class DosFileFilterTest {
     }
 
     @Test
-    public void testAcceptHandlesNullFile() {
+    @DisplayName("accept should throw NullPointerException when file is null")
+    public void acceptShouldHandleNullFile() {
         assertThrows(NullPointerException.class, () -> filter.accept(null));
     }
 }

--- a/src/test/java/org/codelibs/jcifs/smb1/SmbComDeleteTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb1/SmbComDeleteTest.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Field;
 
 import org.codelibs.jcifs.smb1.util.Hexdump;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class SmbComDeleteTest {
@@ -21,14 +22,16 @@ public class SmbComDeleteTest {
     }
 
     @Test
-    public void testConstructor() {
+    @DisplayName("Constructor should set file name and command correctly")
+    public void constructorShouldSetFileNameAndCommand() {
         // Test if the constructor sets the file name and command correctly
         assertEquals(TEST_FILE_NAME, smbComDelete.path);
         assertEquals(ServerMessageBlock.SMB_COM_DELETE, smbComDelete.command);
     }
 
     @Test
-    public void testWriteParameterWordsWireFormat() {
+    @DisplayName("writeParameterWordsWireFormat should write search attributes")
+    public void writeParameterWordsWireFormatShouldWriteSearchAttributes() {
         // Test the writing of parameter words to a byte array
         byte[] dst = new byte[2];
         int bytesWritten = smbComDelete.writeParameterWordsWireFormat(dst, 0);
@@ -39,7 +42,8 @@ public class SmbComDeleteTest {
     }
 
     @Test
-    public void testWriteBytesWireFormat() {
+    @DisplayName("writeBytesWireFormat should write buffer format and file name")
+    public void writeBytesWireFormatShouldWriteBufferFormatAndFileName() {
         // Test the writing of bytes to a byte array
         byte[] dst = new byte[100];
         int bytesWritten = smbComDelete.writeBytesWireFormat(dst, 0);
@@ -52,21 +56,24 @@ public class SmbComDeleteTest {
     }
 
     @Test
-    public void testReadParameterWordsWireFormat() {
+    @DisplayName("readParameterWordsWireFormat should do nothing and return zero")
+    public void readParameterWordsWireFormatShouldReturnZero() {
         // This method is expected to do nothing and return 0
         int result = smbComDelete.readParameterWordsWireFormat(new byte[0], 0);
         assertEquals(0, result);
     }
 
     @Test
-    public void testReadBytesWireFormat() {
+    @DisplayName("readBytesWireFormat should do nothing and return zero")
+    public void readBytesWireFormatShouldReturnZero() {
         // This method is expected to do nothing and return 0
         int result = smbComDelete.readBytesWireFormat(new byte[0], 0);
         assertEquals(0, result);
     }
 
     @Test
-    public void testToString() {
+    @DisplayName("toString should return formatted string with search attributes and file name")
+    public void toStringShouldReturnFormattedString() {
         // Test the string representation of the object
         String result = smbComDelete.toString();
         assertNotNull(result);

--- a/src/test/java/org/codelibs/jcifs/smb1/SmbComQueryInformationResponseTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb1/SmbComQueryInformationResponseTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Date;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -22,80 +23,64 @@ public class SmbComQueryInformationResponseTest {
         response = new SmbComQueryInformationResponse(serverTimeZoneOffset);
     }
 
-    /**
-     * Test of constructor, of class SmbComQueryInformationResponse.
-     */
     @Test
-    public void testConstructor() {
+    @DisplayName("Constructor should initialize with command and server timezone offset")
+    public void constructorShouldInitializeCorrectly() {
         // The constructor sets the command and serverTimeZoneOffset.
         // We can't directly access serverTimeZoneOffset, but we can verify its effect.
         assertEquals(ServerMessageBlock.SMB_COM_QUERY_INFORMATION, response.command);
         assertEquals(serverTimeZoneOffset, response.getLastWriteTime());
     }
 
-    /**
-     * Test of getAttributes method, of class SmbComQueryInformationResponse.
-     */
     @Test
-    public void testGetAttributes() {
+    @DisplayName("getAttributes should return zero initially")
+    public void getAttributesShouldReturnZeroInitially() {
         // Initially, attributes should be 0.
         assertEquals(0, response.getAttributes());
     }
 
-    /**
-     * Test of getCreateTime method, of class SmbComQueryInformationResponse.
-     */
     @Test
-    public void testGetCreateTime() {
+    @DisplayName("getCreateTime should return server timezone offset initially")
+    public void getCreateTimeShouldReturnServerTimezoneOffset() {
         // Initially, lastWriteTime is 0, so createTime should be just the offset.
         assertEquals(serverTimeZoneOffset, response.getCreateTime());
     }
 
-    /**
-     * Test of getLastWriteTime method, of class SmbComQueryInformationResponse.
-     */
     @Test
-    public void testGetLastWriteTime() {
+    @DisplayName("getLastWriteTime should return server timezone offset initially")
+    public void getLastWriteTimeShouldReturnServerTimezoneOffset() {
         // Initially, lastWriteTime is 0, so it should return just the offset.
         assertEquals(serverTimeZoneOffset, response.getLastWriteTime());
     }
 
-    /**
-     * Test of getSize method, of class SmbComQueryInformationResponse.
-     */
     @Test
-    public void testGetSize() {
+    @DisplayName("getSize should return zero initially")
+    public void getSizeShouldReturnZeroInitially() {
         // Initially, fileSize should be 0.
         assertEquals(0, response.getSize());
     }
 
-    /**
-     * Test of writeParameterWordsWireFormat method, of class SmbComQueryInformationResponse.
-     */
     @Test
-    public void testWriteParameterWordsWireFormat() {
+    @DisplayName("writeParameterWordsWireFormat should return zero")
+    public void writeParameterWordsWireFormatShouldReturnZero() {
         byte[] dst = new byte[10];
         int dstIndex = 0;
         // This method does nothing and should return 0.
         assertEquals(0, response.writeParameterWordsWireFormat(dst, dstIndex));
     }
 
-    /**
-     * Test of writeBytesWireFormat method, of class SmbComQueryInformationResponse.
-     */
     @Test
-    public void testWriteBytesWireFormat() {
+    @DisplayName("writeBytesWireFormat should return zero")
+    public void writeBytesWireFormatShouldReturnZero() {
         byte[] dst = new byte[10];
         int dstIndex = 0;
         // This method does nothing and should return 0.
         assertEquals(0, response.writeBytesWireFormat(dst, dstIndex));
     }
 
-    /**
-     * Test of readParameterWordsWireFormat method, of class SmbComQueryInformationResponse.
-     */
     @Test
-    public void testReadParameterWordsWireFormat() {
+    @DisplayName("readParameterWordsWireFormat should read file attributes, time and size")
+    public void readParameterWordsWireFormatShouldReadFileData() {
         // Prepare a buffer with sample data.
         // 2 bytes for fileAttributes, 4 bytes for lastWriteTime, 4 bytes for fileSize
         byte[] buffer = new byte[20];
@@ -121,33 +106,27 @@ public class SmbComQueryInformationResponseTest {
         assertEquals(1024, response.getSize());
     }
 
-    /**
-     * Test of readParameterWordsWireFormat method with zero word count.
-     */
     @Test
-    public void testReadParameterWordsWireFormatWithZeroWordCount() {
+    @DisplayName("readParameterWordsWireFormat should return zero with zero word count")
+    public void readParameterWordsWireFormatWithZeroWordCountShouldReturnZero() {
         byte[] buffer = new byte[20];
         response.wordCount = 0;
         int bytesRead = response.readParameterWordsWireFormat(buffer, 0);
         assertEquals(0, bytesRead);
     }
 
-    /**
-     * Test of readBytesWireFormat method, of class SmbComQueryInformationResponse.
-     */
     @Test
-    public void testReadBytesWireFormat() {
+    @DisplayName("readBytesWireFormat should return zero")
+    public void readBytesWireFormatShouldReturnZero() {
         byte[] buffer = new byte[10];
         int bufferIndex = 0;
         // This method does nothing and should return 0.
         assertEquals(0, response.readBytesWireFormat(buffer, bufferIndex));
     }
 
-    /**
-     * Test of toString method, of class SmbComQueryInformationResponse.
-     */
     @Test
-    public void testToString() {
+    @DisplayName("toString should return properly formatted string representation")
+    public void toStringShouldReturnFormattedRepresentation() {
         String result = response.toString();
         assertNotNull(result);
         assertTrue(result.startsWith("SmbComQueryInformationResponse["));

--- a/src/test/java/org/codelibs/jcifs/smb1/SmbComQueryInformationTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb1/SmbComQueryInformationTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class SmbComQueryInformationTest {
@@ -17,21 +18,24 @@ public class SmbComQueryInformationTest {
     }
 
     @Test
-    public void testConstructor() {
+    @DisplayName("Constructor should set file name and command correctly")
+    public void constructorShouldSetFileNameAndCommand() {
         // Test if the constructor sets the file name and command correctly
         assertEquals(TEST_FILE_NAME, smbComQueryInformation.path);
         assertEquals(ServerMessageBlock.SMB_COM_QUERY_INFORMATION, smbComQueryInformation.command);
     }
 
     @Test
-    public void testWriteParameterWordsWireFormat() {
+    @DisplayName("writeParameterWordsWireFormat should do nothing and return zero")
+    public void writeParameterWordsWireFormatShouldReturnZero() {
         // This method is expected to do nothing and return 0
         int result = smbComQueryInformation.writeParameterWordsWireFormat(new byte[0], 0);
         assertEquals(0, result);
     }
 
     @Test
-    public void testWriteBytesWireFormat() {
+    @DisplayName("writeBytesWireFormat should write buffer format and file name")
+    public void writeBytesWireFormatShouldWriteBufferFormatAndFileName() {
         // Test the writing of bytes to a byte array
         byte[] dst = new byte[100];
         int bytesWritten = smbComQueryInformation.writeBytesWireFormat(dst, 0);
@@ -44,21 +48,24 @@ public class SmbComQueryInformationTest {
     }
 
     @Test
-    public void testReadParameterWordsWireFormat() {
+    @DisplayName("readParameterWordsWireFormat should do nothing and return zero")
+    public void readParameterWordsWireFormatShouldReturnZero() {
         // This method is expected to do nothing and return 0
         int result = smbComQueryInformation.readParameterWordsWireFormat(new byte[0], 0);
         assertEquals(0, result);
     }
 
     @Test
-    public void testReadBytesWireFormat() {
+    @DisplayName("readBytesWireFormat should do nothing and return zero")
+    public void readBytesWireFormatShouldReturnZero() {
         // This method is expected to do nothing and return 0
         int result = smbComQueryInformation.readBytesWireFormat(new byte[0], 0);
         assertEquals(0, result);
     }
 
     @Test
-    public void testToString() {
+    @DisplayName("toString should return formatted string with class name and filename")
+    public void toStringShouldReturnFormattedString() {
         // Test the string representation of the object
         String result = smbComQueryInformation.toString();
         assertTrue(result.startsWith("SmbComQueryInformation["));

--- a/src/test/java/org/codelibs/jcifs/smb1/SmbComReadAndXResponseTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb1/SmbComReadAndXResponseTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -21,12 +22,14 @@ public class SmbComReadAndXResponseTest {
     }
 
     @Test
-    public void testConstructor() {
+    @DisplayName("Constructor should create non-null instance")
+    public void constructorShouldCreateNonNullInstance() {
         assertNotNull(response);
     }
 
     @Test
-    public void testConstructorWithParameters() {
+    @DisplayName("Constructor with parameters should set buffer and offset")
+    public void constructorWithParametersShouldSetBufferAndOffset() {
         byte[] b = new byte[0];
         response = new SmbComReadAndXResponse(b, 0);
         assertNotNull(response);
@@ -35,7 +38,8 @@ public class SmbComReadAndXResponseTest {
     }
 
     @Test
-    public void testSetParam() {
+    @DisplayName("setParam should update buffer and offset")
+    public void setParamShouldUpdateBufferAndOffset() {
         byte[] b = new byte[0];
         response.setParam(b, 0);
         assertEquals(b, response.b);
@@ -43,17 +47,20 @@ public class SmbComReadAndXResponseTest {
     }
 
     @Test
-    public void testWriteParameterWordsWireFormat() {
+    @DisplayName("writeParameterWordsWireFormat should return zero")
+    public void writeParameterWordsWireFormatShouldReturnZero() {
         assertEquals(0, response.writeParameterWordsWireFormat(new byte[0], 0));
     }
 
     @Test
-    public void testWriteBytesWireFormat() {
+    @DisplayName("writeBytesWireFormat should return zero")
+    public void writeBytesWireFormatShouldReturnZero() {
         assertEquals(0, response.writeBytesWireFormat(new byte[0], 0));
     }
 
     @Test
-    public void testReadBytesWireFormat() {
+    @DisplayName("readBytesWireFormat should return zero")
+    public void readBytesWireFormatShouldReturnZero() {
         assertEquals(0, response.readBytesWireFormat(new byte[0], 0));
     }
 
@@ -79,7 +86,8 @@ public class SmbComReadAndXResponseTest {
         }
 
         @Test
-        public void testReadParameterWordsWireFormat() {
+        @DisplayName("readParameterWordsWireFormat should parse buffer data correctly")
+        public void readParameterWordsWireFormatShouldParseBufferCorrectly() {
             int bytesRead = response.readParameterWordsWireFormat(buffer, 0);
 
             assertEquals(20, bytesRead);
@@ -90,7 +98,8 @@ public class SmbComReadAndXResponseTest {
     }
 
     @Test
-    public void testToString() {
+    @DisplayName("toString should include key response fields")
+    public void toStringShouldIncludeKeyFields() {
         response.dataCompactionMode = 1;
         response.dataLength = 1024;
         response.dataOffset = 54;

--- a/src/test/java/org/codelibs/jcifs/smb1/SmbComWriteTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb1/SmbComWriteTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Field;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -31,7 +32,8 @@ public class SmbComWriteTest {
      * Test that the constructor initializes all fields correctly
      */
     @Test
-    public void testConstructor() {
+    @DisplayName("Constructor should initialize all fields correctly")
+    public void constructorShouldInitializeAllFields() {
         // Arrange
         int fid = 0x1234;
         int offset = 100;
@@ -56,7 +58,8 @@ public class SmbComWriteTest {
      * Test setParam method updates the write parameters
      */
     @Test
-    public void testSetParam() {
+    @DisplayName("setParam should update all write parameters")
+    public void setParamShouldUpdateAllWriteParameters() {
         // Arrange
         SmbComWrite write = new SmbComWrite();
         int fid = 0x5678;
@@ -83,7 +86,8 @@ public class SmbComWriteTest {
      * Test writeParameterWordsWireFormat writes correct bytes
      */
     @Test
-    public void testWriteParameterWordsWireFormat() {
+    @DisplayName("writeParameterWordsWireFormat should write correct parameter bytes")
+    public void writeParameterWordsWireFormatShouldWriteCorrectBytes() {
         // Arrange
         SmbComWrite write = new SmbComWrite();
         write.setParam(0x1234, 0x5678L, 100, new byte[10], 0, 10);
@@ -109,7 +113,8 @@ public class SmbComWriteTest {
      * Test writeBytesWireFormat writes data correctly
      */
     @Test
-    public void testWriteBytesWireFormat() {
+    @DisplayName("writeBytesWireFormat should write data block correctly")
+    public void writeBytesWireFormatShouldWriteDataCorrectly() {
         // Arrange
         byte[] data = { 1, 2, 3, 4, 5 };
         SmbComWrite write = new SmbComWrite();
@@ -133,7 +138,8 @@ public class SmbComWriteTest {
      * Test readParameterWordsWireFormat always returns 0
      */
     @Test
-    public void testReadParameterWordsWireFormat() {
+    @DisplayName("readParameterWordsWireFormat should always return zero")
+    public void readParameterWordsWireFormatShouldReturnZero() {
         SmbComWrite write = new SmbComWrite();
         byte[] buffer = new byte[10];
         int result = write.readParameterWordsWireFormat(buffer, 0);
@@ -144,7 +150,8 @@ public class SmbComWriteTest {
      * Test readBytesWireFormat always returns 0
      */
     @Test
-    public void testReadBytesWireFormat() {
+    @DisplayName("readBytesWireFormat should always return zero")
+    public void readBytesWireFormatShouldReturnZero() {
         SmbComWrite write = new SmbComWrite();
         byte[] buffer = new byte[10];
         int result = write.readBytesWireFormat(buffer, 0);
@@ -155,7 +162,8 @@ public class SmbComWriteTest {
      * Test toString contains relevant information
      */
     @Test
-    public void testToString() {
+    @DisplayName("toString should contain relevant write command information")
+    public void toStringShouldContainRelevantInformation() {
         SmbComWrite write = new SmbComWrite();
         write.setParam(0x1234, 100L, 50, new byte[10], 0, 10);
 

--- a/src/test/java/org/codelibs/jcifs/smb1/SmbFileTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb1/SmbFileTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.net.MalformedURLException;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,7 +36,8 @@ public class SmbFileTest {
     class ConstructorTests {
 
         @Test
-        public void testConstructorWithValidUrl() throws MalformedURLException {
+        @DisplayName("Test constructor with valid SMB URL")
+        public void shouldCreateSmbFileWithValidUrl() throws MalformedURLException {
             // Test basic constructor with a valid SMB URL
             String url = "smb1://server/share/file.txt";
             SmbFile smbFile = new SmbFile(url);
@@ -44,7 +46,8 @@ public class SmbFileTest {
         }
 
         @Test
-        public void testConstructorWithValidUrlAndAuth() throws MalformedURLException {
+        @DisplayName("Test constructor with URL and authentication")
+        public void shouldCreateSmbFileWithUrlAndAuth() throws MalformedURLException {
             // Test constructor with authentication
             String url = "smb1://user:pass@server/share/file.txt";
             SmbFile smbFile = new SmbFile(url, mockAuth);
@@ -55,7 +58,8 @@ public class SmbFileTest {
         }
 
         @Test
-        public void testConstructorWithMalformedUrl() {
+        @DisplayName("Test constructor throws exception for malformed URL")
+        public void shouldThrowExceptionForMalformedUrl() {
             // Test that constructor throws MalformedURLException for completely invalid URL
             // Note: http:// URLs are actually accepted by the URL constructor but the protocol is changed to smb
             String invalidUrl = "not-a-valid-url";
@@ -63,7 +67,8 @@ public class SmbFileTest {
         }
 
         @Test
-        public void testConstructorWithContextAndName() throws Exception {
+        @DisplayName("Test constructor with context and name")
+        public void shouldCreateSmbFileWithContextAndName() throws Exception {
             // Test constructor that takes a context SmbFile and a name
             SmbFile context = new SmbFile("smb1://server/share/");
             String name = "file.txt";
@@ -72,7 +77,8 @@ public class SmbFileTest {
         }
 
         @Test
-        public void testConstructorWithIllegalShareAccess() {
+        @DisplayName("Test constructor throws exception for illegal share access")
+        public void shouldThrowExceptionForIllegalShareAccess() {
             // Test that constructor throws RuntimeException for illegal shareAccess parameter
             String url = "smb1://server/share/file.txt";
             int illegalShareAccess = 99; // Not a valid combination
@@ -84,7 +90,8 @@ public class SmbFileTest {
     class PathManipulationTests {
 
         @Test
-        public void testGetName() throws MalformedURLException {
+        @DisplayName("Test getName returns correct file/directory names")
+        public void shouldReturnCorrectNames() throws MalformedURLException {
             // Test file name extraction
             assertEquals("file.txt", new SmbFile("smb1://server/share/file.txt").getName());
             // Test directory name extraction (should include trailing slash)
@@ -98,7 +105,8 @@ public class SmbFileTest {
         }
 
         @Test
-        public void testGetParent() throws MalformedURLException {
+        @DisplayName("Test getParent returns correct parent paths")
+        public void shouldReturnCorrectParentPaths() throws MalformedURLException {
             // Test parent of a file
             assertEquals("smb1://server/share/", new SmbFile("smb1://server/share/file.txt").getParent());
             // Test parent of a directory
@@ -114,7 +122,8 @@ public class SmbFileTest {
         }
 
         @Test
-        public void testGetPath() throws MalformedURLException {
+        @DisplayName("Test getPath returns original uncanonicalized URL")
+        public void shouldReturnOriginalUrl() throws MalformedURLException {
             // Path should be the original, uncanonicalized URL
             String url = "smb1://server/share/../share/file.txt";
             SmbFile smbFile = new SmbFile(url);
@@ -122,7 +131,8 @@ public class SmbFileTest {
         }
 
         @Test
-        public void testGetCanonicalPath() throws MalformedURLException {
+        @DisplayName("Test getCanonicalPath performs path canonicalization")
+        public void shouldCanonicalizePathCorrectly() throws MalformedURLException {
             // Test path canonicalization (removing . and ..)
             assertEquals("smb1://server/share/file.txt", new SmbFile("smb1://server/share/dir/../file.txt").getCanonicalPath());
             assertEquals("smb1://server/file.txt", new SmbFile("smb1://server/share/../file.txt").getCanonicalPath());
@@ -130,7 +140,8 @@ public class SmbFileTest {
         }
 
         @Test
-        public void testGetUncPath() throws MalformedURLException {
+        @DisplayName("Test getUncPath converts to UNC format")
+        public void shouldConvertToUncFormat() throws MalformedURLException {
             // Test UNC path conversion
             assertEquals("\\\\server\\share\\file.txt", new SmbFile("smb1://server/share/file.txt").getUncPath());
             // For share URLs with trailing slash, the UNC path includes the trailing slash
@@ -139,14 +150,16 @@ public class SmbFileTest {
         }
 
         @Test
-        public void testGetShare() throws MalformedURLException {
+        @DisplayName("Test getShare extracts share name correctly")
+        public void shouldExtractShareNameCorrectly() throws MalformedURLException {
             assertEquals("share", new SmbFile("smb1://server/share/file.txt").getShare());
             assertEquals("share", new SmbFile("smb1://server/share/").getShare());
             assertEquals(null, new SmbFile("smb1://server/").getShare());
         }
 
         @Test
-        public void testGetServer() throws MalformedURLException {
+        @DisplayName("Test getServer extracts server name correctly")
+        public void shouldExtractServerNameCorrectly() throws MalformedURLException {
             assertEquals("server", new SmbFile("smb1://server/share/file.txt").getServer());
             assertEquals("server", new SmbFile("smb1://server/").getServer());
             assertEquals(null, new SmbFile("smb1://").getServer());
@@ -157,7 +170,8 @@ public class SmbFileTest {
     class AttributeAndStateTests {
 
         @Test
-        public void testGetTypeForFile() throws Exception {
+        @DisplayName("Test getType returns TYPE_FILESYSTEM for files")
+        public void shouldReturnFileSystemTypeForFiles() throws Exception {
             // Mocking underlying connection and info retrieval is complex.
             // This test focuses on the logic based on the URL structure.
             SmbFile file = new SmbFile("smb1://server/share/file.txt");
@@ -167,7 +181,8 @@ public class SmbFileTest {
         }
 
         @Test
-        public void testGetTypeForShare() throws Exception {
+        @DisplayName("Test getType attempts connection for shares")
+        public void shouldAttemptConnectionForShares() throws Exception {
             SmbFile share = new SmbFile("smb1://server/share/");
             // To test this properly, we would need to mock connect0() and the tree object.
             // This is a limitation of unit testing such a coupled class.
@@ -176,7 +191,8 @@ public class SmbFileTest {
         }
 
         @Test
-        public void testIsHiddenForDollarShare() throws Exception {
+        @DisplayName("Test isHidden returns true for dollar shares")
+        public void shouldRecognizeDollarSharesAsHidden() throws Exception {
             SmbFile hiddenShare = new SmbFile("smb1://server/C$/");
             assertTrue(hiddenShare.isHidden());
         }

--- a/src/test/java/org/codelibs/jcifs/smb1/TransWaitNamedPipeTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb1/TransWaitNamedPipeTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
 
@@ -21,7 +22,8 @@ public class TransWaitNamedPipeTest {
     }
 
     @Test
-    public void testConstructorInitializesFields() {
+    @DisplayName("Constructor should initialize fields correctly")
+    public void constructorShouldInitializeFields() {
         // Test constructor initialization with proper expectations
         String pipeName = "\\\\pipe\\testPipe";
         TransWaitNamedPipe pipe = new TransWaitNamedPipe(pipeName);
@@ -50,7 +52,8 @@ public class TransWaitNamedPipeTest {
     }
 
     @Test
-    public void testWriteSetupWireFormat() {
+    @DisplayName("writeSetupWireFormat should write 4 bytes with subCommand")
+    public void writeSetupWireFormatShouldWriteCorrectBytes() {
         // Test the writeSetupWireFormat method
         TransWaitNamedPipe pipe = new TransWaitNamedPipe("\\\\pipe\\testPipe");
         byte[] dst = new byte[10];
@@ -68,7 +71,8 @@ public class TransWaitNamedPipeTest {
     }
 
     @Test
-    public void testReadSetupWireFormat() {
+    @DisplayName("readSetupWireFormat should always return 0")
+    public void readSetupWireFormatShouldReturnZero() {
         // Test the readSetupWireFormat method
         TransWaitNamedPipe pipe = new TransWaitNamedPipe("\\\\pipe\\testPipe");
         byte[] buffer = new byte[10];
@@ -79,7 +83,8 @@ public class TransWaitNamedPipeTest {
     }
 
     @Test
-    public void testWriteParametersWireFormat() {
+    @DisplayName("writeParametersWireFormat should return 0")
+    public void writeParametersWireFormatShouldReturnZero() {
         // Test that writeParametersWireFormat returns 0
         TransWaitNamedPipe pipe = new TransWaitNamedPipe("\\\\pipe\\testPipe");
         byte[] dst = new byte[100];
@@ -89,7 +94,8 @@ public class TransWaitNamedPipeTest {
     }
 
     @Test
-    public void testWriteDataWireFormat() {
+    @DisplayName("writeDataWireFormat should return 0")
+    public void writeDataWireFormatShouldReturnZero() {
         // Test that writeDataWireFormat returns 0
         TransWaitNamedPipe pipe = new TransWaitNamedPipe("\\\\pipe\\testPipe");
         byte[] dst = new byte[100];
@@ -99,7 +105,8 @@ public class TransWaitNamedPipeTest {
     }
 
     @Test
-    public void testReadParametersWireFormat() {
+    @DisplayName("readParametersWireFormat should return 0")
+    public void readParametersWireFormatShouldReturnZero() {
         // Test that readParametersWireFormat returns 0
         TransWaitNamedPipe pipe = new TransWaitNamedPipe("\\\\pipe\\testPipe");
         byte[] buffer = new byte[100];
@@ -109,7 +116,8 @@ public class TransWaitNamedPipeTest {
     }
 
     @Test
-    public void testReadDataWireFormat() {
+    @DisplayName("readDataWireFormat should return 0")
+    public void readDataWireFormatShouldReturnZero() {
         // Test that readDataWireFormat returns 0
         TransWaitNamedPipe pipe = new TransWaitNamedPipe("\\\\pipe\\testPipe");
         byte[] buffer = new byte[100];
@@ -119,7 +127,8 @@ public class TransWaitNamedPipeTest {
     }
 
     @Test
-    public void testToString() {
+    @DisplayName("toString should contain class name and pipe name")
+    public void toStringShouldContainClassAndPipeName() {
         // Test the toString method
         String pipeName = "\\\\pipe\\testPipe";
         TransWaitNamedPipe pipe = new TransWaitNamedPipe(pipeName);
@@ -131,7 +140,8 @@ public class TransWaitNamedPipeTest {
     }
 
     @Test
-    public void testMultiplePipeNames() {
+    @DisplayName("Constructor should work with various pipe names")
+    public void constructorShouldWorkWithVariousPipeNames() {
         // Test with various pipe names
         String[] pipeNames = { "\\\\pipe\\test", "\\\\pipe\\PIPE\\sql\\query", "\\\\pipe\\spoolss", "\\\\pipe\\winreg" };
 

--- a/src/test/java/org/codelibs/jcifs/smb1/dcerpc/ndr/NdrHyperTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb1/dcerpc/ndr/NdrHyperTest.java
@@ -39,7 +39,7 @@ public class NdrHyperTest {
      */
     @Test
     @DisplayName("Basic round‑trip for a fixed value")
-    public void testEncodeRoundTrip() throws NdrException {
+    public void shouldEncodeAndDecodeRoundTrip() throws NdrException {
         final long original = 0x1122334455667788L;
         NdrHyper hyper = new NdrHyper(original);
         // Create buffer with extra space for alignment
@@ -57,7 +57,7 @@ public class NdrHyperTest {
      */
     @ParameterizedTest(name = "Encode and decode {0}")
     @ValueSource(longs = { 0L, 1L, -1L, Long.MAX_VALUE, Long.MIN_VALUE })
-    public void testEncodeWithVariousValues(long val) throws NdrException {
+    public void shouldEncodeAndDecodeVariousValues(long val) throws NdrException {
         NdrHyper hyper = new NdrHyper(val);
         // Create buffer with extra space for alignment
         NdrBuffer buf = new NdrBuffer(new byte[16], 0);
@@ -74,7 +74,7 @@ public class NdrHyperTest {
      */
     @Test
     @DisplayName("Encode with null buffer throws NullPointerException")
-    public void testEncodeNullBuffer() throws NdrException {
+    public void shouldThrowNullPointerExceptionForEncodeWithNullBuffer() throws NdrException {
         NdrHyper hyper = new NdrHyper(5L);
         assertThrows(NullPointerException.class, () -> hyper.encode(null));
     }
@@ -84,7 +84,7 @@ public class NdrHyperTest {
      */
     @Test
     @DisplayName("Decode with null buffer throws NullPointerException")
-    public void testDecodeNullBuffer() throws NdrException {
+    public void shouldThrowNullPointerExceptionForDecodeWithNullBuffer() throws NdrException {
         NdrHyper hyper = new NdrHyper(0L);
         assertThrows(NullPointerException.class, () -> hyper.decode(null));
     }
@@ -94,7 +94,7 @@ public class NdrHyperTest {
      */
     @Test
     @DisplayName("Encode should call NdrBuffer.enc_ndr_hyper with correct value")
-    public void testEncodeInteraction() throws NdrException {
+    public void shouldCallEncodeHyperWithCorrectValue() throws NdrException {
         NdrBuffer buf = mock(NdrBuffer.class);
         NdrHyper hyper = new NdrHyper(12345L);
         hyper.encode(buf);
@@ -106,7 +106,7 @@ public class NdrHyperTest {
      */
     @Test
     @DisplayName("Decode should set value from NdrBuffer.dec_ndr_hyper")
-    public void testDecodeInteraction() throws NdrException {
+    public void shouldSetValueFromDecodeHyper() throws NdrException {
         NdrBuffer buf = mock(NdrBuffer.class);
         when(buf.dec_ndr_hyper()).thenReturn(0xdeadbeefcafebabeL);
         NdrHyper hyper = new NdrHyper(0L);


### PR DESCRIPTION
This pull request primarily refactors and improves the test code for better readability, maintainability, and clarity. The main changes include renaming test methods to follow descriptive naming conventions, adding `@DisplayName` annotations for clearer test output, and cleaning up the `pom.xml` configuration for more efficient license and resource exclusion.

### Test Code Improvements

* Renamed test methods in `src/test/java/org/codelibs/jcifs/smb/SmbConnectionTest.java`, `SmbPipeHandleTest.java`, `NtlmSspTest.java`, and `ReferralTest.java` to use descriptive names that clearly state the intent and expected outcome of each test. [[1]](diffhunk://#diff-8932e2d447e5aaec438846ec91a000803e5e77cf5c312a6b9f6eb942549e15c7L23-R23) [[2]](diffhunk://#diff-8932e2d447e5aaec438846ec91a000803e5e77cf5c312a6b9f6eb942549e15c7L46-R46) [[3]](diffhunk://#diff-8932e2d447e5aaec438846ec91a000803e5e77cf5c312a6b9f6eb942549e15c7L66-R66) [[4]](diffhunk://#diff-8932e2d447e5aaec438846ec91a000803e5e77cf5c312a6b9f6eb942549e15c7L86-R86) [[5]](diffhunk://#diff-34f0dc45b196282b385293773395309411fe5384d326dc6ac4502fc3a1356a32L56-R71) [[6]](diffhunk://#diff-34f0dc45b196282b385293773395309411fe5384d326dc6ac4502fc3a1356a32L88-R98) [[7]](diffhunk://#diff-34f0dc45b196282b385293773395309411fe5384d326dc6ac4502fc3a1356a32L124-R119) [[8]](diffhunk://#diff-34f0dc45b196282b385293773395309411fe5384d326dc6ac4502fc3a1356a32L149-R141) [[9]](diffhunk://#diff-34f0dc45b196282b385293773395309411fe5384d326dc6ac4502fc3a1356a32L175-R155) [[10]](diffhunk://#diff-08915daeb011a57fe603c6eb3bc7e6713090e461d58673aa09ac975880834230L213-R215) [[11]](diffhunk://#diff-08915daeb011a57fe603c6eb3bc7e6713090e461d58673aa09ac975880834230L234-R237) [[12]](diffhunk://#diff-08915daeb011a57fe603c6eb3bc7e6713090e461d58673aa09ac975880834230L275-R279) [[13]](diffhunk://#diff-08915daeb011a57fe603c6eb3bc7e6713090e461d58673aa09ac975880834230L299-R304) [[14]](diffhunk://#diff-d3d1c6123763549d3647dc36575fbb09589e971c7f935cb6fc03c9a4dd9f5cb8L36-R38) [[15]](diffhunk://#diff-d3d1c6123763549d3647dc36575fbb09589e971c7f935cb6fc03c9a4dd9f5cb8L88-R91) [[16]](diffhunk://#diff-d3d1c6123763549d3647dc36575fbb09589e971c7f935cb6fc03c9a4dd9f5cb8L136-R140) [[17]](diffhunk://#diff-d3d1c6123763549d3647dc36575fbb09589e971c7f935cb6fc03c9a4dd9f5cb8L161-R166) [[18]](diffhunk://#diff-d3d1c6123763549d3647dc36575fbb09589e971c7f935cb6fc03c9a4dd9f5cb8L186-R192) [[19]](diffhunk://#diff-d3d1c6123763549d3647dc36575fbb09589e971c7f935cb6fc03c9a4dd9f5cb8L222-R229) [[20]](diffhunk://#diff-d3d1c6123763549d3647dc36575fbb09589e971c7f935cb6fc03c9a4dd9f5cb8L244-R252)
* Added `@DisplayName` annotations to all test methods for improved test reporting and readability. [[1]](diffhunk://#diff-34f0dc45b196282b385293773395309411fe5384d326dc6ac4502fc3a1356a32L56-R71) [[2]](diffhunk://#diff-34f0dc45b196282b385293773395309411fe5384d326dc6ac4502fc3a1356a32L88-R98) [[3]](diffhunk://#diff-34f0dc45b196282b385293773395309411fe5384d326dc6ac4502fc3a1356a32L124-R119) [[4]](diffhunk://#diff-34f0dc45b196282b385293773395309411fe5384d326dc6ac4502fc3a1356a32L149-R141) [[5]](diffhunk://#diff-34f0dc45b196282b385293773395309411fe5384d326dc6ac4502fc3a1356a32L175-R155) [[6]](diffhunk://#diff-08915daeb011a57fe603c6eb3bc7e6713090e461d58673aa09ac975880834230R24) [[7]](diffhunk://#diff-08915daeb011a57fe603c6eb3bc7e6713090e461d58673aa09ac975880834230L213-R215) [[8]](diffhunk://#diff-08915daeb011a57fe603c6eb3bc7e6713090e461d58673aa09ac975880834230L234-R237) [[9]](diffhunk://#diff-08915daeb011a57fe603c6eb3bc7e6713090e461d58673aa09ac975880834230L275-R279) [[10]](diffhunk://#diff-08915daeb011a57fe603c6eb3bc7e6713090e461d58673aa09ac975880834230L299-R304) [[11]](diffhunk://#diff-d3d1c6123763549d3647dc36575fbb09589e971c7f935cb6fc03c9a4dd9f5cb8R17) [[12]](diffhunk://#diff-d3d1c6123763549d3647dc36575fbb09589e971c7f935cb6fc03c9a4dd9f5cb8L36-R38) [[13]](diffhunk://#diff-d3d1c6123763549d3647dc36575fbb09589e971c7f935cb6fc03c9a4dd9f5cb8L88-R91) [[14]](diffhunk://#diff-d3d1c6123763549d3647dc36575fbb09589e971c7f935cb6fc03c9a4dd9f5cb8L136-R140) [[15]](diffhunk://#diff-d3d1c6123763549d3647dc36575fbb09589e971c7f935cb6fc03c9a4dd9f5cb8L161-R166) [[16]](diffhunk://#diff-d3d1c6123763549d3647dc36575fbb09589e971c7f935cb6fc03c9a4dd9f5cb8L186-R192) [[17]](diffhunk://#diff-d3d1c6123763549d3647dc36575fbb09589e971c7f935cb6fc03c9a4dd9f5cb8L222-R229) [[18]](diffhunk://#diff-d3d1c6123763549d3647dc36575fbb09589e971c7f935cb6fc03c9a4dd9f5cb8L244-R252)

### Build Configuration and License Exclusion

* Updated `pom.xml` to simplify and broaden license exclusion patterns, replacing specific file exclusions (like `pom.xml`, `README.md`, etc.) with wildcard-based exclusions (`*.xml`, `*.md`), and expanded exclusion of test and documentation resources. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L237-R222) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L253-R235)
* Removed the `maven-failsafe-plugin` configuration from `pom.xml`, likely because it was redundant or not needed for the current test setup.

These changes collectively improve the clarity and maintainability of the test suite and streamline the build process.