### PR TITLE
fix: only report overlapping copy paths on path element boundaries

### DIFF
--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbResourceLocatorImpl.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbResourceLocatorImpl.java
@@ -694,9 +694,47 @@ class SmbResourceLocatorImpl implements SmbResourceLocatorInternal, Cloneable {
      */
     @Override
     public boolean overlaps(final SmbResourceLocator other) throws CIFSException {
-        final String tp = getCanonicalURL();
-        final String op = other.getCanonicalURL();
-        return getAddress().equals(other.getAddress()) && tp.regionMatches(true, 0, op, 0, Math.min(tp.length(), op.length()));
+        if (!getAddress().equals(other.getAddress())) {
+            return false;
+        }
+        final String tp = getURLPath();
+        final String op = other.getURLPath();
+        return isSameOrAncestor(tp, op) || isSameOrAncestor(op, tp);
+    }
+
+    /**
+     * Tests whether {@code path} denotes {@code ancestor} itself or a resource below it. Both arguments are canonical
+     * URL paths; trailing separators are insignificant and the comparison is case insensitive, as SMB paths are. A
+     * shared name prefix that does not end on a path separator (for example {@code /share/file} and
+     * {@code /share/file123}) does not qualify.
+     *
+     * @param ancestor
+     *            canonical URL path of the possible ancestor
+     * @param path
+     *            canonical URL path to test
+     * @return whether path is ancestor or is contained in it
+     */
+    private static boolean isSameOrAncestor(final String ancestor, final String path) {
+        final int al = trimTrailingSeparators(ancestor);
+        final int pl = trimTrailingSeparators(path);
+        if (al > pl || !path.regionMatches(true, 0, ancestor, 0, al)) {
+            return false;
+        }
+        // equal paths, the root itself, or a separator right after the common prefix
+        return al == pl || al <= 1 || path.charAt(al) == '/';
+    }
+
+    /**
+     * @param path
+     *            path to inspect
+     * @return the length of path with any trailing separators removed, keeping a leading root separator
+     */
+    private static int trimTrailingSeparators(final String path) {
+        int len = path.length();
+        while (len > 1 && path.charAt(len - 1) == '/') {
+            len--;
+        }
+        return len;
     }
 
     /**

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbResourceLocatorImplTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbResourceLocatorImplTest.java
@@ -298,7 +298,7 @@ class SmbResourceLocatorImplTest {
     }
 
     @Test
-    @DisplayName("overlaps requires same address and canonical URL prefix match")
+    @DisplayName("overlaps requires the same address")
     void testOverlaps() throws Exception {
         UniAddress a = mock(UniAddress.class);
         when(nsc.getAllByName(anyString(), anyBoolean())).thenReturn(new Address[] { a });
@@ -308,6 +308,30 @@ class SmbResourceLocatorImplTest {
 
         SmbResourceLocatorImpl other = locator("smb://server/share/other");
         assertFalse(base.overlaps(other));
+
+        UniAddress b = mock(UniAddress.class);
+        when(nsc.getAllByName(eq("other"), anyBoolean())).thenReturn(new Address[] { b });
+        assertFalse(base.overlaps(locator("smb://other/share/dir/file")));
+    }
+
+    @ParameterizedTest
+    @DisplayName("overlaps matches whole path elements, ignoring authority and trailing separators")
+    @CsvSource({
+            // parent/child and identical paths overlap
+            "smb://server/share/dir,smb://server/share/dir/file,true", "smb://server/share/dir/file,smb://server/share/dir,true",
+            "smb://server/share/dir/,smb://server/share/dir/file,true", "smb://server/share/a/b,smb://server/share/a/b/,true",
+            "smb://server/share/file,smb://server/share/file,true", "smb://server/share/file,smb://server/share/FILE,true",
+            "smb://server/share,smb://server/share/dir/file,true", "smb://server/share/,smb://server/share/dir/file,true",
+            // the authority is not part of the path, the address comparison covers the server
+            "smb://user@server/share/a,smb://server/share/a/b,true", "smb://server:445/share/a,smb://server/share/a/b,true",
+            // siblings sharing a name prefix are not parent/child
+            "smb://server/share/file,smb://server/share/file123,false", "smb://server/share/file123,smb://server/share/file,false",
+            "smb://server/share/dir,smb://server/share/dir2/,false", "smb://server/share/dir/,smb://server/share/dir2/,false",
+            "smb://server/share,smb://server/share2/file,false", "smb://server/share/other,smb://server/share/dir,false" })
+    void testOverlapsPathBoundaries(String left, String right, boolean expected) throws Exception {
+        UniAddress a = mock(UniAddress.class);
+        when(nsc.getAllByName(anyString(), anyBoolean())).thenReturn(new Address[] { a });
+        assertEquals(expected, locator(left).overlaps(locator(right)));
     }
 
     @Test


### PR DESCRIPTION
Fixes #69

## Problem

`SmbResourceLocatorImpl.overlaps()` decided whether two paths overlap with an unbounded prefix match over the two canonical URLs:

```java
final String tp = getCanonicalURL();
final String op = other.getCanonicalURL();
return getAddress().equals(other.getAddress())
    && tp.regionMatches(true, 0, op, 0, Math.min(tp.length(), op.length()));
```

There is no path separator boundary check, and the compared strings include the URL authority even though server identity is already established by `getAddress().equals(...)`. Both halves are wrong, in opposite directions. `SmbFile.copyTo()` is the only caller.

### False positives — a valid copy is rejected

| source | destination | before | expected |
| --- | --- | --- | --- |
| `smb://server/share/file` | `smb://server/share/file123` | overlap | no overlap |
| `smb://server/share/dir` | `smb://server/share/dir2/` | overlap | no overlap |
| `smb://server/share` | `smb://server/share2/file` | overlap | no overlap |

`copyTo` throws `SmbException("Source and destination paths overlap.")` for siblings whose names share a prefix, and for two different shares whose names share a prefix. This is the case reported in #69.

A source spelled with a trailing separator happens to escape the first two rows, because the separator itself then breaks the match — so in practice this hits files and directories addressed without a trailing slash.

### False negatives — a real overlap goes undetected

| source | destination | before | expected |
| --- | --- | --- | --- |
| `smb://user@server/share/a` | `smb://server/share/a/b` | no overlap | overlap |
| `smb://server:445/share/a` | `smb://server/share/a/b` | no overlap | overlap |

When the two URLs name the same server with different authority text (user info, an explicit port, or an address instead of a host name), the address comparison passes but the string comparison fails, so a genuine parent/child pair is not detected. `copyTo` then proceeds and `SmbCopyUtil.copyDir()` recurses into the destination it is itself creating inside the enumerated source tree.

jcifs 1.3.x compared `canon` (the URL path), not the full URL; the authority was pulled into the comparison during the 2.x rewrite.

## Fix

Compare the canonical URL *paths*, and treat two paths as overlapping only when one is the other or continues after a path separator. Trailing separators remain insignificant and the comparison remains case insensitive, as SMB paths are.

## Tests

`SmbResourceLocatorImplTest` gains a parameterized `testOverlapsPathBoundaries` covering both directions of the parent/child, identical, case-differing, share-root, trailing-separator, differing-authority and shared-name-prefix cases; `testOverlaps` additionally asserts that a differing address yields no overlap. Six of the sixteen new rows fail against the current implementation.

Full suite: 8582 tests, 0 failures.
