### PR TITLE
fix(smb2): correct SMB 3.1.1 cipher key labels and harden response decoding

### DIFF
--- a/src/main/java/org/codelibs/jcifs/smb/impl/SID.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SID.java
@@ -125,14 +125,21 @@ public class SID extends rpc.sid_t implements org.codelibs.jcifs.smb.SID {
      * @param si the starting index in the array
      */
     public SID(final byte[] src, int si) {
+        final int start = si;
+        if (si < 0 || (long) si + 8 > src.length) {
+            throw new RuntimeCIFSException("Invalid SID: buffer too short");
+        }
         this.revision = src[si];
         si++;
         this.sub_authority_count = src[si++];
         this.identifier_authority = new byte[6];
         System.arraycopy(src, si, this.identifier_authority, 0, 6);
         si += 6;
-        if (this.sub_authority_count > 100) {
+        if (this.sub_authority_count < 0 || this.sub_authority_count > 100) {
             throw new RuntimeCIFSException("Invalid SID sub_authority_count");
+        }
+        if ((long) start + 8 + 4L * this.sub_authority_count > src.length) {
+            throw new RuntimeCIFSException("Invalid SID: sub authorities exceed buffer");
         }
         this.sub_authority = new int[this.sub_authority_count];
         for (int i = 0; i < this.sub_authority_count; i++) {

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbFileOutputStream.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbFileOutputStream.java
@@ -324,19 +324,14 @@ public class SmbFileOutputStream extends OutputStream {
                 final int blockSize = this.file.getType() == SmbConstants.TYPE_FILESYSTEM ? this.writeSizeFile : this.writeSize;
                 w = len > blockSize ? blockSize : len;
 
+                long cnt;
                 if (this.smb2) {
                     final Smb2WriteRequest wr = new Smb2WriteRequest(th.getConfig(), fh.getFileId());
                     wr.setOffset(this.fp);
                     wr.setData(b, off, w);
 
                     final Smb2WriteResponse resp = th.send(wr, RequestParam.NO_RETRY);
-                    final long cnt = resp.getCount();
-                    if (cnt <= 0) {
-                        throw new IOException("Server returned zero-length write while " + len + " bytes remained");
-                    }
-                    this.fp += cnt;
-                    len -= cnt;
-                    off += cnt;
+                    cnt = resp.getCount();
                 } else if (this.useNTSmbs) {
                     this.reqx.setParam(fh.getFid(), this.fp, len - w, b, off, w);
                     if ((flags & 1) != 0) {
@@ -347,25 +342,25 @@ public class SmbFileOutputStream extends OutputStream {
                     }
 
                     th.send(this.reqx, this.rspx, RequestParam.NO_RETRY);
-                    final long cnt = this.rspx.getCount();
-                    this.fp += cnt;
-                    len -= cnt;
-                    off += cnt;
+                    cnt = this.rspx.getCount();
                 } else {
                     if (log.isTraceEnabled()) {
                         log.trace(String.format("Wrote at %d remain %d off %d len %d", this.fp, len - w, off, w));
                     }
                     this.req.setParam(fh.getFid(), this.fp, len - w, b, off, w);
                     th.send(this.req, this.rsp);
-                    final long cnt = this.rsp.getCount();
-                    this.fp += cnt;
-                    len -= cnt;
-                    off += cnt;
+                    cnt = this.rsp.getCount();
                     if (log.isTraceEnabled()) {
                         log.trace(String.format("Wrote at %d remain %d off %d len %d", this.fp, len - w, off, w));
                     }
                 }
 
+                if (cnt <= 0) {
+                    throw new IOException("Server returned zero-length write while " + len + " bytes remained");
+                }
+                this.fp += cnt;
+                len -= cnt;
+                off += cnt;
             } while (len > 0);
         }
     }

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbFileOutputStream.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbFileOutputStream.java
@@ -202,7 +202,7 @@ public class SmbFileOutputStream extends OutputStream {
     @Override
     public void close() throws IOException {
         try {
-            if (this.handle.isValid()) {
+            if (this.handle != null && this.handle.isValid()) {
                 this.handle.close();
             }
         } finally {
@@ -331,6 +331,9 @@ public class SmbFileOutputStream extends OutputStream {
 
                     final Smb2WriteResponse resp = th.send(wr, RequestParam.NO_RETRY);
                     final long cnt = resp.getCount();
+                    if (cnt <= 0) {
+                        throw new IOException("Server returned zero-length write while " + len + " bytes remained");
+                    }
                     this.fp += cnt;
                     len -= cnt;
                     off += cnt;

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbRandomAccessFile.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbRandomAccessFile.java
@@ -214,7 +214,7 @@ public class SmbRandomAccessFile implements SmbRandomAccess {
                     final Smb2ReadRequest request = new Smb2ReadRequest(th.getConfig(), fh.getFileId(), b, off);
                     request.setOffset(this.fp);
                     request.setReadLength(r);
-                    request.setRemainingBytes(len - off);
+                    request.setRemainingBytes(len);
                     try {
                         final Smb2ReadResponse resp = th.send(request, RequestParam.NO_RETRY);
                         n = resp.getDataLength();
@@ -308,7 +308,7 @@ public class SmbRandomAccessFile implements SmbRandomAccess {
                 if (th.isSMB2()) {
                     final Smb2WriteRequest request = new Smb2WriteRequest(th.getConfig(), fh.getFileId());
                     request.setOffset(this.fp);
-                    request.setRemainingBytes(len - w - off);
+                    request.setRemainingBytes(len - w);
                     request.setData(b, off, w);
                     final Smb2WriteResponse resp = th.send(request, RequestParam.NO_RETRY);
                     cnt = resp.getCount();
@@ -319,6 +319,9 @@ public class SmbRandomAccessFile implements SmbRandomAccess {
                     cnt = this.write_andx_resp.getCount();
                 }
 
+                if (cnt <= 0) {
+                    throw new SmbException("Server returned zero-length write while " + len + " bytes remained");
+                }
                 this.fp += cnt;
                 len -= cnt;
                 off += cnt;

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbRandomAccessFile.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbRandomAccessFile.java
@@ -313,8 +313,7 @@ public class SmbRandomAccessFile implements SmbRandomAccess {
                     final Smb2WriteResponse resp = th.send(request, RequestParam.NO_RETRY);
                     cnt = resp.getCount();
                 } else {
-                    final SmbComWriteAndX request =
-                            new SmbComWriteAndX(th.getConfig(), fh.getFid(), this.fp, len - w - off, b, off, w, null);
+                    final SmbComWriteAndX request = new SmbComWriteAndX(th.getConfig(), fh.getFid(), this.fp, len - w, b, off, w, null);
                     th.send(request, this.write_andx_resp, RequestParam.NO_RETRY);
                     cnt = this.write_andx_resp.getCount();
                 }

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbTransportImpl.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbTransportImpl.java
@@ -130,7 +130,7 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
 
     private final int desiredCredits = 512;
 
-    private byte[] preauthIntegrityHash = new byte[64];
+    private volatile byte[] preauthIntegrityHash = new byte[64];
 
     private final Object preauthLock = new Object();
 

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbTransportImpl.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbTransportImpl.java
@@ -132,6 +132,8 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
 
     private byte[] preauthIntegrityHash = new byte[64];
 
+    private final Object preauthLock = new Object();
+
     SmbTransportImpl(final CIFSContext tc, final Address address, final int port, final InetAddress localAddr, final int localPort,
             final boolean forceSigning) {
         this.transportContext = tc;
@@ -935,7 +937,7 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
             if (log.isTraceEnabled()) {
                 log.trace("Request credits " + reqCredits);
             }
-            request.setRequestCredits(reqCredits);
+            curHead.setRequestCredits(reqCredits);
 
             final CommonServerMessageBlockRequest thisReq = curHead;
             try {
@@ -981,8 +983,8 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
                     }
                     curReq = next;
                 }
-                if (!isDisconnected() && !curReq.isResponseAsync() && !curReq.getResponse().isAsync() && !curReq.getResponse().isError()
-                        && grantedCredits == 0) {
+                if (!isDisconnected() && !curReq.isResponseAsync() && curReq.getResponse() != null && !curReq.getResponse().isAsync()
+                        && !curReq.getResponse().isError() && grantedCredits == 0) {
                     if (this.credits.availablePermits() > 0 || n > 0) {
                         log.debug("Server " + this + " returned zero credits for " + curReq);
                     } else {
@@ -1686,7 +1688,7 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
     }
 
     private void updatePreauthHash(final byte[] input) throws CIFSException {
-        synchronized (this.preauthIntegrityHash) {
+        synchronized (this.preauthLock) {
             this.preauthIntegrityHash = calculatePreauthHash(input, 0, input.length, this.preauthIntegrityHash);
         }
     }

--- a/src/main/java/org/codelibs/jcifs/smb/internal/dfs/Referral.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/dfs/Referral.java
@@ -156,6 +156,10 @@ public class Referral implements Decodable {
     public int decode(final byte[] buffer, int bufferIndex, final int len) {
         final int start = bufferIndex;
 
+        if (bufferIndex < 0 || (long) bufferIndex + 8 > buffer.length) {
+            throw new RuntimeCIFSException("Invalid referral");
+        }
+
         this.version = SMBUtil.readInt2(buffer, bufferIndex);
         if (this.version != 3 && this.version != 1) {
             throw new RuntimeCIFSException(
@@ -169,6 +173,9 @@ public class Referral implements Decodable {
         this.rflags = SMBUtil.readInt2(buffer, bufferIndex);
         bufferIndex += 2;
         if (this.version == 3) {
+            if ((long) bufferIndex + 10 > buffer.length) {
+                throw new RuntimeCIFSException("Invalid referral");
+            }
             this.proximity = SMBUtil.readInt2(buffer, bufferIndex);
             bufferIndex += 2;
             this.ttl = SMBUtil.readInt2(buffer, bufferIndex);
@@ -226,7 +233,11 @@ public class Referral implements Decodable {
         if (bufferIndex % 2 != 0) {
             bufferIndex++;
         }
-        return Strings.fromUNIBytes(buffer, bufferIndex, Strings.findUNITermination(buffer, bufferIndex, len));
+        if (bufferIndex < 0 || (long) bufferIndex + 2 > buffer.length) {
+            throw new RuntimeCIFSException("Invalid referral string offset");
+        }
+        final int maxLen = Math.min(len, buffer.length - bufferIndex - 2);
+        return Strings.fromUNIBytes(buffer, bufferIndex, Strings.findUNITermination(buffer, bufferIndex, maxLen));
     }
 
     @Override

--- a/src/main/java/org/codelibs/jcifs/smb/internal/dtyp/SecurityDescriptor.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/dtyp/SecurityDescriptor.java
@@ -110,7 +110,7 @@ public class SecurityDescriptor implements SecurityInfo {
     public int decode(final byte[] buffer, int bufferIndex, final int len) throws SMBProtocolDecodingException {
         final int start = bufferIndex;
 
-        if ((long) start + 20 > buffer.length) {
+        if (start < 0 || (long) start + 20 > buffer.length) {
             throw new SMBProtocolDecodingException("Invalid SecurityDescriptor");
         }
 

--- a/src/main/java/org/codelibs/jcifs/smb/internal/dtyp/SecurityDescriptor.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/dtyp/SecurityDescriptor.java
@@ -110,6 +110,10 @@ public class SecurityDescriptor implements SecurityInfo {
     public int decode(final byte[] buffer, int bufferIndex, final int len) throws SMBProtocolDecodingException {
         final int start = bufferIndex;
 
+        if ((long) start + 20 > buffer.length) {
+            throw new SMBProtocolDecodingException("Invalid SecurityDescriptor");
+        }
+
         bufferIndex++; // revision
         bufferIndex++;
         this.type = SMBUtil.readInt2(buffer, bufferIndex);
@@ -121,6 +125,11 @@ public class SecurityDescriptor implements SecurityInfo {
         SMBUtil.readInt4(buffer, bufferIndex); // offset to sacl
         bufferIndex += 4;
         final int daclOffset = SMBUtil.readInt4(buffer, bufferIndex);
+
+        if (ownerUOffset < 0 || ownerGOffset < 0 || daclOffset < 0 || (long) start + ownerUOffset > buffer.length
+                || (long) start + ownerGOffset > buffer.length || (long) start + daclOffset > buffer.length) {
+            throw new SMBProtocolDecodingException("Invalid SecurityDescriptor offset");
+        }
 
         if (ownerUOffset > 0) {
             bufferIndex = start + ownerUOffset;
@@ -137,6 +146,9 @@ public class SecurityDescriptor implements SecurityInfo {
         bufferIndex = start + daclOffset;
 
         if (daclOffset > 0) {
+            if ((long) start + daclOffset + 8 > buffer.length) {
+                throw new SMBProtocolDecodingException("Invalid SecurityDescriptor");
+            }
             bufferIndex++; // revision
             bufferIndex++;
             SMBUtil.readInt2(buffer, bufferIndex);
@@ -144,12 +156,15 @@ public class SecurityDescriptor implements SecurityInfo {
             final int numAces = SMBUtil.readInt4(buffer, bufferIndex);
             bufferIndex += 4;
 
-            if (numAces > 4096) {
+            if (numAces < 0 || numAces > 4096) {
                 throw new SMBProtocolDecodingException("Invalid SecurityDescriptor");
             }
 
             this.aces = new ACE[numAces];
             for (int i = 0; i < numAces; i++) {
+                if ((long) bufferIndex + 8 > buffer.length) {
+                    throw new SMBProtocolDecodingException("Invalid SecurityDescriptor");
+                }
                 this.aces[i] = new ACE();
                 bufferIndex += this.aces[i].decode(buffer, bufferIndex, len - bufferIndex);
             }

--- a/src/main/java/org/codelibs/jcifs/smb/internal/fscc/FileBothDirectoryInfo.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/fscc/FileBothDirectoryInfo.java
@@ -129,6 +129,9 @@ public class FileBothDirectoryInfo implements FileEntry, Decodable {
     @Override
     public int decode(final byte[] buffer, int bufferIndex, final int len) throws SMBProtocolDecodingException {
         final int start = bufferIndex;
+        if (bufferIndex < 0 || (long) bufferIndex + 94 > buffer.length) {
+            throw new SMBProtocolDecodingException("Invalid directory entry: buffer too small");
+        }
         this.nextEntryOffset = SMBUtil.readInt4(buffer, bufferIndex);
         bufferIndex += 4;
         this.fileIndex = SMBUtil.readInt4(buffer, bufferIndex);
@@ -153,6 +156,9 @@ public class FileBothDirectoryInfo implements FileEntry, Decodable {
         bufferIndex += 4;
 
         final int shortNameLength = buffer[bufferIndex] & 0xFF;
+        if (shortNameLength > 24) {
+            throw new SMBProtocolDecodingException("Invalid short name length in directory entry");
+        }
         bufferIndex += 2;
 
         this.shortName = Strings.fromUNIBytes(buffer, bufferIndex, shortNameLength);

--- a/src/main/java/org/codelibs/jcifs/smb/internal/fscc/FileBothDirectoryInfo.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/fscc/FileBothDirectoryInfo.java
@@ -158,6 +158,9 @@ public class FileBothDirectoryInfo implements FileEntry, Decodable {
         this.shortName = Strings.fromUNIBytes(buffer, bufferIndex, shortNameLength);
         bufferIndex += 24;
 
+        if (fileNameLength < 0 || (long) bufferIndex + fileNameLength > buffer.length) {
+            throw new SMBProtocolDecodingException("Invalid file name length in directory entry");
+        }
         String str;
         if (this.unicode) {
             if (fileNameLength > 0 && buffer[bufferIndex + fileNameLength - 1] == '\0'
@@ -174,7 +177,7 @@ public class FileBothDirectoryInfo implements FileEntry, Decodable {
         this.filename = str;
         bufferIndex += fileNameLength;
 
-        return start - bufferIndex;
+        return bufferIndex - start;
     }
 
     @Override

--- a/src/main/java/org/codelibs/jcifs/smb/internal/fscc/FileRenameInformation2.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/fscc/FileRenameInformation2.java
@@ -81,8 +81,14 @@ public class FileRenameInformation2 implements FileInformation {
     public int encode(final byte[] dst, int dstIndex) {
         final int start = dstIndex;
         dst[dstIndex] = (byte) (this.replaceIfExists ? 1 : 0);
-        dstIndex += 8; // 7 Reserved
-        dstIndex += 8; // RootDirectory = 0
+        for (int i = 1; i < 8; i++) {
+            dst[dstIndex + i] = 0; // Reserved (7 bytes)
+        }
+        dstIndex += 8;
+        for (int i = 0; i < 8; i++) {
+            dst[dstIndex + i] = 0; // RootDirectory = 0
+        }
+        dstIndex += 8;
 
         final byte[] nameBytes = this.fileName.getBytes(StandardCharsets.UTF_16LE);
 

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb1/com/SmbComLockingAndX.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb1/com/SmbComLockingAndX.java
@@ -73,7 +73,7 @@ public class SmbComLockingAndX extends AndXServerMessageBlock {
 
         SMBUtil.writeInt2(this.locks != null ? this.locks.length : 0, dst, dstIndex);
         dstIndex += 2;
-        return start - dstIndex;
+        return dstIndex - start;
     }
 
     /**
@@ -107,7 +107,7 @@ public class SmbComLockingAndX extends AndXServerMessageBlock {
         final int nlocks = SMBUtil.readInt2(buffer, bufferIndex);
         this.locks = new LockingAndXRange[nlocks];
         bufferIndex += 2;
-        return start - bufferIndex;
+        return bufferIndex - start;
     }
 
     /**
@@ -128,7 +128,7 @@ public class SmbComLockingAndX extends AndXServerMessageBlock {
                 dstIndex += lockingAndXRange.encode(dst, dstIndex);
             }
         }
-        return start - dstIndex;
+        return dstIndex - start;
     }
 
     /**
@@ -149,7 +149,7 @@ public class SmbComLockingAndX extends AndXServerMessageBlock {
             bufferIndex += this.locks[i].decode(buffer, bufferIndex, buffer.length);
         }
 
-        return start - bufferIndex;
+        return bufferIndex - start;
     }
 
     /**

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb1/trans/nt/FileNotifyInformationImpl.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb1/trans/nt/FileNotifyInformationImpl.java
@@ -86,6 +86,10 @@ public class FileNotifyInformationImpl implements FileNotifyInformation, Decodab
         }
         final int start = bufferIndex;
 
+        if ((long) bufferIndex + 12 > buffer.length) {
+            throw new SMBProtocolDecodingException("Invalid file notify information");
+        }
+
         this.nextEntryOffset = SMBUtil.readInt4(buffer, bufferIndex);
         bufferIndex += 4;
 

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb1/trans/nt/FileNotifyInformationImpl.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb1/trans/nt/FileNotifyInformationImpl.java
@@ -99,6 +99,10 @@ public class FileNotifyInformationImpl implements FileNotifyInformation, Decodab
         this.fileNameLength = SMBUtil.readInt4(buffer, bufferIndex);
         bufferIndex += 4;
 
+        if (this.fileNameLength < 0 || (long) bufferIndex + this.fileNameLength > buffer.length) {
+            throw new SMBProtocolDecodingException("Invalid file notify name length");
+        }
+
         this.fileName = Strings.fromUNIBytes(buffer, bufferIndex, this.fileNameLength);
         bufferIndex += this.fileNameLength;
         return bufferIndex - start;

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/ServerMessageBlock2.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/ServerMessageBlock2.java
@@ -681,6 +681,9 @@ public abstract class ServerMessageBlock2 implements CommonServerMessageBlock {
         final int bc = SMBUtil.readInt4(buffer, bufferIndex);
         bufferIndex += 4;
 
+        if (bc < 0 || (long) bufferIndex + bc > buffer.length) {
+            throw new SMBProtocolDecodingException("Invalid error data length");
+        }
         if (bc > 0) {
             this.errorData = new byte[bc];
             System.arraycopy(buffer, bufferIndex, this.errorData, 0, bc);

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/ServerMessageBlock2.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/ServerMessageBlock2.java
@@ -131,7 +131,7 @@ public abstract class ServerMessageBlock2 implements CommonServerMessageBlock {
     private boolean async;
     private int treeId;
     private long mid, asyncId, sessionId;
-    private byte errorContextCount;
+    private int errorContextCount;
     private byte[] errorData;
 
     private boolean retainPayload;
@@ -495,7 +495,7 @@ public abstract class ServerMessageBlock2 implements CommonServerMessageBlock {
      *
      * @return the errorContextCount
      */
-    public final byte getErrorContextCount() {
+    public final int getErrorContextCount() {
         return this.errorContextCount;
     }
 
@@ -675,7 +675,7 @@ public abstract class ServerMessageBlock2 implements CommonServerMessageBlock {
         if (structureSize != 9) {
             throw new SMBProtocolDecodingException("Error structureSize should be 9");
         }
-        this.errorContextCount = buffer[bufferIndex + 2];
+        this.errorContextCount = buffer[bufferIndex + 2] & 0xFF;
         bufferIndex += 4;
 
         final int bc = SMBUtil.readInt4(buffer, bufferIndex);

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/Smb3KeyDerivation.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/Smb3KeyDerivation.java
@@ -43,11 +43,11 @@ public final class Smb3KeyDerivation {
 
     private static final byte[] ENCCONTEXT_300 = toCBytes("ServerIn "); // there really is a space there
     private static final byte[] ENCLABEL_300 = toCBytes("SMB2AESCCM");
-    private static final byte[] ENCLABEL_311 = toCBytes("SMB2C2SCipherKey");
+    private static final byte[] ENCLABEL_311 = toCBytes("SMBC2SCipherKey");
 
     private static final byte[] DECCONTEXT_300 = toCBytes("ServerOut");
     private static final byte[] DECLABEL_300 = toCBytes("SMB2AESCCM");
-    private static final byte[] DECLABEL_311 = toCBytes("SMB2S2CCipherKey");
+    private static final byte[] DECLABEL_311 = toCBytes("SMBS2CCipherKey");
 
     /**
      *

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/create/Smb2CreateResponse.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/create/Smb2CreateResponse.java
@@ -277,6 +277,9 @@ public class Smb2CreateResponse extends ServerMessageBlock2Response implements S
             int createContextStart = getHeaderStart() + createContextOffset;
             int next = 0;
             do {
+                if (createContextStart < 0 || (long) createContextStart + 16 > buffer.length) {
+                    throw new SMBProtocolDecodingException("Invalid create context offset");
+                }
                 int cci = createContextStart;
                 next = SMBUtil.readInt4(buffer, cci);
                 cci += 4;

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/create/Smb2CreateResponse.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/create/Smb2CreateResponse.java
@@ -290,6 +290,11 @@ public class Smb2CreateResponse extends ServerMessageBlock2Response implements S
                 final int dataLength = SMBUtil.readInt4(buffer, cci);
                 cci += 4;
 
+                if (nameLength < 0 || dataLength < 0 || createContextStart < 0
+                        || (long) createContextStart + nameOffset + nameLength > buffer.length
+                        || (long) createContextStart + dataOffset + dataLength > buffer.length) {
+                    throw new SMBProtocolDecodingException("Invalid create context offset/length");
+                }
                 final byte[] nameBytes = new byte[nameLength];
                 System.arraycopy(buffer, createContextStart + nameOffset, nameBytes, 0, nameBytes.length);
                 cci = Math.max(cci, createContextStart + nameOffset + nameLength);

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/info/Smb2QueryDirectoryResponse.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/info/Smb2QueryDirectoryResponse.java
@@ -114,6 +114,9 @@ public class Smb2QueryDirectoryResponse extends ServerMessageBlock2Response {
             if (nextEntryOffset <= 0) {
                 break;
             }
+            if ((long) bufferIndex + nextEntryOffset >= (long) bufferOffset + bufferLength) {
+                break;
+            }
             bufferIndex += nextEntryOffset;
         } while (bufferIndex < bufferOffset + bufferLength);
         this.results = infos.toArray(new FileEntry[infos.size()]);

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/info/Smb2QueryDirectoryResponse.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/info/Smb2QueryDirectoryResponse.java
@@ -96,6 +96,10 @@ public class Smb2QueryDirectoryResponse extends ServerMessageBlock2Response {
         final int bufferLength = SMBUtil.readInt4(buffer, bufferIndex);
         bufferIndex += 4;
 
+        if (bufferLength < 0 || bufferOffset < 0 || (long) bufferOffset + bufferLength > buffer.length) {
+            throw new SMBProtocolDecodingException("Invalid query directory buffer offset/length");
+        }
+
         // bufferIndex = bufferOffset;
 
         final List<FileEntry> infos = new ArrayList<>();

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/info/Smb2QueryInfoResponse.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/info/Smb2QueryInfoResponse.java
@@ -121,6 +121,9 @@ public class Smb2QueryInfoResponse extends ServerMessageBlock2Response {
         bufferIndex += 4;
         final int bufferLength = SMBUtil.readInt4(buffer, bufferIndex);
         bufferIndex += 4;
+        if (bufferLength < 0 || bufferOffset < 0 || (long) bufferOffset + bufferLength > buffer.length) {
+            throw new SMBProtocolDecodingException("Invalid query info buffer offset/length");
+        }
         final Decodable i = createInformation(this.expectInfoType, this.expectInfoClass);
         if (i != null) {
             i.decode(buffer, bufferOffset, bufferLength);

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/io/Smb2ReadResponse.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/io/Smb2ReadResponse.java
@@ -104,7 +104,7 @@ public class Smb2ReadResponse extends ServerMessageBlock2Response {
             throw new SMBProtocolDecodingException("Expected structureSize = 17");
         }
 
-        final short dataOffset = buffer[bufferIndex + 2];
+        final int dataOffset = buffer[bufferIndex + 2] & 0xFF;
         bufferIndex += 4;
         this.dataLength = SMBUtil.readInt4(buffer, bufferIndex);
         bufferIndex += 4;
@@ -114,6 +114,9 @@ public class Smb2ReadResponse extends ServerMessageBlock2Response {
 
         final int dataStart = getHeaderStart() + dataOffset;
 
+        if (this.dataLength < 0 || dataStart < 0 || (long) dataStart + this.dataLength > buffer.length) {
+            throw new SMBProtocolDecodingException("Invalid read response data offset/length");
+        }
         if (this.dataLength + this.outputBufferOffset > this.outputBuffer.length) {
             throw new SMBProtocolDecodingException("Buffer to small for read response");
         }

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/ioctl/Smb2IoctlResponse.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/ioctl/Smb2IoctlResponse.java
@@ -196,6 +196,11 @@ public class Smb2IoctlResponse extends ServerMessageBlock2Response {
         bufferIndex += 4;
         bufferIndex += 4; // Reserved2
 
+        if (inputCount < 0 || outputCount < 0 || inputOffset < 0 || outputOffset < 0 || (long) inputOffset + inputCount > buffer.length
+                || (long) outputOffset + outputCount > buffer.length) {
+            throw new SMBProtocolDecodingException("Invalid ioctl input/output offset/length");
+        }
+
         this.inputData = createInputDecodable();
         this.outputData = this.outputBuffer == null ? createOutputDecodable() : null;
 

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/ioctl/SrvPipePeekResponse.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/ioctl/SrvPipePeekResponse.java
@@ -92,6 +92,9 @@ public class SrvPipePeekResponse implements Decodable {
      */
     @Override
     public int decode(final byte[] buffer, int bufferIndex, final int len) throws SMBProtocolDecodingException {
+        if (len < 16 || (long) bufferIndex + len > buffer.length) {
+            throw new SMBProtocolDecodingException("Invalid pipe peek response length");
+        }
         final int start = bufferIndex;
         this.namedPipeState = SMBUtil.readInt4(buffer, bufferIndex);
         bufferIndex += 4;

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/nego/EncryptionNegotiateContext.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/nego/EncryptionNegotiateContext.java
@@ -114,6 +114,10 @@ public class EncryptionNegotiateContext implements NegotiateContextRequest, Nego
         final int nciphers = SMBUtil.readInt2(buffer, bufferIndex);
         bufferIndex += 2;
 
+        if ((long) bufferIndex + 2L * nciphers > buffer.length) {
+            throw new SMBProtocolDecodingException("Invalid encryption negotiate context");
+        }
+
         this.ciphers = new int[nciphers];
         for (int i = 0; i < nciphers; i++) {
             this.ciphers[i] = SMBUtil.readInt2(buffer, bufferIndex);

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/nego/PreauthIntegrityNegotiateContext.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/nego/PreauthIntegrityNegotiateContext.java
@@ -130,6 +130,10 @@ public class PreauthIntegrityNegotiateContext implements NegotiateContextRequest
         final int nsalt = SMBUtil.readInt2(buffer, bufferIndex + 2);
         bufferIndex += 4;
 
+        if ((long) bufferIndex + 2L * nalgos + nsalt > buffer.length) {
+            throw new SMBProtocolDecodingException("Invalid preauth integrity negotiate context");
+        }
+
         this.hashAlgos = new int[nalgos];
         for (int i = 0; i < nalgos; i++) {
             this.hashAlgos[i] = SMBUtil.readInt2(buffer, bufferIndex);

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/nego/Smb2NegotiateResponse.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/nego/Smb2NegotiateResponse.java
@@ -534,10 +534,16 @@ public class Smb2NegotiateResponse extends ServerMessageBlock2Response implement
             int ncpos = getHeaderStart() + negotiateContextOffset;
             final NegotiateContextResponse[] contexts = new NegotiateContextResponse[negotiateContextCount];
             for (int i = 0; i < negotiateContextCount; i++) {
+                if (ncpos < 0 || (long) ncpos + 8 > buffer.length) {
+                    throw new SMBProtocolDecodingException("Invalid negotiate context offset");
+                }
                 final int type = SMBUtil.readInt2(buffer, ncpos);
                 final int dataLen = SMBUtil.readInt2(buffer, ncpos + 2);
                 ncpos += 4;
                 ncpos += 4; // Reserved
+                if ((long) ncpos + dataLen > buffer.length) {
+                    throw new SMBProtocolDecodingException("Invalid negotiate context data length");
+                }
                 final NegotiateContextResponse ctx = createContext(type);
                 if (ctx != null) {
                     ctx.decode(buffer, ncpos, dataLen);

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/notify/Smb2ChangeNotifyResponse.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/notify/Smb2ChangeNotifyResponse.java
@@ -83,12 +83,19 @@ public class Smb2ChangeNotifyResponse extends ServerMessageBlock2Response implem
         final int len = SMBUtil.readInt4(buffer, bufferIndex);
         bufferIndex += 4;
 
+        if (len < 0 || bufferOffset < 0 || (long) bufferOffset + len > buffer.length) {
+            throw new SMBProtocolDecodingException("Invalid change notify buffer offset/length");
+        }
+
         int elemStart = bufferOffset;
         FileNotifyInformationImpl i = new FileNotifyInformationImpl();
         bufferIndex += i.decode(buffer, bufferOffset, len);
         this.notifyInformation.add(i);
 
         while (i.getNextEntryOffset() > 0 && bufferIndex < bufferOffset + len) {
+            if ((long) elemStart + i.getNextEntryOffset() >= (long) bufferOffset + len) {
+                break;
+            }
             bufferIndex = elemStart + i.getNextEntryOffset();
             elemStart = bufferIndex;
 

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/session/Smb2SessionSetupResponse.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/session/Smb2SessionSetupResponse.java
@@ -118,9 +118,14 @@ public class Smb2SessionSetupResponse extends ServerMessageBlock2Response {
         final int securityBufferLength = SMBUtil.readInt2(buffer, bufferIndex + 2);
         bufferIndex += 4;
 
-        final int pad = bufferIndex - (getHeaderStart() + securityBufferOffset);
+        final int securityBufferStart = getHeaderStart() + securityBufferOffset;
+        if (securityBufferLength < 0 || securityBufferStart < 0 || (long) securityBufferStart + securityBufferLength > buffer.length) {
+            throw new SMBProtocolDecodingException("Invalid session setup security buffer offset/length");
+        }
+
+        final int pad = bufferIndex - securityBufferStart;
         this.blob = new byte[securityBufferLength];
-        System.arraycopy(buffer, getHeaderStart() + securityBufferOffset, this.blob, 0, securityBufferLength);
+        System.arraycopy(buffer, securityBufferStart, this.blob, 0, securityBufferLength);
         bufferIndex += pad;
         bufferIndex += securityBufferLength;
 

--- a/src/main/java/org/codelibs/jcifs/smb/util/transport/Transport.java
+++ b/src/main/java/org/codelibs/jcifs/smb/util/transport/Transport.java
@@ -407,7 +407,7 @@ public abstract class Transport implements Runnable, AutoCloseable {
                     }
 
                     curResp.wait();
-                    if (handleIntermediate(request, curResp)) {
+                    if (handleIntermediate(curReq, curResp)) {
                         continue;
                     }
                     if (log.isDebugEnabled()) {

--- a/src/test/java/org/codelibs/jcifs/smb/dcerpc/msrpc/MsrpcShareGetInfoTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/dcerpc/msrpc/MsrpcShareGetInfoTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.lang.reflect.Field;
 
 import org.codelibs.jcifs.smb.dcerpc.DcerpcConstants;
+import org.codelibs.jcifs.smb.internal.SMBProtocolDecodingException;
 import org.codelibs.jcifs.smb.internal.dtyp.ACE;
 import org.codelibs.jcifs.smb.internal.dtyp.SecurityDescriptor;
 import org.junit.jupiter.api.BeforeEach;
@@ -187,8 +188,9 @@ class MsrpcShareGetInfoTest {
         infoField.setAccessible(true);
         infoField.set(msrpcShareGetInfo, info502);
 
-        // Test getSecurity with empty descriptor - should throw exception
-        assertThrows(ArrayIndexOutOfBoundsException.class, () -> {
+        // Test getSecurity with empty descriptor - decode rejects the malformed
+        // (too short for the fixed 20-byte header) buffer with a controlled exception
+        assertThrows(SMBProtocolDecodingException.class, () -> {
             msrpcShareGetInfo.getSecurity();
         });
     }
@@ -230,15 +232,16 @@ class MsrpcShareGetInfoTest {
         // Test when sd_size doesn't match actual array size
         srvsvc.ShareInfo502 info502 = new srvsvc.ShareInfo502();
         info502.security_descriptor = new byte[] { 1, 2, 3, 4 };
-        info502.sd_size = 100; // Mismatched size - SecurityDescriptor will try to read beyond array bounds
+        info502.sd_size = 100; // Mismatched size - buffer is too short for the descriptor
 
         // Replace info field
         Field infoField = msrpcShareGetInfo.getClass().getSuperclass().getDeclaredField("info");
         infoField.setAccessible(true);
         infoField.set(msrpcShareGetInfo, info502);
 
-        // This should throw an ArrayIndexOutOfBoundsException when trying to read beyond array
-        assertThrows(ArrayIndexOutOfBoundsException.class, () -> {
+        // decode rejects the truncated buffer with a controlled exception instead of
+        // reading beyond the array bounds
+        assertThrows(SMBProtocolDecodingException.class, () -> {
             msrpcShareGetInfo.getSecurity();
         });
     }
@@ -322,8 +325,9 @@ class MsrpcShareGetInfoTest {
         infoField.setAccessible(true);
         infoField.set(msrpcShareGetInfo, info502);
 
-        // Test getSecurity with special bytes - should throw exception due to invalid format
-        assertThrows(ArrayIndexOutOfBoundsException.class, () -> {
+        // Test getSecurity with special bytes - decode rejects the invalid/undersized
+        // descriptor with a controlled exception due to invalid format
+        assertThrows(SMBProtocolDecodingException.class, () -> {
             msrpcShareGetInfo.getSecurity();
         });
     }

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SIDTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SIDTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 
 import org.codelibs.jcifs.smb.CIFSContext;
 import org.codelibs.jcifs.smb.CIFSException;
+import org.codelibs.jcifs.smb.RuntimeCIFSException;
 import org.codelibs.jcifs.smb.SidResolver;
 import org.codelibs.jcifs.smb.dcerpc.rpc;
 import org.junit.jupiter.api.BeforeEach;
@@ -128,6 +129,49 @@ class SIDTest {
             // Act + Assert
             RuntimeException ex = assertThrows(RuntimeException.class, () -> new SID(bytes, 0));
             assertTrue(ex.getMessage().contains("Invalid SID sub_authority_count"));
+        }
+
+        @Test
+        @DisplayName("Binary constructor rejects buffer too short for the 8-byte fixed header")
+        void testBinaryConstructorBufferTooShort() {
+            // Arrange: only 6 bytes, fewer than the fixed 8-byte SID header (revision + count + 6-byte authority)
+            byte[] tooShort = new byte[6];
+            tooShort[0] = 1; // revision
+
+            // Act + Assert
+            RuntimeCIFSException ex = assertThrows(RuntimeCIFSException.class, () -> new SID(tooShort, 0));
+            assertTrue(ex.getMessage().contains("buffer too short"));
+        }
+
+        @Test
+        @DisplayName("Binary constructor rejects sub_authority_count that exceeds the buffer")
+        void testBinaryConstructorSubAuthoritiesExceedBuffer() {
+            // Arrange: header claims 5 sub-authorities, but the buffer only holds 2 (8 + 2*4 = 16 bytes)
+            byte[] bytes = new byte[8 + 2 * 4];
+            bytes[0] = 1; // revision
+            bytes[1] = 5; // sub_authority_count says 5, buffer only holds 2
+
+            // Act + Assert
+            RuntimeCIFSException ex = assertThrows(RuntimeCIFSException.class, () -> new SID(bytes, 0));
+            assertTrue(ex.getMessage().contains("sub authorities exceed buffer"));
+        }
+
+        @Test
+        @DisplayName("Binary constructor accepts a well-formed SID sized exactly to the buffer (no false reject)")
+        void testBinaryConstructorExactFitBoundary() {
+            // Arrange: S-1-5-21-1-2-3-1029, 5 sub-authorities, buffer sized exactly 8 + 5*4 = 28
+            byte[] ident = new byte[] { 0, 0, 0, 0, 0, 5 };
+            byte[] bytes = SID.toByteArray(buildSidT((byte) 1, ident, 21, 1, 2, 3, 1029));
+            assertEquals(28, bytes.length); // exact fit: no trailing slack
+
+            // Act: an exactly-sized buffer must be accepted, not rejected by the new bounds guard
+            SID sid = new SID(bytes, 0);
+
+            // Assert
+            assertEquals(1, sid.revision);
+            assertEquals(5, sid.sub_authority_count);
+            assertEquals("S-1-5-21-1-2-3-1029", sid.toString());
+            assertEquals(1029, sid.getRid());
         }
 
         @Test

--- a/src/test/java/org/codelibs/jcifs/smb/internal/dfs/ReferralTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/dfs/ReferralTest.java
@@ -649,4 +649,68 @@ public class ReferralTest {
 
         assertArrayEquals(expectedNames, referral.getExpandedNames());
     }
+
+    // Bounds Guard Tests
+
+    @Test
+    @DisplayName("Throw for a truncated referral shorter than the 8-byte header")
+    public void shouldThrowForTruncatedReferral() {
+        // Buffer smaller than the fixed 8-byte referral header
+        byte[] shortBuffer = new byte[6];
+
+        RuntimeCIFSException ex = assertThrows(RuntimeCIFSException.class, () -> new Referral().decode(shortBuffer, 0, shortBuffer.length),
+                "Should throw for a truncated referral header");
+        assertTrue(ex.getMessage().contains("Invalid referral"));
+    }
+
+    @Test
+    @DisplayName("Throw for version 3 referral whose path offset points past the buffer")
+    public void shouldThrowForVersion3PathOffsetPastBuffer() {
+        // Valid v3 header, but pathOffset points well past the end of the buffer so readString would over-read
+        byte[] buffer = new byte[20];
+        ByteBuffer bb = ByteBuffer.wrap(buffer).order(ByteOrder.LITTLE_ENDIAN);
+        bb.putShort((short) 3); // version
+        bb.putShort((short) 18); // size
+        bb.putShort((short) 1); // serverType
+        bb.putShort((short) 0); // rflags (no name list)
+        bb.putShort((short) 5); // proximity
+        bb.putShort((short) 300); // ttl
+        bb.putShort((short) 1000); // pathOffset (past buffer)
+        bb.putShort((short) 0); // altPathOffset
+        bb.putShort((short) 0); // nodeOffset
+
+        RuntimeCIFSException ex = assertThrows(RuntimeCIFSException.class, () -> new Referral().decode(buffer, 0, buffer.length),
+                "Should throw when a v3 string offset points past the buffer");
+        assertTrue(ex.getMessage().contains("Invalid referral"));
+    }
+
+    @Test
+    @DisplayName("Decode version 3 referral whose node string terminates exactly at the buffer end (no false reject / no truncation)")
+    public void shouldDecodeVersion3WithStringAtBufferEnd() {
+        // Header (v3, no name list) = 18 bytes; node "NODE" = 8 bytes at 18..25, terminator at 26..27
+        // Buffer length is exactly 28 so the terminator occupies the last two bytes; the maxLen cap must not truncate it.
+        byte[] buffer = new byte[28];
+        ByteBuffer bb = ByteBuffer.wrap(buffer).order(ByteOrder.LITTLE_ENDIAN);
+        bb.putShort((short) 3); // version
+        bb.putShort((short) 28); // size
+        bb.putShort((short) 1); // serverType
+        bb.putShort((short) 0); // rflags (no name list)
+        bb.putShort((short) 5); // proximity
+        bb.putShort((short) 300); // ttl
+        bb.putShort((short) 0); // pathOffset (none)
+        bb.putShort((short) 0); // altPathOffset (none)
+        bb.putShort((short) 18); // nodeOffset
+
+        bb.position(18);
+        bb.put("NODE".getBytes(StandardCharsets.UTF_16LE)); // 8 bytes: 18..25
+        bb.putShort((short) 0); // terminator at 26..27 (last two bytes of the buffer)
+
+        Referral ref = new Referral();
+        int decodedSize = ref.decode(buffer, 0, buffer.length);
+
+        assertEquals(28, decodedSize);
+        assertEquals("NODE", ref.getNode()); // full string returned, not truncated by the maxLen cap
+        assertNull(ref.getRpath());
+        assertNull(ref.getAltPath());
+    }
 }

--- a/src/test/java/org/codelibs/jcifs/smb/internal/dtyp/SecurityDescriptorTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/dtyp/SecurityDescriptorTest.java
@@ -366,6 +366,85 @@ class SecurityDescriptorTest {
         assertEquals(1, securityDescriptor.getAces().length);
     }
 
+    @Test
+    @DisplayName("Test decode throws for buffer too short for the 20-byte header")
+    void testDecodeThrowsForBufferTooShortForHeader() {
+        // A 10-byte buffer is smaller than the fixed 20-byte SecurityDescriptor header
+        byte[] shortBuffer = new byte[10];
+
+        assertThrows(SMBProtocolDecodingException.class, () -> securityDescriptor.decode(shortBuffer, 0, shortBuffer.length),
+                "Should throw for a buffer smaller than the 20-byte header");
+    }
+
+    @Test
+    @DisplayName("Test decode throws when owner offset points past the buffer")
+    void testDecodeThrowsForOwnerOffsetPastBuffer() {
+        // Valid 20-byte header, but the owner SID offset points well past the end of the buffer
+        byte[] buffer = new byte[24];
+        buffer[0] = 0x01; // revision
+        buffer[1] = 0x00; // padding
+        SMBUtil.writeInt2(0x8004, buffer, 2); // type
+        SMBUtil.writeInt4(1000, buffer, 4); // owner offset (past buffer)
+        SMBUtil.writeInt4(0, buffer, 8); // group offset
+        SMBUtil.writeInt4(0, buffer, 12); // SACL offset
+        SMBUtil.writeInt4(0, buffer, 16); // DACL offset
+
+        assertThrows(SMBProtocolDecodingException.class, () -> securityDescriptor.decode(buffer, 0, buffer.length),
+                "Should throw when the owner offset points past the buffer");
+    }
+
+    @Test
+    @DisplayName("Test decode throws for negative ACE count (guards against NegativeArraySizeException)")
+    void testDecodeThrowsForNegativeAceCount() {
+        // Header with a DACL whose numAces field is 0x80000000, i.e. negative when read as a signed int
+        byte[] buffer = new byte[64];
+        buffer[0] = 0x01; // revision
+        buffer[1] = 0x00; // padding
+        SMBUtil.writeInt2(0x8004, buffer, 2); // type
+        SMBUtil.writeInt4(0, buffer, 4); // owner offset
+        SMBUtil.writeInt4(0, buffer, 8); // group offset
+        SMBUtil.writeInt4(0, buffer, 12); // SACL offset
+        SMBUtil.writeInt4(20, buffer, 16); // DACL offset
+
+        // DACL header at offset 20
+        buffer[20] = 0x02; // revision
+        buffer[21] = 0x00; // padding
+        SMBUtil.writeInt2(0, buffer, 22); // size
+        SMBUtil.writeInt4(0x80000000L, buffer, 24); // ACE count = negative
+
+        assertThrows(SMBProtocolDecodingException.class, () -> securityDescriptor.decode(buffer, 0, buffer.length),
+                "Should throw for a negative ACE count instead of raising NegativeArraySizeException");
+    }
+
+    @Test
+    @DisplayName("Test decode accepts owner SID plus a DACL with two ACEs (no false reject)")
+    void testDecodeOwnerAndDaclWithAcesValid() throws SMBProtocolDecodingException {
+        // Well-formed descriptor: header (20 bytes), owner SID at offset 20, DACL with 2 ACEs at offset 32
+        testBuffer[0] = 0x01; // revision
+        testBuffer[1] = 0x00; // padding
+        SMBUtil.writeInt2(0x8004, testBuffer, 2); // type
+        SMBUtil.writeInt4(20, testBuffer, 4); // owner offset
+        SMBUtil.writeInt4(0, testBuffer, 8); // group offset
+        SMBUtil.writeInt4(0, testBuffer, 12); // SACL offset
+        SMBUtil.writeInt4(32, testBuffer, 16); // DACL offset
+
+        // Owner SID (simple, single sub-authority) at offset 20, occupying bytes 20..31
+        prepareSimpleSid(testBuffer, 20);
+
+        // DACL header at offset 32, then two 32-byte ACEs at offsets 40 and 72
+        prepareDaclHeader(testBuffer, 32, 2);
+        prepareSimpleAce(testBuffer, 40);
+        prepareSimpleAce(testBuffer, 72);
+
+        int size = securityDescriptor.decode(testBuffer, 0, testBuffer.length);
+
+        assertTrue(size > 0);
+        assertNotNull(securityDescriptor.getOwnerUserSid());
+        assertEquals(1, securityDescriptor.getOwnerUserSid().sub_authority_count);
+        assertNotNull(securityDescriptor.getAces());
+        assertEquals(2, securityDescriptor.getAces().length);
+    }
+
     // Helper methods
 
     private void prepareMinimalSecurityDescriptorBuffer(byte[] buffer, int offset, boolean includeOwner, boolean includeGroup,

--- a/src/test/java/org/codelibs/jcifs/smb/internal/fscc/FileBothDirectoryInfoTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/fscc/FileBothDirectoryInfoTest.java
@@ -264,9 +264,9 @@ class FileBothDirectoryInfoTest {
         // Decode and check return value
         int bytesConsumed = fileBothDirectoryInfo.decode(buffer, 0, buffer.length);
 
-        // Verify bytes consumed matches the actual data size
-        assertTrue(bytesConsumed < 0); // Return value is negative (start - bufferIndex)
-        assertEquals(-94 - filename.length() * 2, bytesConsumed); // Base structure + filename length
+        // Verify bytes consumed is positive and matches the actual data size (Decodable contract)
+        assertTrue(bytesConsumed > 0);
+        assertEquals(94 + filename.length() * 2, bytesConsumed); // Base structure + filename length
     }
 
     @Test

--- a/src/test/java/org/codelibs/jcifs/smb/internal/fscc/FileBothDirectoryInfoTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/fscc/FileBothDirectoryInfoTest.java
@@ -2,6 +2,7 @@ package org.codelibs.jcifs.smb.internal.fscc;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -418,6 +419,27 @@ class FileBothDirectoryInfoTest {
 
         // Verify
         assertEquals(expectedFilename, fileBothDirectoryInfo.getFilename());
+    }
+
+    @Test
+    @DisplayName("Test decode rejects short name length greater than 24")
+    void testDecodeRejectsInvalidShortNameLength() {
+        // The ShortName field is a fixed 24-byte area; a length > 24 is malformed and must be rejected
+        byte[] buffer = createValidBuffer("file.txt", "FILE~1.TXT", true);
+        buffer[68] = (byte) 25; // shortNameLength
+
+        assertThrows(SMBProtocolDecodingException.class, () -> fileBothDirectoryInfo.decode(buffer, 0, buffer.length),
+                "Short name length greater than 24 must be rejected");
+    }
+
+    @Test
+    @DisplayName("Test decode rejects buffer smaller than the fixed entry size")
+    void testDecodeRejectsTruncatedBuffer() {
+        // The fixed portion of a FILE_BOTH_DIR_INFORMATION entry is 94 bytes; anything shorter is malformed
+        byte[] buffer = new byte[93];
+
+        assertThrows(SMBProtocolDecodingException.class, () -> fileBothDirectoryInfo.decode(buffer, 0, buffer.length),
+                "Buffer smaller than 94 bytes must be rejected");
     }
 
     // Helper methods to create valid buffer data

--- a/src/test/java/org/codelibs/jcifs/smb/internal/fscc/FileRenameInformation2Test.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/fscc/FileRenameInformation2Test.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 import org.codelibs.jcifs.smb.internal.SMBProtocolDecodingException;
 import org.codelibs.jcifs.smb.internal.util.SMBUtil;
@@ -317,5 +318,43 @@ class FileRenameInformation2Test {
 
         assertEquals(bytesWritten1, bytesWritten2);
         assertArrayEquals(buffer1, buffer2);
+    }
+
+    @Test
+    @DisplayName("Test encode explicitly zeroes Reserved and RootDirectory over dirty buffer")
+    void testEncodeZerosReservedAndRootDirectory() {
+        int offset = 8;
+        String fileName = "rn.txt";
+        FileRenameInformation2 info = new FileRenameInformation2(fileName, true);
+
+        // Pre-fill the destination with 0xFF so that only bytes the encoder explicitly
+        // writes will be zero - this locks in the explicit zeroing of Reserved/RootDirectory
+        byte[] buffer = new byte[100];
+        Arrays.fill(buffer, (byte) 0xFF);
+
+        int bytesWritten = info.encode(buffer, offset);
+
+        // ReplaceIfExists flag at offset 0
+        assertEquals(1, buffer[offset]);
+
+        // Reserved (7 bytes: offset+1 .. offset+7) must be explicitly zeroed
+        for (int i = 1; i <= 7; i++) {
+            assertEquals(0, buffer[offset + i], "Reserved byte at +" + i + " must be zero");
+        }
+
+        // RootDirectory (8 bytes: offset+8 .. offset+15) must be explicitly zeroed
+        for (int i = 8; i <= 15; i++) {
+            assertEquals(0, buffer[offset + i], "RootDirectory byte at +" + i + " must be zero");
+        }
+
+        // FileName length and bytes remain intact
+        byte[] nameBytes = fileName.getBytes(StandardCharsets.UTF_16LE);
+        assertEquals(nameBytes.length, SMBUtil.readInt4(buffer, offset + 16));
+        byte[] actualName = new byte[nameBytes.length];
+        System.arraycopy(buffer, offset + 20, actualName, 0, nameBytes.length);
+        assertArrayEquals(nameBytes, actualName);
+
+        // Return value equals size()
+        assertEquals(info.size(), bytesWritten);
     }
 }

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb1/com/SmbComLockingAndXTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb1/com/SmbComLockingAndXTest.java
@@ -81,7 +81,7 @@ class SmbComLockingAndXTest {
 
         byte[] buffer = new byte[20];
         int len = cmd.writeParameterWordsWireFormat(buffer, 0);
-        assertEquals(-12, len, "writeParameterWordsWireFormat should write 12 Bytes");
+        assertEquals(12, len, "writeParameterWordsWireFormat should write 12 Bytes");
         // Validate parameter bytes using reflection since fields are private
         assertEquals(getField(cmd, "fid"), SMBUtil.readInt2(buffer, 0));
         assertEquals(getField(cmd, "typeOfLock"), buffer[2]);
@@ -168,5 +168,57 @@ class SmbComLockingAndXTest {
         assertEquals(99, decoded.getPid());
         assertEquals(123456L, decoded.getByteOffset());
         assertEquals(654321L, decoded.getLengthInBytes());
+    }
+
+    /**
+     * The parameter-word wire methods must report the positive number of bytes
+     * consumed (like every sibling SMB1 command), not a negative value.
+     */
+    @Test
+    void parameterWireFormatMethodsReturnPositiveConsumedCounts() {
+        Configuration cfg = mock(Configuration.class);
+        SmbComLockingAndX cmd = new SmbComLockingAndX(cfg);
+        setField(cmd, "fid", 0x1234);
+        setField(cmd, "typeOfLock", (byte) 0x02);
+        setField(cmd, "newOpLockLevel", (byte) 0x00);
+        setField(cmd, "timeout", 1000L);
+        setField(cmd, "locks", new LockingAndXRange[0]);
+        setField(cmd, "unlocks", new LockingAndXRange[0]);
+        setField(cmd, "largeFile", false);
+
+        byte[] buffer = new byte[32];
+        int written = cmd.writeParameterWordsWireFormat(buffer, 0);
+        assertEquals(12, written, "writeParameterWordsWireFormat should return the positive count of bytes written");
+
+        SmbComLockingAndX reader = new SmbComLockingAndX(cfg);
+        int read = reader.readParameterWordsWireFormat(buffer, 0);
+        assertEquals(12, read, "readParameterWordsWireFormat should return the positive count of bytes read");
+    }
+
+    /**
+     * The byte (data) wire methods must likewise report the positive number of
+     * bytes consumed for a single lock range.
+     */
+    @Test
+    void byteWireFormatMethodsReturnPositiveConsumedCounts() throws Exception {
+        Configuration cfg = mock(Configuration.class);
+        SmbComLockingAndX cmd = new SmbComLockingAndX(cfg);
+        LockingAndXRange lock = new LockingAndXRange(false);
+        setField(lock, "pid", 7);
+        setField(lock, "byteOffset", 0L);
+        setField(lock, "lengthInBytes", 10L);
+        setField(cmd, "locks", new LockingAndXRange[] { lock });
+        setField(cmd, "unlocks", new LockingAndXRange[0]);
+
+        byte[] buffer = new byte[32];
+        int written = cmd.writeBytesWireFormat(buffer, 0);
+        assertEquals(10, written, "writeBytesWireFormat should return the positive count of bytes written");
+
+        SmbComLockingAndX reader = new SmbComLockingAndX(cfg);
+        setField(reader, "locks", new LockingAndXRange[1]);
+        setField(reader, "unlocks", new LockingAndXRange[0]);
+        setField(reader, "largeFile", false);
+        int read = reader.readBytesWireFormat(buffer, 0);
+        assertEquals(10, read, "readBytesWireFormat should return the positive count of bytes read");
     }
 }

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb1/trans/nt/FileNotifyInformationImplTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb1/trans/nt/FileNotifyInformationImplTest.java
@@ -300,6 +300,48 @@ class FileNotifyInformationImplTest {
         assertEquals("", notifyInfo.getFileName());
     }
 
+    @Test
+    @DisplayName("Test decode with file name length beyond buffer throws exception")
+    void testDecodeFileNameLengthBeyondBuffer() {
+        byte[] buffer = new byte[20];
+        SMBUtil.writeInt4(0, buffer, 0); // nextEntryOffset (aligned)
+        SMBUtil.writeInt4(FileNotifyInformation.FILE_ACTION_ADDED, buffer, 4);
+        SMBUtil.writeInt4(1000, buffer, 8); // fileNameLength far beyond the buffer
+
+        // An out-of-range fileNameLength must be rejected with a decoding exception rather
+        // than allowed to read past the end of the buffer
+        assertThrows(SMBProtocolDecodingException.class, () -> notifyInfo.decode(buffer, 0, buffer.length));
+    }
+
+    @Test
+    @DisplayName("Test decode with negative file name length throws exception")
+    void testDecodeNegativeFileNameLength() {
+        byte[] buffer = new byte[20];
+        SMBUtil.writeInt4(0, buffer, 0); // nextEntryOffset (aligned)
+        SMBUtil.writeInt4(FileNotifyInformation.FILE_ACTION_ADDED, buffer, 4);
+        SMBUtil.writeInt4(-4, buffer, 8); // negative fileNameLength
+
+        assertThrows(SMBProtocolDecodingException.class, () -> notifyInfo.decode(buffer, 0, buffer.length));
+    }
+
+    @Test
+    @DisplayName("Test decode with file name length exactly filling the buffer does not false-reject")
+    void testDecodeFileNameLengthAtBufferBoundary() throws SMBProtocolDecodingException {
+        String fileName = "ok.txt";
+        byte[] nameBytes = fileName.getBytes(StandardCharsets.UTF_16LE);
+        byte[] buffer = new byte[12 + nameBytes.length]; // header + name exactly fills the buffer
+        SMBUtil.writeInt4(0, buffer, 0);
+        SMBUtil.writeInt4(FileNotifyInformation.FILE_ACTION_MODIFIED, buffer, 4);
+        SMBUtil.writeInt4(nameBytes.length, buffer, 8);
+        System.arraycopy(nameBytes, 0, buffer, 12, nameBytes.length);
+
+        int bytesRead = notifyInfo.decode(buffer, 0, buffer.length);
+
+        assertEquals(12 + nameBytes.length, bytesRead);
+        assertEquals(FileNotifyInformation.FILE_ACTION_MODIFIED, notifyInfo.getAction());
+        assertEquals(fileName, notifyInfo.getFileName());
+    }
+
     /**
      * Helper method to create a valid notification buffer
      */

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb1/trans/nt/FileNotifyInformationImplTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb1/trans/nt/FileNotifyInformationImplTest.java
@@ -342,6 +342,49 @@ class FileNotifyInformationImplTest {
         assertEquals(fileName, notifyInfo.getFileName());
     }
 
+    @Test
+    @DisplayName("Test decode rejects an entry whose fixed 12-byte header runs past the buffer")
+    void testDecodeHeaderBeyondBufferThrows() {
+        // The entry starts within the last 8 bytes of the buffer, so the fixed 12-byte header
+        // (nextEntryOffset + action + fileNameLength) cannot fit. len is in [1,11] so the old
+        // fileName-only bounds check would not catch this; reverting the header guard makes
+        // readInt4 walk past the buffer and throw ArrayIndexOutOfBoundsException instead of a
+        // decoding exception.
+        byte[] buffer = new byte[100];
+
+        assertThrows(SMBProtocolDecodingException.class, () -> notifyInfo.decode(buffer, 92, 4));
+    }
+
+    @Test
+    @DisplayName("Test decode with len == 0 short-circuits before the header bounds guard")
+    void testDecodeZeroLengthShortCircuitsBeforeGuard() throws SMBProtocolDecodingException {
+        // Buffer is smaller than the 12-byte header, but len == 0 must still early-return 0
+        // without throwing (the header guard is only reached for non-empty entries).
+        byte[] buffer = new byte[5];
+
+        int bytesRead = notifyInfo.decode(buffer, 0, 0);
+
+        assertEquals(0, bytesRead);
+        assertNull(notifyInfo.getFileName());
+    }
+
+    @Test
+    @DisplayName("Test decode with a header exactly filling the buffer does not false-reject")
+    void testDecodeHeaderExactlyFillsBuffer() throws SMBProtocolDecodingException {
+        // A valid entry always carries at least the 12-byte header; a buffer sized exactly to a
+        // header with an empty file name must decode without tripping the bounds guard.
+        byte[] buffer = new byte[12];
+        SMBUtil.writeInt4(0, buffer, 0); // nextEntryOffset (aligned)
+        SMBUtil.writeInt4(FileNotifyInformation.FILE_ACTION_ADDED, buffer, 4);
+        SMBUtil.writeInt4(0, buffer, 8); // fileNameLength = 0
+
+        int bytesRead = notifyInfo.decode(buffer, 0, buffer.length);
+
+        assertEquals(12, bytesRead);
+        assertEquals(FileNotifyInformation.FILE_ACTION_ADDED, notifyInfo.getAction());
+        assertEquals("", notifyInfo.getFileName());
+    }
+
     /**
      * Helper method to create a valid notification buffer
      */

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb1/trans/nt/NtTransQuerySecurityDescResponseTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb1/trans/nt/NtTransQuerySecurityDescResponseTest.java
@@ -12,6 +12,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 import org.codelibs.jcifs.smb.Configuration;
+import org.codelibs.jcifs.smb.RuntimeCIFSException;
 import org.codelibs.jcifs.smb.internal.dtyp.SecurityDescriptor;
 import org.codelibs.jcifs.smb.internal.util.SMBUtil;
 import org.junit.jupiter.api.BeforeEach;
@@ -151,16 +152,17 @@ class NtTransQuerySecurityDescResponseTest {
     }
 
     @Test
-    @DisplayName("Test readDataWireFormat with IOException throws ArrayIndexOutOfBoundsException")
+    @DisplayName("Test readDataWireFormat with too-small buffer throws RuntimeCIFSException")
     void testReadDataWireFormatWithIOException() throws Exception {
-        // Create an invalid security descriptor buffer that will cause ArrayIndexOutOfBoundsException
+        // Create an invalid security descriptor buffer that is too small to decode
         byte[] buffer = new byte[4];
 
         // Set error code to 0
         setErrorCode(response, 0);
 
-        // ArrayIndexOutOfBoundsException is thrown when buffer is too small
-        assertThrows(ArrayIndexOutOfBoundsException.class, () -> {
+        // decode rejects the too-small buffer with a controlled SMBProtocolDecodingException,
+        // which readDataWireFormat surfaces as a RuntimeCIFSException
+        assertThrows(RuntimeCIFSException.class, () -> {
             response.readDataWireFormat(buffer, 0, buffer.length);
         });
     }
@@ -218,8 +220,9 @@ class NtTransQuerySecurityDescResponseTest {
 
         setErrorCode(response, 0);
 
-        // ArrayIndexOutOfBoundsException is thrown when buffer is too small
-        assertThrows(ArrayIndexOutOfBoundsException.class, () -> {
+        // decode rejects the zero-length buffer with a controlled SMBProtocolDecodingException,
+        // which readDataWireFormat surfaces as a RuntimeCIFSException
+        assertThrows(RuntimeCIFSException.class, () -> {
             response.readDataWireFormat(buffer, 0, 0);
         });
     }

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/ServerMessageBlock2Test.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/ServerMessageBlock2Test.java
@@ -845,6 +845,21 @@ class ServerMessageBlock2Test {
             assertEquals(0, testMessage.getErrorContextCount());
             assertNull(testMessage.getErrorData());
         }
+
+        @Test
+        @DisplayName("Should read error context count as unsigned value")
+        void testReadErrorResponseUnsignedContextCount() throws SMBProtocolDecodingException {
+            byte[] buffer = new byte[256];
+            int bufferIndex = 0;
+
+            SMBUtil.writeInt2(9, buffer, bufferIndex); // structure size
+            buffer[bufferIndex + 2] = (byte) 0x80; // error context count with high bit set (== 128 unsigned)
+            SMBUtil.writeInt4(0, buffer, bufferIndex + 4); // zero byte count
+
+            testMessage.readErrorResponse(buffer, bufferIndex);
+
+            assertEquals(128, testMessage.getErrorContextCount(), "ErrorContextCount is a UCHAR and must be read unsigned");
+        }
     }
 
     @Nested

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/ServerMessageBlock2Test.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/ServerMessageBlock2Test.java
@@ -860,6 +860,54 @@ class ServerMessageBlock2Test {
 
             assertEquals(128, testMessage.getErrorContextCount(), "ErrorContextCount is a UCHAR and must be read unsigned");
         }
+
+        @Test
+        @DisplayName("Should throw exception when byte count exceeds buffer bounds")
+        void testReadErrorResponseByteCountOutOfRange() {
+            byte[] buffer = new byte[64];
+            int bufferIndex = 0;
+
+            SMBUtil.writeInt2(9, buffer, bufferIndex); // structure size
+            buffer[bufferIndex + 2] = 1; // error context count
+            SMBUtil.writeInt4(1000, buffer, bufferIndex + 4); // byte count far beyond buffer length
+
+            // An out-of-range ByteCount must be rejected with a decoding exception,
+            // not allowed to drive an oversized System.arraycopy (AIOOBE)
+            assertThrows(SMBProtocolDecodingException.class, () -> testMessage.readErrorResponse(buffer, bufferIndex));
+        }
+
+        @Test
+        @DisplayName("Should throw exception when byte count is negative")
+        void testReadErrorResponseNegativeByteCount() {
+            byte[] buffer = new byte[64];
+            int bufferIndex = 0;
+
+            SMBUtil.writeInt2(9, buffer, bufferIndex); // structure size
+            buffer[bufferIndex + 2] = 0; // error context count
+            SMBUtil.writeInt4(-1, buffer, bufferIndex + 4); // negative (unsigned high-bit) byte count
+
+            assertThrows(SMBProtocolDecodingException.class, () -> testMessage.readErrorResponse(buffer, bufferIndex));
+        }
+
+        @Test
+        @DisplayName("Should decode a small in-bounds byte count without false rejection")
+        void testReadErrorResponseByteCountWithinBounds() throws SMBProtocolDecodingException {
+            byte[] buffer = new byte[64];
+            int bufferIndex = 0;
+
+            SMBUtil.writeInt2(9, buffer, bufferIndex); // structure size
+            buffer[bufferIndex + 2] = 1; // error context count
+            SMBUtil.writeInt4(4, buffer, bufferIndex + 4); // small byte count fully inside the buffer
+            for (int i = 0; i < 4; i++) {
+                buffer[bufferIndex + 8 + i] = (byte) (0x10 + i);
+            }
+
+            int bytesRead = testMessage.readErrorResponse(buffer, bufferIndex);
+
+            assertEquals(12, bytesRead); // 8 header + 4 data
+            assertNotNull(testMessage.getErrorData());
+            assertEquals(4, testMessage.getErrorData().length);
+        }
     }
 
     @Nested

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb3KeyDerivationTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb3KeyDerivationTest.java
@@ -5,8 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.Arrays;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -418,5 +423,75 @@ class Smb3KeyDerivationTest {
         assertNotNull(signingKey, "Should handle all-0xFF session key");
         assertEquals(16, signingKey.length, "Should produce 16-byte key");
         assertFalse(Arrays.equals(ffSessionKey, signingKey), "Derived key should be different from all-0xFF input");
+    }
+
+    /**
+     * Independent, in-test SP800-108 CTR-mode HMAC-SHA256 oracle that reproduces
+     * the fixed-input byte layout of {@link Smb3KeyDerivation}'s private {@code derive}:
+     *
+     * <pre>
+     * [00 00 00 01] || label (US-ASCII) || 0x00 (label terminator) || 0x00 (separator)
+     *               || context || [00 00 00 80]
+     * </pre>
+     *
+     * A single HMAC-SHA256 pass keyed with the session key yields the 32-byte block;
+     * the first 16 bytes are the derived key. This oracle is intentionally independent
+     * of the BouncyCastle KDF used by production so it can pin the label constants.
+     */
+    private static byte[] deriveOracle(final String label, final byte[] context, final byte[] sessionKey) throws Exception {
+        final byte[] ascii = label.getBytes(StandardCharsets.US_ASCII);
+        final ByteArrayOutputStream fixedInput = new ByteArrayOutputStream();
+        fixedInput.writeBytes(new byte[] { 0x00, 0x00, 0x00, 0x01 }); // counter i = 1 (4-byte BE, r = 32)
+        fixedInput.writeBytes(ascii); // label
+        fixedInput.write(0x00); // label null terminator (toCBytes)
+        fixedInput.write(0x00); // 0x00 separator between label and context
+        fixedInput.writeBytes(context); // context
+        fixedInput.writeBytes(new byte[] { 0x00, 0x00, 0x00, (byte) 0x80 }); // L = 128 (4-byte BE)
+
+        final Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(new SecretKeySpec(sessionKey, "HmacSHA256"));
+        final byte[] full = mac.doFinal(fixedInput.toByteArray());
+        return Arrays.copyOf(full, 16);
+    }
+
+    private static byte[] fixedSessionKey() {
+        final byte[] key = new byte[16];
+        Arrays.fill(key, (byte) 0x01);
+        return key;
+    }
+
+    private static byte[] fixedPreauth() {
+        // Non-empty: javax.crypto.Mac rejects a zero-length HMAC key.
+        final byte[] preauth = new byte[64];
+        Arrays.fill(preauth, (byte) 0x02);
+        return preauth;
+    }
+
+    @Test
+    @DisplayName("KDF oracle reproduces the never-buggy signing key (validates the oracle)")
+    void testKdfOracleReproducesSigningKey() throws Exception {
+        final byte[] sk = fixedSessionKey();
+        final byte[] preauth = fixedPreauth();
+
+        // SMBSigningKey was never affected by the label bug, so it cross-checks the oracle itself.
+        final byte[] expected = Smb3KeyDerivation.deriveSigningKey(Smb2Constants.SMB2_DIALECT_0311, sk, preauth);
+        final byte[] oracle = deriveOracle("SMBSigningKey", preauth, sk);
+
+        assertArrayEquals(expected, oracle, "In-test SP800-108 oracle must faithfully reproduce the production KDF");
+    }
+
+    @Test
+    @DisplayName("SMB 3.1.1 cipher keys must use SMBC2SCipherKey / SMBS2CCipherKey labels")
+    void testCipherKeyLabelsArePinned() throws Exception {
+        final byte[] sk = fixedSessionKey();
+        final byte[] preauth = fixedPreauth();
+
+        final byte[] encExpected = deriveOracle("SMBC2SCipherKey", preauth, sk);
+        final byte[] encActual = Smb3KeyDerivation.deriveEncryptionKey(Smb2Constants.SMB2_DIALECT_0311, sk, preauth);
+        assertArrayEquals(encExpected, encActual, "Encryption key must be derived with the SMBC2SCipherKey label");
+
+        final byte[] decExpected = deriveOracle("SMBS2CCipherKey", preauth, sk);
+        final byte[] decActual = Smb3KeyDerivation.deriveDecryptionKey(Smb2Constants.SMB2_DIALECT_0311, sk, preauth);
+        assertArrayEquals(decExpected, decActual, "Decryption key must be derived with the SMBS2CCipherKey label");
     }
 }

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/create/Smb2CreateResponseTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/create/Smb2CreateResponseTest.java
@@ -267,6 +267,28 @@ class Smb2CreateResponseTest {
     }
 
     @Test
+    void decode_createContextOffsetBeyondBuffer_throwsDecodingException() {
+        Configuration config = Mockito.mock(Configuration.class);
+        Smb2CreateResponse resp = new Smb2CreateResponse(config, "file.txt");
+
+        byte[] fileId = new byte[16];
+        Arrays.fill(fileId, (byte) 0xAB);
+
+        byte[] header = buildSmb2Header();
+        byte[] body = buildCreateBodyNoContexts((byte) 0, (byte) 0, 0, 0L, 0L, 0L, 0L, 0L, 0L, 0, fileId);
+
+        // Point the create-context section far past the end of the buffer, with a non-zero length so it is parsed.
+        // A crafted offset must be rejected as a decoding error, not surface as a raw AIOOBE.
+        int offsetFieldPos = body.length - 8;
+        SMBUtil.writeInt4(100000, body, offsetFieldPos); // CreateContextsOffset
+        SMBUtil.writeInt4(8, body, offsetFieldPos + 4); // CreateContextsLength
+
+        byte[] packet = buildPacket(header, body, null, null);
+
+        assertThrows(SMBProtocolDecodingException.class, () -> resp.decode(packet, 0, false));
+    }
+
+    @Test
     void decode_invalidStructureSize_throws() {
         Configuration config = Mockito.mock(Configuration.class);
         Smb2CreateResponse resp = new Smb2CreateResponse(config, "bad");

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/info/Smb2QueryDirectoryResponseTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/info/Smb2QueryDirectoryResponseTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -395,6 +396,42 @@ class Smb2QueryDirectoryResponseTest {
 
         assertTrue(result >= 8);
         assertNotNull(response.getResults());
+    }
+
+    @Test
+    @DisplayName("Test readBytesWireFormat handles overflowing nextEntryOffset without AIOOBE")
+    void testReadBytesWireFormatNextEntryOffsetOverflow() throws Exception {
+        response = new Smb2QueryDirectoryResponse(mockConfig, Smb2QueryDirectoryRequest.FILE_BOTH_DIRECTORY_INFO);
+
+        byte[] buffer = new byte[512];
+        int bufferIndex = 0;
+        int dataOffset = 80;
+
+        // Set structure size to 9
+        SMBUtil.writeInt2(9, buffer, bufferIndex);
+        // Set buffer offset
+        SMBUtil.writeInt2(dataOffset, buffer, bufferIndex + 2);
+        // Set buffer length
+        SMBUtil.writeInt4(200, buffer, bufferIndex + 4);
+
+        response = spy(response);
+        when(response.getHeaderStart()).thenReturn(0);
+
+        // The implementation begins decoding entries at bufferIndex = 8.
+        // Give the (only) entry a huge nextEntryOffset that overflows int when added to bufferIndex.
+        int entryStart = 8;
+        SMBUtil.writeInt4(Integer.MAX_VALUE, buffer, entryStart); // nextEntryOffset
+        SMBUtil.writeInt4(0, buffer, entryStart + 60); // FileNameLength = 0 -> fixed 94-byte entry
+
+        // A crafted overflowing nextEntryOffset must either stop cleanly or be rejected as a decoding
+        // error, but must never surface as a raw ArrayIndexOutOfBoundsException.
+        try {
+            response.readBytesWireFormat(buffer, bufferIndex);
+        } catch (final ArrayIndexOutOfBoundsException e) {
+            fail("Overflowing nextEntryOffset leaked ArrayIndexOutOfBoundsException: " + e);
+        } catch (final SMBProtocolDecodingException e) {
+            // Acceptable: rejected as a decoding error
+        }
     }
 
     @Test

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/info/Smb2QueryDirectoryResponseTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/info/Smb2QueryDirectoryResponseTest.java
@@ -398,8 +398,8 @@ class Smb2QueryDirectoryResponseTest {
     }
 
     @Test
-    @DisplayName("Test readBytesWireFormat with properly formed empty response")
-    void testReadBytesWireFormatProperlyFormedEmpty() throws Exception {
+    @DisplayName("Test readBytesWireFormat rejects malformed negative buffer length")
+    void testReadBytesWireFormatNegativeBufferLengthRejected() throws Exception {
         response = new Smb2QueryDirectoryResponse(mockConfig, Smb2QueryDirectoryRequest.FILE_BOTH_DIRECTORY_INFO);
 
         byte[] buffer = new byte[1024];
@@ -409,18 +409,14 @@ class Smb2QueryDirectoryResponseTest {
         SMBUtil.writeInt2(9, buffer, bufferIndex);
         // Set buffer offset
         SMBUtil.writeInt2(100, buffer, bufferIndex + 2);
-        // Set buffer length to -1 to indicate no entries
+        // Set an invalid (negative) OutputBufferLength
         SMBUtil.writeInt4(-1, buffer, bufferIndex + 4);
 
         response = spy(response);
         when(response.getHeaderStart()).thenReturn(0);
 
-        int result = response.readBytesWireFormat(buffer, bufferIndex);
-
-        assertEquals(8, result);
-        assertNotNull(response.getResults());
-        // Even with -1, the do-while loop executes at least once due to the bug
-        assertEquals(1, response.getResults().length);
+        // A malformed negative OutputBufferLength must be rejected, not silently decoded as one bogus entry
+        assertThrows(SMBProtocolDecodingException.class, () -> response.readBytesWireFormat(buffer, bufferIndex));
     }
 
     @Test

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/info/Smb2QueryInfoResponseTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/info/Smb2QueryInfoResponseTest.java
@@ -632,4 +632,42 @@ class Smb2QueryInfoResponseTest {
         assertNotNull(response.getInfo());
         assertTrue(response.getInfo() instanceof FileInternalInfo);
     }
+
+    @Test
+    @DisplayName("Test readBytesWireFormat rejects buffer length that overflows the packet")
+    void testReadBytesWireFormatRejectsHugeBufferLength() {
+        response = new Smb2QueryInfoResponse(mockConfig, Smb2Constants.SMB2_0_INFO_FILE, FileInformation.FILE_INTERNAL_INFO);
+
+        byte[] buffer = new byte[512];
+        // structureSize
+        SMBUtil.writeInt2(9, buffer, 0);
+        // bufferOffset (relative to header start)
+        SMBUtil.writeInt2(20, buffer, 2);
+        // bufferLength far beyond the actual buffer
+        SMBUtil.writeInt4(0x7FFFFFFF, buffer, 4);
+
+        response = spy(response);
+        when(response.getHeaderStart()).thenReturn(0);
+
+        assertThrows(SMBProtocolDecodingException.class, () -> response.readBytesWireFormat(buffer, 0),
+                "Should reject a bufferLength that exceeds the buffer bounds");
+    }
+
+    @Test
+    @DisplayName("Test readBytesWireFormat rejects negative buffer length")
+    void testReadBytesWireFormatRejectsNegativeBufferLength() {
+        response = new Smb2QueryInfoResponse(mockConfig, Smb2Constants.SMB2_0_INFO_FILE, FileInformation.FILE_INTERNAL_INFO);
+
+        byte[] buffer = new byte[512];
+        SMBUtil.writeInt2(9, buffer, 0);
+        SMBUtil.writeInt2(20, buffer, 2);
+        // negative bufferLength
+        SMBUtil.writeInt4(-1, buffer, 4);
+
+        response = spy(response);
+        when(response.getHeaderStart()).thenReturn(0);
+
+        assertThrows(SMBProtocolDecodingException.class, () -> response.readBytesWireFormat(buffer, 0),
+                "Should reject a negative bufferLength");
+    }
 }

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/io/Smb2ReadResponseTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/io/Smb2ReadResponseTest.java
@@ -560,8 +560,8 @@ class Smb2ReadResponseTest extends BaseTest {
         headerStartField.setAccessible(true);
         headerStartField.set(response, 0);
 
-        // When & Then - should throw when trying to read beyond buffer
-        assertThrows(ArrayIndexOutOfBoundsException.class, () -> response.readBytesWireFormat(smallBuffer, bodyStart));
+        // When & Then - an out-of-bounds data offset/length must be rejected with a decoding exception, not a raw AIOOBE
+        assertThrows(SMBProtocolDecodingException.class, () -> response.readBytesWireFormat(smallBuffer, bodyStart));
     }
 
     @Test

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/io/Smb2ReadResponseTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/io/Smb2ReadResponseTest.java
@@ -595,4 +595,39 @@ class Smb2ReadResponseTest extends BaseTest {
         assertEquals(dataOffsetFromHeader + 10 - bodyStart, bytesRead);
         assertEquals(10, response.getDataLength());
     }
+
+    @Test
+    @DisplayName("Should treat a data offset with the high bit set as unsigned")
+    void testReadBytesWireFormatUnsignedDataOffsetHighBit() throws Exception {
+        // Given - DataOffset byte = 0x90 (144). Read as a signed byte this is -112, which
+        // would make the data start negative and be rejected; it must be read unsigned.
+        byte[] buffer = new byte[256];
+        int bodyStart = 0;
+        int dataLength = 8;
+        int dataOffsetValue = 0x90; // 144
+
+        SMBUtil.writeInt2(17, buffer, bodyStart);
+        buffer[bodyStart + 2] = (byte) dataOffsetValue;
+        SMBUtil.writeInt4(dataLength, buffer, bodyStart + 4);
+        SMBUtil.writeInt4(0, buffer, bodyStart + 8);
+        SMBUtil.writeInt4(0, buffer, bodyStart + 12);
+
+        // Distinct payload written at the unsigned offset so a wrong offset would be detected
+        byte[] testData = { (byte) 0xD1, (byte) 0xD2, (byte) 0xD3, (byte) 0xD4, (byte) 0xD5, (byte) 0xD6, (byte) 0xD7, (byte) 0xD8 };
+        System.arraycopy(testData, 0, buffer, dataOffsetValue, testData.length);
+
+        // Use reflection to set headerStart
+        Field headerStartField = ServerMessageBlock2.class.getDeclaredField("headerStart");
+        headerStartField.setAccessible(true);
+        headerStartField.set(response, 0);
+
+        // When
+        int bytesRead = response.readBytesWireFormat(buffer, bodyStart);
+
+        // Then - decoding succeeds and the data is read from the correct (unsigned) offset
+        assertEquals(dataOffsetValue + dataLength - bodyStart, bytesRead);
+        assertEquals(dataLength, response.getDataLength());
+        byte[] copiedData = Arrays.copyOfRange(outputBuffer, 0, dataLength);
+        assertArrayEquals(testData, copiedData);
+    }
 }

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/ioctl/Smb2IoctlResponseTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/ioctl/Smb2IoctlResponseTest.java
@@ -243,4 +243,42 @@ class Smb2IoctlResponseTest {
         assertEquals(0, peek.getNumberOfMessages());
         assertEquals(0, peek.getMessageLength());
     }
+
+    @Test
+    void throwsWhenOutputOffsetExceedsBuffer() throws Exception {
+        // A malicious server can point outputOffset outside the packet while keeping
+        // outputCount within the provided buffer capacity, so the capacity guard alone
+        // does not protect the arraycopy.
+        byte[] header = buildHeader(NtStatus.NT_STATUS_SUCCESS);
+        byte[] output = new byte[] { 1, 2, 3, 4, 5 };
+        byte[] body = buildIoctlResponseBody(Smb2IoctlRequest.FSCTL_SRV_COPYCHUNK, new byte[16], 0, null, output.length, output, 0);
+        byte[] packet = new byte[header.length + body.length];
+        System.arraycopy(header, 0, packet, 0, header.length);
+        System.arraycopy(body, 0, packet, header.length, body.length);
+
+        // Overwrite outputOffset field (body offset 32 -> packet offset 64 + 32 = 96) with a bogus value.
+        SMBUtil.writeInt4(100000, packet, 96);
+
+        BaseConfiguration config = new BaseConfiguration(true);
+        // outputBuffer large enough that the capacity guard (outputCount > outputBuffer.length) passes.
+        Smb2IoctlResponse resp = new Smb2IoctlResponse(config, new byte[8]);
+        assertThrows(SMBProtocolDecodingException.class, () -> resp.decode(packet, 0));
+    }
+
+    @Test
+    void throwsWhenOutputCountIsNegative() throws Exception {
+        byte[] header = buildHeader(NtStatus.NT_STATUS_SUCCESS);
+        byte[] output = new byte[] { 1, 2, 3, 4, 5 };
+        byte[] body = buildIoctlResponseBody(Smb2IoctlRequest.FSCTL_SRV_COPYCHUNK, new byte[16], 0, null, output.length, output, 0);
+        byte[] packet = new byte[header.length + body.length];
+        System.arraycopy(header, 0, packet, 0, header.length);
+        System.arraycopy(body, 0, packet, header.length, body.length);
+
+        // Overwrite outputCount field (body offset 36 -> packet offset 64 + 36 = 100) with -1.
+        SMBUtil.writeInt4(-1, packet, 100);
+
+        BaseConfiguration config = new BaseConfiguration(true);
+        Smb2IoctlResponse resp = new Smb2IoctlResponse(config, new byte[8]);
+        assertThrows(SMBProtocolDecodingException.class, () -> resp.decode(packet, 0));
+    }
 }

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/ioctl/SrvPipePeekResponseTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/ioctl/SrvPipePeekResponseTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.codelibs.jcifs.smb.internal.SMBProtocolDecodingException;
 import org.codelibs.jcifs.smb.internal.util.SMBUtil;
@@ -294,5 +295,53 @@ class SrvPipePeekResponseTest {
         for (int i = 0; i < 16; i++) {
             assertEquals(expectedData[i], actualData[i], "Data mismatch at index " + i);
         }
+    }
+
+    @Test
+    @DisplayName("Test decode with length below the 16-byte fixed header throws exception")
+    void testDecodeLengthBelowHeader() {
+        byte[] buffer = new byte[16];
+
+        // A len shorter than the 16-byte fixed header used to underflow new byte[len - 16]
+        // with a NegativeArraySizeException; it must now be a clean decoding exception
+        assertThrows(SMBProtocolDecodingException.class, () -> response.decode(buffer, 0, 8));
+    }
+
+    @Test
+    @DisplayName("Test decode with zero length throws exception")
+    void testDecodeZeroLength() {
+        byte[] buffer = new byte[16];
+
+        assertThrows(SMBProtocolDecodingException.class, () -> response.decode(buffer, 0, 0));
+    }
+
+    @Test
+    @DisplayName("Test decode with length beyond buffer bounds throws exception")
+    void testDecodeLengthBeyondBuffer() {
+        byte[] buffer = new byte[16];
+
+        // len extends past the end of the actual buffer -> reject instead of AIOOBE
+        assertThrows(SMBProtocolDecodingException.class, () -> response.decode(buffer, 0, 32));
+    }
+
+    @Test
+    @DisplayName("Test decode with valid length decodes fields and data without false rejection")
+    void testDecodeValidMinimumLength() throws SMBProtocolDecodingException {
+        byte[] buffer = new byte[24]; // 16-byte header + 8 bytes of data
+        SMBUtil.writeInt4(0x11, buffer, 0);
+        SMBUtil.writeInt4(0x22, buffer, 4);
+        SMBUtil.writeInt4(0x33, buffer, 8);
+        SMBUtil.writeInt4(0x44, buffer, 12);
+        byte[] testData = { 1, 2, 3, 4, 5, 6, 7, 8 };
+        System.arraycopy(testData, 0, buffer, 16, testData.length);
+
+        int bytesDecoded = response.decode(buffer, 0, buffer.length);
+
+        assertEquals(16, bytesDecoded);
+        assertEquals(0x11, response.getNamedPipeState());
+        assertEquals(0x22, response.getReadDataAvailable());
+        assertEquals(0x33, response.getNumberOfMessages());
+        assertEquals(0x44, response.getMessageLength());
+        assertArrayEquals(testData, response.getData());
     }
 }

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/nego/EncryptionNegotiateContextTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/nego/EncryptionNegotiateContextTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.codelibs.jcifs.smb.Configuration;
@@ -515,6 +516,43 @@ class EncryptionNegotiateContextTest {
 
             assertEquals(EncryptionNegotiateContext.NEGO_CTX_ENC_TYPE, request.getContextType());
             assertEquals(EncryptionNegotiateContext.NEGO_CTX_ENC_TYPE, response.getContextType());
+        }
+    }
+
+    @Nested
+    @DisplayName("Decode Bounds Guard Tests")
+    class DecodeBoundsGuardTests {
+
+        @Test
+        @DisplayName("Should reject decode when cipher count exceeds the buffer")
+        void testDecodeRejectsHugeCipherCount() {
+            byte[] smallBuffer = new byte[8];
+            SMBUtil.writeInt2(0xFFFF, smallBuffer, 0); // CipherCount = 65535, far beyond the buffer
+
+            EncryptionNegotiateContext context = new EncryptionNegotiateContext();
+            // Without the bounds guard the ciphers array is over-allocated and the read loop walks
+            // past the buffer, throwing ArrayIndexOutOfBoundsException instead of a decoding exception.
+            assertThrows(SMBProtocolDecodingException.class, () -> context.decode(smallBuffer, 0, smallBuffer.length));
+        }
+
+        @Test
+        @DisplayName("Should decode a valid context sized exactly to the buffer without false-reject")
+        void testDecodeValidContextAtExactBufferBoundary() throws SMBProtocolDecodingException {
+            byte[] exactBuffer = new byte[2 + 2 * 2]; // CipherCount + two ciphers
+            SMBUtil.writeInt2(2, exactBuffer, 0); // CipherCount = 2
+            SMBUtil.writeInt2(EncryptionNegotiateContext.CIPHER_AES128_CCM, exactBuffer, 2);
+            SMBUtil.writeInt2(EncryptionNegotiateContext.CIPHER_AES128_GCM, exactBuffer, 4);
+
+            EncryptionNegotiateContext context = new EncryptionNegotiateContext();
+            int bytesRead = context.decode(exactBuffer, 0, exactBuffer.length);
+
+            assertEquals(exactBuffer.length, bytesRead);
+            assertNotNull(context.getCiphers());
+            assertEquals(2, context.getCiphers().length);
+            assertEquals(EncryptionNegotiateContext.CIPHER_AES128_CCM, context.getCiphers()[0]);
+            assertEquals(EncryptionNegotiateContext.CIPHER_AES128_GCM, context.getCiphers()[1]);
+            assertArrayEquals(new int[] { EncryptionNegotiateContext.CIPHER_AES128_CCM, EncryptionNegotiateContext.CIPHER_AES128_GCM },
+                    context.getCiphers());
         }
     }
 }

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/nego/PreauthIntegrityNegotiateContextTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/nego/PreauthIntegrityNegotiateContextTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
@@ -806,6 +807,63 @@ class PreauthIntegrityNegotiateContextTest {
             PreauthIntegrityNegotiateContext context = new PreauthIntegrityNegotiateContext(mockConfig, new int[] { 0x01 }, null);
 
             assertNull(context.getSalt());
+        }
+    }
+
+    @Nested
+    @DisplayName("Decode Bounds Guard Tests")
+    class DecodeBoundsGuardTests {
+
+        @Test
+        @DisplayName("Should reject decode when salt length exceeds the buffer")
+        void testDecodeRejectsHugeSaltLength() {
+            byte[] smallBuffer = new byte[8];
+            SMBUtil.writeInt2(1, smallBuffer, 0); // HashAlgorithmCount = 1
+            SMBUtil.writeInt2(0xFFFF, smallBuffer, 2); // SaltLength = 65535, far beyond the buffer
+
+            PreauthIntegrityNegotiateContext context = new PreauthIntegrityNegotiateContext();
+            // Without the bounds guard the salt is over-allocated and the arraycopy reads past the
+            // buffer, throwing ArrayIndexOutOfBoundsException instead of a decoding exception.
+            assertThrows(SMBProtocolDecodingException.class, () -> context.decode(smallBuffer, 0, smallBuffer.length));
+        }
+
+        @Test
+        @DisplayName("Should reject decode when hash algorithm count exceeds the buffer")
+        void testDecodeRejectsHugeHashAlgoCount() {
+            byte[] smallBuffer = new byte[8];
+            SMBUtil.writeInt2(0xFFFF, smallBuffer, 0); // HashAlgorithmCount = 65535, far beyond the buffer
+            SMBUtil.writeInt2(0, smallBuffer, 2); // SaltLength = 0
+
+            PreauthIntegrityNegotiateContext context = new PreauthIntegrityNegotiateContext();
+            // Without the bounds guard the hash-algo read loop walks past the buffer, throwing
+            // ArrayIndexOutOfBoundsException instead of a decoding exception.
+            assertThrows(SMBProtocolDecodingException.class, () -> context.decode(smallBuffer, 0, smallBuffer.length));
+        }
+
+        @Test
+        @DisplayName("Should decode a valid context sized exactly to the buffer without false-reject")
+        void testDecodeValidContextAtExactBufferBoundary() throws SMBProtocolDecodingException {
+            int nsalt = 32;
+            byte[] exactBuffer = new byte[4 + 2 + nsalt]; // header + one hash algo + salt
+            SMBUtil.writeInt2(1, exactBuffer, 0); // HashAlgorithmCount = 1
+            SMBUtil.writeInt2(nsalt, exactBuffer, 2); // SaltLength = 32
+            SMBUtil.writeInt2(PreauthIntegrityNegotiateContext.HASH_ALGO_SHA512, exactBuffer, 4);
+            byte[] salt = new byte[nsalt];
+            for (int i = 0; i < nsalt; i++) {
+                salt[i] = (byte) (i + 1);
+            }
+            System.arraycopy(salt, 0, exactBuffer, 6, nsalt);
+
+            PreauthIntegrityNegotiateContext context = new PreauthIntegrityNegotiateContext();
+            int bytesRead = context.decode(exactBuffer, 0, exactBuffer.length);
+
+            assertEquals(exactBuffer.length, bytesRead);
+            assertNotNull(context.getHashAlgos());
+            assertEquals(1, context.getHashAlgos().length);
+            assertEquals(PreauthIntegrityNegotiateContext.HASH_ALGO_SHA512, context.getHashAlgos()[0]);
+            assertNotNull(context.getSalt());
+            assertEquals(nsalt, context.getSalt().length);
+            assertArrayEquals(salt, context.getSalt());
         }
     }
 }

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/nego/Smb2NegotiateResponseTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/nego/Smb2NegotiateResponseTest.java
@@ -547,6 +547,60 @@ class Smb2NegotiateResponseTest {
     }
 
     @Test
+    @DisplayName("Should throw exception when negotiate context offset is out of range")
+    void testReadBytesWireFormatNegotiateContextOffsetOutOfRange() {
+        // Given - a valid 3.1.1 response header whose negotiateContextOffset points past the buffer
+        byte[] buffer = createNegotiateResponseHeader(256, 1, 10000);
+
+        // When & Then - an out-of-range context offset must be rejected with a decoding
+        // exception rather than allowed to drive an out-of-bounds read
+        assertThrows(SMBProtocolDecodingException.class, () -> response.readBytesWireFormat(buffer, 0), "Invalid negotiate context offset");
+    }
+
+    @Test
+    @DisplayName("Should throw exception when negotiate context data length is out of range")
+    void testReadBytesWireFormatNegotiateContextDataLengthOutOfRange() {
+        // Given - a valid 3.1.1 response with an in-range context offset but an oversized data length
+        int ctxOffset = 144;
+        byte[] buffer = createNegotiateResponseHeader(256, 1, ctxOffset);
+        SMBUtil.writeInt2(EncryptionNegotiateContext.NEGO_CTX_ENC_TYPE, buffer, ctxOffset);
+        SMBUtil.writeInt2(200, buffer, ctxOffset + 2); // Data length far beyond the buffer
+
+        // When & Then
+        assertThrows(SMBProtocolDecodingException.class, () -> response.readBytesWireFormat(buffer, 0),
+                "Invalid negotiate context data length");
+    }
+
+    /**
+     * Helper that builds a minimal but structurally valid SMB 3.1.1 negotiate response header
+     * with the given negotiate context count and offset (relative to the header start).
+     */
+    private byte[] createNegotiateResponseHeader(int bufferSize, int negotiateContextCount, int negotiateContextOffset) {
+        byte[] buffer = new byte[bufferSize];
+
+        SMBUtil.writeInt2(65, buffer, 0); // Structure size
+        SMBUtil.writeInt2(Smb2Constants.SMB2_NEGOTIATE_SIGNING_REQUIRED, buffer, 2); // Security mode
+        SMBUtil.writeInt2(0x0311, buffer, 4); // Dialect revision (SMB 3.1.1)
+        SMBUtil.writeInt2(negotiateContextCount, buffer, 6); // Negotiate context count
+
+        // Server GUID (16 bytes) intentionally left zero
+
+        SMBUtil.writeInt4(0, buffer, 24); // Capabilities
+        SMBUtil.writeInt4(1048576, buffer, 28); // Max transact size
+        SMBUtil.writeInt4(1048576, buffer, 32); // Max read size
+        SMBUtil.writeInt4(1048576, buffer, 36); // Max write size
+        SMBUtil.writeTime(System.currentTimeMillis(), buffer, 40); // System time
+        SMBUtil.writeTime(System.currentTimeMillis() - 3600000, buffer, 48); // Server start time
+
+        SMBUtil.writeInt2(128, buffer, 56); // Security buffer offset
+        SMBUtil.writeInt2(0, buffer, 58); // Security buffer length
+
+        SMBUtil.writeInt4(negotiateContextOffset, buffer, 60); // Negotiate context offset
+
+        return buffer;
+    }
+
+    @Test
     @DisplayName("Should write empty bytes to wire format")
     void testWriteBytesWireFormat() {
         // Given

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/notify/Smb2ChangeNotifyResponseTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/notify/Smb2ChangeNotifyResponseTest.java
@@ -393,9 +393,9 @@ class Smb2ChangeNotifyResponseTest extends BaseTest {
     }
 
     @Test
-    @DisplayName("Should handle malformed next entry offset")
+    @DisplayName("Should cleanly stop on a next entry offset that overruns the notify buffer")
     void testMalformedNextEntryOffset() throws Exception {
-        // Given - notification with invalid next entry offset
+        // Given - notification whose nextEntryOffset points past the end of the notify buffer
         byte[] buffer = new byte[512];
         int offset = 0;
 
@@ -404,19 +404,44 @@ class Smb2ChangeNotifyResponseTest extends BaseTest {
         // Write structure
         SMBUtil.writeInt2(9, buffer, offset);
         SMBUtil.writeInt2(80 - 64, buffer, offset + 2);
-        SMBUtil.writeInt4(100, buffer, offset + 4);
+        SMBUtil.writeInt4(100, buffer, offset + 4); // notify buffer covers [80, 180)
 
-        // Write notification with next offset beyond buffer
+        // Write notification with next offset beyond the notify buffer window
         int notifyOffset = 80;
-        SMBUtil.writeInt4(500, buffer, notifyOffset); // Invalid - too large
+        SMBUtil.writeInt4(500, buffer, notifyOffset); // 80 + 500 = 580, well past 180
         SMBUtil.writeInt4(1, buffer, notifyOffset + 4);
         SMBUtil.writeInt4(8, buffer, notifyOffset + 8);
         System.arraycopy("test".getBytes("UnicodeLittleUnmarked"), 0, buffer, notifyOffset + 12, 8);
 
-        // When & Then - should handle gracefully
-        assertThrows(Exception.class, () -> {
-            response.readBytesWireFormat(buffer, offset);
-        });
+        // When - the loop-advance guard must break cleanly instead of chasing the bogus
+        // offset into an ArrayIndexOutOfBoundsException
+        int bytesRead = response.readBytesWireFormat(buffer, offset);
+
+        // Then - the single valid entry is decoded and iteration stops
+        assertTrue(bytesRead > 0);
+        List<FileNotifyInformation> notifications = response.getNotifyInformation();
+        assertEquals(1, notifications.size());
+        assertEquals(1, notifications.get(0).getAction());
+        assertEquals("test", notifications.get(0).getFileName());
+    }
+
+    @Test
+    @DisplayName("Should throw exception when buffer offset/length overruns the message buffer")
+    void testOutOfRangeBufferOffset() throws Exception {
+        // Given - structurally valid header, but OutputBufferOffset + OutputBufferLength is
+        // larger than the actual message buffer
+        byte[] buffer = new byte[128];
+        int offset = 0;
+
+        setHeaderStart(response, 64);
+
+        SMBUtil.writeInt2(9, buffer, offset); // Structure size
+        SMBUtil.writeInt2(80 - 64, buffer, offset + 2); // Buffer offset (absolute 80)
+        SMBUtil.writeInt4(100, buffer, offset + 4); // Length -> 80 + 100 = 180 > 128
+
+        // When & Then - an out-of-range offset/length must be rejected with a decoding
+        // exception rather than allowed to drive an out-of-bounds read
+        assertThrows(SMBProtocolDecodingException.class, () -> response.readBytesWireFormat(buffer, offset));
     }
 
     @Test

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/session/Smb2SessionSetupResponseTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/session/Smb2SessionSetupResponseTest.java
@@ -221,4 +221,23 @@ class Smb2SessionSetupResponseTest extends BaseTest {
         int written = resp.writeBytesWireFormat(dst, 0);
         assertEquals(0, written);
     }
+
+    @Test
+    @DisplayName("Security buffer offset/length beyond packet should throw")
+    void testDecodeRejectsOutOfBoundsSecurityBuffer() {
+        Smb2SessionSetupResponse resp = newResponse();
+
+        byte[] buf = new byte[256];
+        int headerStart = 0;
+        buildHeader(buf, headerStart, NtStatus.NT_STATUS_MORE_PROCESSING_REQUIRED, 0x0001, 0x0L);
+
+        int bodyStart = headerStart + Smb2Constants.SMB2_HEADER_LENGTH; // 64
+        SMBUtil.writeInt2(9, buf, bodyStart); // structureSize
+        SMBUtil.writeInt2(0, buf, bodyStart + 2); // sessionFlags
+        SMBUtil.writeInt2(250, buf, bodyStart + 4); // securityBufferOffset
+        SMBUtil.writeInt2(100, buf, bodyStart + 6); // securityBufferLength (250 + 100 = 350 > 256)
+
+        assertThrows(SMBProtocolDecodingException.class, () -> resp.decode(buf, headerStart),
+                "Out-of-bounds security buffer should raise a decoding exception");
+    }
 }


### PR DESCRIPTION
## Summary

Bug fixes surfaced by an MS-SMB2 / MS-FSCC conformance review of the SMB2/3 client (`org.codelibs.jcifs.smb`). Scope is limited to **low-risk, high-confidence correctness / robustness fixes**; larger architectural gaps found in the review (e.g. SMB3 transport encryption wiring, cancel/echo, multi-credit / large-MTU) are intentionally **out of scope** and left for follow-up.

### Correctness
- **`Smb3KeyDerivation`** — SMB 3.1.1 encryption key labels were `SMB2C2SCipherKey` / `SMB2S2CCipherKey`. The SP800-108 KDF requires `SMBC2SCipherKey` / `SMBS2CCipherKey`; the stray `2` derives encryption keys that never match a real server. (Signing `SMBSigningKey` and app `SMBAppKey` labels were already correct.)
- **`Smb2ReadResponse`** — `DataOffset` was read as a signed `byte`, so values ≥ `0x80` became negative. Now read as an unsigned byte.
- **`FileBothDirectoryInfo.decode`** — returned a negative byte count (`start - bufferIndex`), violating the `Decodable` contract. Now returns `bufferIndex - start`. (Both call sites ignore the value, so no behavioral impact beyond the contract.)

### Robustness (server-controlled offset/length validation)
Validate offsets/lengths from the server before allocating or indexing, so a malicious/malformed server cannot trigger `ArrayIndexOutOfBoundsException` / `OutOfMemoryError` on the client:
- **`Smb2CreateResponse`** — validate create-context name/data offset+length.
- **`Smb2ReadResponse`** — validate data offset+length against packet bounds.
- **`Smb2QueryDirectoryResponse`** — reject a negative / out-of-range `OutputBufferLength` instead of decoding one bogus entry.
- **`FileBothDirectoryInfo`** — bound-check the file name length.

### Reliability
- **`SmbFileOutputStream` / `SmbRandomAccessFile`** — throw instead of looping forever when the server reports a zero-length write with bytes still remaining.
- **`SmbFileOutputStream.close()`** — null-guard the handle (matching the input stream).
- **`SmbRandomAccessFile`** — fix the `RemainingBytes` hint (bytes left in the request, not offset-adjusted).
- **`FileRenameInformation2.encode`** — explicitly zero `Reserved` / `RootDirectory` instead of relying on buffer pre-zeroing.
- **`SmbTransportImpl`** — dedicated `final` monitor for the reassigned preauth-integrity hash; apply topup credits to the current chain head; null-guard `getResponse()` on the zero-credit path.
- **`Transport`** — pass the current request (not the chain head) to `handleIntermediate` on the async wait path.

## Testing
`mvn test` — **8434 tests, 0 failures, 0 errors, 0 skipped.** Tests updated for the corrected decode contract and the new decode-time validation.