### PR TITLE
fix(dfs): Improve DFS referral path mapping and resolution

### DIFF
--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbFile.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbFile.java
@@ -953,7 +953,7 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
     public String getDfsPath() throws SmbException {
         try {
             String path = this.treeConnection.ensureDFSResolved(this.fileLocator).getDfsPath();
-            if (path != null && isDirectory()) {
+            if (path != null && isDirectory() && !path.endsWith("/")) {
                 path += '/';
             }
             return path;

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbTreeConnection.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbTreeConnection.java
@@ -512,7 +512,7 @@ class SmbTreeConnection {
                             SmbTreeImpl ct = connectTree(loc, host, share, trans, uct, dr)) {
 
                         if (dr != null) {
-                            ct.setTreeReferral(dr);
+                            ct.setTreeReferral(dr, path);
                             if (dr != start) {
                                 dr.unwrap(DfsReferralDataInternal.class).replaceCache();
                             }
@@ -529,7 +529,7 @@ class SmbTreeConnection {
                         SmbTreeImpl uct = smbSession.getSmbTree(share, null).unwrap(SmbTreeImpl.class);
                         SmbTreeImpl ct = connectTree(loc, host, share, trans, uct, dr)) {
                     if (dr != null) {
-                        ct.setTreeReferral(dr);
+                        ct.setTreeReferral(dr, path);
                         if (dr != start) {
                             dr.unwrap(DfsReferralDataInternal.class).replaceCache();
                         }
@@ -666,7 +666,10 @@ class SmbTreeConnection {
                     return loc;
                 }
                 // need to adjust request path
-                final DfsReferralData dr = t.getTreeReferral();
+                DfsReferralData dr = t.getTreeReferral(rpath);
+                if (dr == null && loc.getDfsReferral() != null && loc.getDfsReferral().getLink() != null) {
+                    dr = t.getTreeReferral(loc.getDfsReferral().getLink());
+                }
                 if (dr != null) {
                     if (log.isDebugEnabled()) {
                         log.debug(String.format("Need to adjust request path %s (full: %s) -> %s", rpath, rfullpath, dr));


### PR DESCRIPTION
## Summary

This PR enhances the DFS (Distributed File System) referral handling mechanism in JCIFS to properly track and resolve path-specific referrals within SMB tree connections. The previous implementation stored only a single DFS referral per tree, which caused issues when working with complex DFS hierarchies containing multiple referral points at different path levels.

## Changes Made

### Core Implementation Changes

1. **SmbTreeImpl.java**
   - Replaced single `DfsReferralData treeReferral` field with `Map<String, DfsReferralData> treeReferrals`
   - Modified `setTreeReferral()` to accept a path parameter and store referrals indexed by both link and path
   - Updated `getTreeReferral()` to search for matching referrals by path prefix, enabling hierarchical resolution
   - Added debug logging for referral mapping and lookup operations

2. **SmbTreeConnection.java**
   - Updated all `setTreeReferral()` calls to include the path parameter
   - Enhanced `ensureDFSResolved()` to use path-aware referral lookup
   - Added fallback logic to search by DFS link when path lookup fails

3. **SmbFile.java**
   - Fixed `getDfsPath()` to prevent duplicate trailing slashes on directory paths

### Testing

4. **SmbTreeImplTest.java**
   - Added comprehensive unit tests to verify referral storage and retrieval
   - Tests cover both link-based and path-based referral mapping
   - Validates prefix matching for nested DFS paths

## Technical Details

The new implementation uses a HashMap to store multiple DFS referrals per tree connection, indexed by either:
- The referral's link property (e.g., "\dfs\root\folder")
- The requested path that triggered the referral

When resolving a path, the code now:
1. Searches for exact path matches in the referral map
2. Performs prefix matching to find parent referrals
3. Falls back to link-based lookup if needed

This approach ensures proper resolution even in complex DFS topologies with multiple namespace levels.

## Testing

- Added unit tests in `SmbTreeImplTest` covering referral storage and retrieval scenarios
- Verified path prefix matching works correctly for nested DFS paths
- Confirmed backward compatibility with existing DFS resolution logic

## Breaking Changes

None. This is an internal implementation improvement that maintains API compatibility.

## Additional Notes

This fix addresses scenarios where:
- Multiple DFS referrals exist at different levels of the same tree
- Nested DFS namespaces require path-specific resolution
- Previous single-referral approach would lose referral information

The change improves reliability when working with enterprise DFS deployments that use complex hierarchical structures.