### PR TITLE
chore(deps): bump build plugins and dependencies, move gpg signing to release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.14.0</version>
+				<version>3.15.0</version>
 				<configuration>
 					<source>17</source>
 					<target>17</target>
@@ -54,7 +54,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.11.2</version>
+				<version>3.12.0</version>
 				<configuration>
 					<encoding>UTF-8</encoding>
 					<docencoding>UTF-8</docencoding>
@@ -64,7 +64,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.4.2</version>
+				<version>3.5.0</version>
 				<configuration>
 					<archive>
 						<manifestEntries>
@@ -156,7 +156,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.5.0</version>
+				<version>3.5.5</version>
 				<configuration>
 					<includes>
 						<include>**/*Test.java</include>
@@ -178,14 +178,14 @@
 					<dependency>
 						<groupId>org.apache.maven.surefire</groupId>
 						<artifactId>surefire-junit-platform</artifactId>
-						<version>3.5.0</version>
+						<version>3.5.5</version>
 					</dependency>
 				</dependencies>
 			</plugin>
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.13</version>
+				<version>0.8.14</version>
 				<executions>
 					<execution>
 						<goals>
@@ -255,7 +255,7 @@
 			<plugin>
 				<groupId>net.revelc.code.formatter</groupId>
 				<artifactId>formatter-maven-plugin</artifactId>
-				<version>2.26.0</version>
+				<version>2.29.0</version>
 				<executions>
 					<execution>
 						<goals>
@@ -268,23 +268,9 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-gpg-plugin</artifactId>
-				<version>3.2.7</version>
-				<executions>
-					<execution>
-						<id>sign-artifacts</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>sign</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.10.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>central</publishingServerId>
@@ -292,6 +278,32 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>3.2.8</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+								<configuration>
+									<bestPractices>true</bestPractices>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 	<dependencies>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>
@@ -319,36 +331,36 @@
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk18on</artifactId>
-			<version>1.80</version>
+			<version>1.84</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
-			<version>5.10.3</version>
+			<version>5.14.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.10.3</version>
+			<version>5.14.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-params</artifactId>
-			<version>5.10.3</version>
+			<version>5.14.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-suite</artifactId>
-			<version>1.10.3</version>
+			<version>1.14.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-runner</artifactId>
-			<version>1.10.3</version>
+			<version>1.14.3</version>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>
@@ -366,25 +378,25 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>5.11.0</version>
+			<version>5.23.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-junit-jupiter</artifactId>
-			<version>5.11.0</version>
+			<version>5.23.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>testcontainers</artifactId>
-			<version>1.20.4</version>
+			<version>1.21.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>1.20.4</version>
+			<version>1.21.4</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
## Summary
Routine refresh of Maven build plugins and test/runtime dependencies, plus a build-config tweak to scope GPG signing to release builds only.

## Changes Made
- **Maven plugins** bumped:
  - `maven-compiler-plugin` 3.14.0 → 3.15.0
  - `maven-javadoc-plugin` 3.11.2 → 3.12.0
  - `maven-jar-plugin` 3.4.2 → 3.5.0
  - `maven-surefire-plugin` (and `surefire-junit-platform`) 3.5.0 → 3.5.5
  - `jacoco-maven-plugin` 0.8.13 → 0.8.14
  - `formatter-maven-plugin` 2.26.0 → 2.29.0
  - `central-publishing-maven-plugin` 0.7.0 → 0.10.0
- **Dependencies** bumped:
  - `bcprov-jdk18on` 1.80 → 1.84
  - JUnit Jupiter 5.10.3 → 5.14.3, JUnit Platform 1.10.3 → 1.14.3
  - Mockito 5.11.0 → 5.23.0
  - Testcontainers 1.20.4 → 1.21.4
- **Build config**: moved `maven-gpg-plugin` (bumped to 3.2.8) out of the always-on `<build>` block and into a new `release` profile, with `<bestPractices>true</bestPractices>` enabled. Non-release builds no longer require a GPG signing key.

## Testing
- `mvn clean test` locally to confirm the new Surefire / JUnit / Mockito stack runs the existing test suite.
- Release flow needs to be exercised with `-Prelease` to pick up the GPG signing step now that it lives in the profile.

## Breaking Changes
- For anyone running `mvn verify` or `mvn package` expecting artifacts to be GPG-signed, signing now requires `-Prelease`. CI/release jobs that publish to Central must activate the `release` profile.

## Additional Notes
- Please double-check the release profile is wired into the publishing workflow (e.g. release scripts / GitHub Actions) before the next release.
- BouncyCastle, JUnit, and Mockito jumps span several minor versions — worth a quick scan of test output for any deprecation warnings.