### PR TITLE
build(pom): pin maven-source-plugin to 3.2.1 to avoid duplicate sources jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,7 +282,7 @@
 				<plugins>
 					<plugin>
 						<artifactId>maven-source-plugin</artifactId>
-						<version>3.3.1</version>
+						<version>3.2.1</version><!-- https://issues.apache.org/jira/browse/MSOURCES-143 -->
 						<executions>
 							<execution>
 								<id>attach-sources</id>


### PR DESCRIPTION
## Summary
The Jenkins deploy job fails with `We have duplicated artifacts attached` because the `attach-sources` execution (maven-source-plugin 3.3.1) in the `release` profile attaches a sources jar that the job's command-line `source:jar` goal has already attached. Since 3.3.0, maven-source-plugin fails on duplicate attachment instead of silently overwriting ([MSOURCES-143](https://issues.apache.org/jira/browse/MSOURCES-143)).

## Changes Made
- Pin `maven-source-plugin` to 3.2.1 in the `release` profile, with a comment pointing to MSOURCES-143
- Same fix as codelibs/corelib#22 and the workaround already in place in `fess-parent`

## Testing
- `mvn clean source:jar package -Prelease` succeeds locally and the sources jar is built and attached correctly