### PR TITLE
build: attach sources and javadoc jars to release builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,18 @@
 				</configuration>
 			</plugin>
 			<plugin>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>3.3.1</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>3.12.0</version>
 				<configuration>
@@ -61,6 +73,14 @@
 					<charset>UTF-8</charset>
 					<source>17</source>
 				</configuration>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
## Summary
Release builds did not generate sources and javadoc jars because maven-source-plugin was missing and maven-javadoc-plugin had no jar goal execution. The super POM release-profile that used to handle this is no longer available in current Maven versions, so publishing to Maven Central fails validation during `mvn release:perform`.

## Changes Made
- Add maven-source-plugin 3.3.1 with an `attach-sources` execution (`jar-no-fork` goal)
- Add an `attach-javadocs` execution (`jar` goal) to the existing maven-javadoc-plugin

## Testing
- Ran `mvn package -DskipTests` and confirmed that both `*-sources.jar` and `*-javadoc.jar` are generated under `target/`

## Additional Notes
- Same fix as codelibs/opensearch-runner#20 (codelibs/opensearch-runner@25c54af)