### PR TITLE
fix: ConcurrentModificationException when accessing DFS referrals

### DIFF
--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbTreeImpl.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbTreeImpl.java
@@ -22,11 +22,11 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -94,7 +94,7 @@ class SmbTreeImpl implements SmbTreeInternal {
     private final List<StackTraceElement[]> acquires;
     private final List<StackTraceElement[]> releases;
 
-    private final Map<String, DfsReferralData> treeReferrals = new HashMap<>();
+    private final Map<String, DfsReferralData> treeReferrals = new ConcurrentHashMap<>();
 
     SmbTreeImpl(final SmbSessionImpl session, final String share, final String service) {
         this.session = session.acquire();


### PR DESCRIPTION
SmbTreeImpl caches DFS referrals in a plain HashMap. getTreeReferral reads it by iterating the key set to find the entry whose path prefix matches the request, and setTreeReferral writes to it with put.

Neither is synchronized, and a tree connection is shared by every thread that works on the same share, so one thread can iterate the map while another caches a referral into it. The iteration then fails with ConcurrentModificationException.

Refs:
- https://github.com/codelibs/jcifs/issues/76