### PR TITLE
fix: correct configuration property names and warn about pre-3.0.0 keys

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,10 @@ src/main/java/org/codelibs/jcifs/
 
 ## Configuration
 
-Prefix: `jcifs.smb.client.` - see `Configuration` interface for all properties and defaults
+Prefix: `jcifs.client.` (plus `jcifs.netbios.`, `jcifs.http.` and a few bare `jcifs.` keys) -
+see `Configuration` interface for all properties and defaults. The keys actually read live in
+`PropertyConfiguration`; treat that file as the source of truth. The `.smb` segment used by
+2.x (`jcifs.smb.client.*`) was dropped in 3.0.0 and old keys are ignored.
 
 ## Code Conventions
 
@@ -112,4 +115,4 @@ CIFSContext → SmbTransportPool → SmbTransport → SmbSession → SmbTree →
 1. **SMB1 Code**: Legacy code in `smb1` package - avoid modifying
 2. **Internal Package**: Never depend on `internal` from external code
 3. **Thread Safety**: `CIFSContext` is thread-safe; `SmbFile` operations are not
-4. **DFS**: Paths auto-resolved; disable with `jcifs.smb.client.dfs.disabled=true`
+4. **DFS**: Paths auto-resolved; disable with `jcifs.client.dfs.disabled=true`

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ import org.codelibs.jcifs.smb.config.PropertyConfiguration;
 // Create context with domain credentials
 Properties props = new Properties();
 // Optional: Set SMB protocol preferences
-props.setProperty("jcifs.smb.client.minVersion", "SMB202");
-props.setProperty("jcifs.smb.client.maxVersion", "SMB311");
+props.setProperty("jcifs.client.minVersion", "SMB202");
+props.setProperty("jcifs.client.maxVersion", "SMB311");
 
 CIFSContext baseContext = new BaseContext(new PropertyConfiguration(props));
 NtlmPasswordAuthenticator auth = new NtlmPasswordAuthenticator(
@@ -192,10 +192,9 @@ try (SmbFile dir = new SmbFile("smb://server/share/monitored/", context);
 ```java
 // Advanced configuration
 Properties config = new Properties();
-config.setProperty("jcifs.smb.client.minVersion", "SMB300");  // Require SMB3+
-config.setProperty("jcifs.smb.client.maxVersion", "SMB311");
-config.setProperty("jcifs.smb.client.enableSMB2Signing", "true");  // Enable signing
-config.setProperty("jcifs.smb.client.signingPreferred", "true");
+config.setProperty("jcifs.client.minVersion", "SMB300");  // Require SMB3+
+config.setProperty("jcifs.client.maxVersion", "SMB311");
+config.setProperty("jcifs.client.signingPreferred", "true");  // Prefer signing
 config.setProperty("jcifs.resolveOrder", "LMHOSTS,DNS,WINS,BCAST");
 
 CIFSContext customContext = new BaseContext(new PropertyConfiguration(config));
@@ -306,20 +305,20 @@ try (InputStream is = smbFile.getInputStream()) {
 ### Protocol Selection
 ```java
 // For maximum performance on modern servers
-props.setProperty("jcifs.smb.client.minVersion", "SMB300");
-props.setProperty("jcifs.smb.client.maxVersion", "SMB311");
+props.setProperty("jcifs.client.minVersion", "SMB300");
+props.setProperty("jcifs.client.maxVersion", "SMB311");
 
 // For maximum compatibility (default)
-props.setProperty("jcifs.smb.client.minVersion", "SMB1");
-props.setProperty("jcifs.smb.client.maxVersion", "SMB311");
+props.setProperty("jcifs.client.minVersion", "SMB1");
+props.setProperty("jcifs.client.maxVersion", "SMB311");
 ```
 
 ## 🔒 Security Best Practices
 
 ### Authentication
 - **Use domain authentication** when possible for better security
-- **Enable SMB signing** for data integrity: `jcifs.smb.client.signingPreferred=true`
-- **Prefer SMB3** for encryption: `jcifs.smb.client.minVersion=SMB300`
+- **Enable SMB signing** for data integrity: `jcifs.client.signingPreferred=true`
+- **Prefer SMB3** for encryption: `jcifs.client.minVersion=SMB300`
 - **Rotate credentials** regularly and implement credential renewal
 
 ### Network Security
@@ -332,10 +331,9 @@ props.setProperty("jcifs.smb.client.maxVersion", "SMB311");
 ```java
 // Secure configuration example
 Properties secureConfig = new Properties();
-secureConfig.setProperty("jcifs.smb.client.minVersion", "SMB300");
-secureConfig.setProperty("jcifs.smb.client.enableSMB2Signing", "true");
-secureConfig.setProperty("jcifs.smb.client.signingPreferred", "true");
-secureConfig.setProperty("jcifs.smb.client.ipcSigningEnforced", "true");
+secureConfig.setProperty("jcifs.client.minVersion", "SMB300");
+secureConfig.setProperty("jcifs.client.signingEnforced", "true");
+secureConfig.setProperty("jcifs.client.ipcSigningEnforced", "true");
 ```
 
 ## 🛠️ Troubleshooting
@@ -345,9 +343,9 @@ secureConfig.setProperty("jcifs.smb.client.ipcSigningEnforced", "true");
 **Connection Timeouts**
 ```java
 // Increase timeout values
-props.setProperty("jcifs.smb.client.soTimeout", "35000");      // 35 seconds
-props.setProperty("jcifs.smb.client.connTimeout", "10000");    // 10 seconds
-props.setProperty("jcifs.smb.client.responseTimeout", "30000"); // 30 seconds
+props.setProperty("jcifs.client.soTimeout", "35000");      // 35 seconds
+props.setProperty("jcifs.client.connTimeout", "10000");    // 10 seconds
+props.setProperty("jcifs.client.responseTimeout", "30000"); // 30 seconds
 ```
 
 **Authentication Failures**
@@ -359,11 +357,12 @@ props.setProperty("jcifs.smb.client.responseTimeout", "30000"); // 30 seconds
 **Protocol Negotiation Issues**
 ```java
 // Debug protocol negotiation
-props.setProperty("jcifs.util.loglevel", "3");  // Enable debug logging
+// Enable debug logging through your SLF4J backend, e.g.
+//   <logger name="org.codelibs.jcifs.smb.internal.smb2" level="DEBUG"/>
 
 // Force specific protocol version if needed
-props.setProperty("jcifs.smb.client.minVersion", "SMB202");
-props.setProperty("jcifs.smb.client.maxVersion", "SMB202");
+props.setProperty("jcifs.client.minVersion", "SMB202");
+props.setProperty("jcifs.client.maxVersion", "SMB202");
 ```
 
 **Performance Issues**
@@ -390,8 +389,24 @@ JCIFS uses SLF4J for logging. Configure your logging framework accordingly:
 ### From JCIFS 2.x to 3.x
 - **Java 17+ required**: Update your runtime environment
 - **Package changes**: All classes moved to `org.codelibs.jcifs.smb`
+- **Property names changed**: the `.smb` segment was dropped from every configuration
+  key (see below). Old keys are *silently ignored*, so settings fall back to their
+  defaults until you rename them.
 - **Enhanced SMB3 support**: New encryption and signing capabilities
 - **Improved authentication**: Enhanced credential management
+
+#### Configuration property names
+
+| 2.x | 3.x |
+| --- | --- |
+| `jcifs.smb.client.<name>` | `jcifs.client.<name>` |
+| `jcifs.smb.<name>` (`lmCompatibility`, `maxBuffers`, `allowNTLMFallback`, `useRawNTLM`) | `jcifs.<name>` |
+| `jcifs.smb1.smb.client.<name>` (legacy SMB1 stack) | `jcifs.client.<name>` |
+| `jcifs.netbios.<name>`, `jcifs.http.<name>`, `jcifs.resolveOrder`, `jcifs.encoding` | unchanged |
+
+`PropertyConfiguration` logs a warning for every property it receives under one of the
+old prefixes, naming the key to use instead. The authoritative list of keys and their
+defaults is the `Configuration` interface javadoc.
 
 ### From Original JCIFS
 - **Context-based API**: Replace global configuration with contexts

--- a/docs/SMB3_IMPLEMENTATION_PLAN.md
+++ b/docs/SMB3_IMPLEMENTATION_PLAN.md
@@ -230,29 +230,29 @@ graph TD
 
 ```properties
 # Lease configuration
-org.codelibs.jcifs.smb.impl.client.useLeases=true
-org.codelibs.jcifs.smb.impl.client.leaseTimeout=30000
+jcifs.client.useLeases=true
+jcifs.client.leaseTimeout=30000
 
 # Persistent handles
-org.codelibs.jcifs.smb.impl.client.usePersistentHandles=true
-org.codelibs.jcifs.smb.impl.client.durableTimeout=120000
+jcifs.client.usePersistentHandles=true
+jcifs.client.durableTimeout=120000
 
 # Multi-channel
-org.codelibs.jcifs.smb.impl.client.useMultiChannel=true
-org.codelibs.jcifs.smb.impl.client.maxChannels=4
-org.codelibs.jcifs.smb.impl.client.channelBindingPolicy=required
+jcifs.client.useMultiChannel=true
+jcifs.client.maxChannels=4
+jcifs.client.channelBindingPolicy=required
 
 # Directory leasing
-org.codelibs.jcifs.smb.impl.client.useDirectoryLeasing=true
-org.codelibs.jcifs.smb.impl.client.dirCacheTimeout=60000
+jcifs.client.useDirectoryLeasing=true
+jcifs.client.dirCacheTimeout=60000
 
 # RDMA
-org.codelibs.jcifs.smb.impl.client.useRDMA=auto
-org.codelibs.jcifs.smb.impl.client.rdmaProvider=disni
+jcifs.client.useRDMA=auto
+jcifs.client.rdmaProvider=disni
 
 # Witness
-org.codelibs.jcifs.smb.impl.client.useWitness=true
-org.codelibs.jcifs.smb.impl.client.witnessNotificationTimeout=5000
+jcifs.client.useWitness=true
+jcifs.client.witnessNotificationTimeout=5000
 ```
 
 ## Risk Assessment

--- a/docs/smb3-features/01-smb3-lease-design.md
+++ b/docs/smb3-features/01-smb3-lease-design.md
@@ -560,10 +560,10 @@ private void handleIncomingMessage(ServerMessageBlock2 msg) {
 // In PropertyConfiguration.java
 public class PropertyConfiguration implements Configuration {
     // Lease configuration properties
-    public static final String USE_LEASES = "org.codelibs.jcifs.smb.impl.client.useLeases";
-    public static final String LEASE_TIMEOUT = "org.codelibs.jcifs.smb.impl.client.leaseTimeout";
-    public static final String MAX_LEASES = "org.codelibs.jcifs.smb.impl.client.maxLeases";
-    public static final String LEASE_VERSION = "org.codelibs.jcifs.smb.impl.client.leaseVersion";
+    public static final String USE_LEASES = "jcifs.client.useLeases";
+    public static final String LEASE_TIMEOUT = "jcifs.client.leaseTimeout";
+    public static final String MAX_LEASES = "jcifs.client.maxLeases";
+    public static final String LEASE_VERSION = "jcifs.client.leaseVersion";
     
     public boolean isUseLeases() {
         return getBooleanProperty(USE_LEASES, true);
@@ -641,7 +641,7 @@ public class LeaseTest {
 public void testLeaseWithRealServer() throws Exception {
     // Requires SMB3 capable server
     CIFSContext context = getTestContext();
-    context.getConfig().setProperty("org.codelibs.jcifs.smb.impl.client.useLeases", "true");
+    context.getConfig().setProperty("jcifs.client.useLeases", "true");
     
     try (SmbFile file = new SmbFile("smb://server/share/test.txt", context)) {
         // Open file with lease

--- a/docs/smb3-features/02-persistent-handles-design.md
+++ b/docs/smb3-features/02-persistent-handles-design.md
@@ -687,11 +687,11 @@ public void logoff() throws IOException {
 ### 7.1 Configuration Properties
 ```java
 // In PropertyConfiguration.java
-public static final String USE_DURABLE_HANDLES = "org.codelibs.jcifs.smb.impl.client.useDurableHandles";
-public static final String USE_PERSISTENT_HANDLES = "org.codelibs.jcifs.smb.impl.client.usePersistentHandles";
-public static final String DURABLE_HANDLE_TIMEOUT = "org.codelibs.jcifs.smb.impl.client.durableHandleTimeout";
-public static final String HANDLE_RECONNECT_RETRIES = "org.codelibs.jcifs.smb.impl.client.handleReconnectRetries";
-public static final String HANDLE_STATE_DIR = "org.codelibs.jcifs.smb.impl.client.handleStateDirectory";
+public static final String USE_DURABLE_HANDLES = "jcifs.client.useDurableHandles";
+public static final String USE_PERSISTENT_HANDLES = "jcifs.client.usePersistentHandles";
+public static final String DURABLE_HANDLE_TIMEOUT = "jcifs.client.durableHandleTimeout";
+public static final String HANDLE_RECONNECT_RETRIES = "jcifs.client.handleReconnectRetries";
+public static final String HANDLE_STATE_DIR = "jcifs.client.handleStateDirectory";
 
 public boolean isUseDurableHandles() {
     return getBooleanProperty(USE_DURABLE_HANDLES, true);
@@ -805,7 +805,7 @@ public class PersistentHandleTest {
 @Test
 public void testDurableHandleReconnection() throws Exception {
     CIFSContext context = getTestContext();
-    context.getConfig().setProperty("org.codelibs.jcifs.smb.impl.client.useDurableHandles", "true");
+    context.getConfig().setProperty("jcifs.client.useDurableHandles", "true");
     
     SmbFile file = new SmbFile("smb://server/share/test.txt", context);
     file.createNewFile();
@@ -830,7 +830,7 @@ public void testDurableHandleReconnection() throws Exception {
 public void testPersistentHandleSurvivesReboot() throws Exception {
     // This test requires special setup with server reboot capability
     CIFSContext context = getTestContext();
-    context.getConfig().setProperty("org.codelibs.jcifs.smb.impl.client.usePersistentHandles", "true");
+    context.getConfig().setProperty("jcifs.client.usePersistentHandles", "true");
     
     SmbFile file = new SmbFile("smb://server/share/persistent.txt", context);
     file.createNewFile();

--- a/docs/smb3-features/03-multi-channel-design.md
+++ b/docs/smb3-features/03-multi-channel-design.md
@@ -993,11 +993,11 @@ public void optimizedLargeRead(byte[] buffer, long offset, int length) throws IO
 ### 6.1 Configuration Properties
 ```java
 // In PropertyConfiguration.java
-public static final String USE_MULTI_CHANNEL = "org.codelibs.jcifs.smb.impl.client.useMultiChannel";
-public static final String MAX_CHANNELS = "org.codelibs.jcifs.smb.impl.client.maxChannels";
-public static final String CHANNEL_BINDING_POLICY = "org.codelibs.jcifs.smb.impl.client.channelBindingPolicy";
-public static final String LOAD_BALANCING_STRATEGY = "org.codelibs.jcifs.smb.impl.client.loadBalancingStrategy";
-public static final String CHANNEL_HEALTH_CHECK_INTERVAL = "org.codelibs.jcifs.smb.impl.client.channelHealthCheckInterval";
+public static final String USE_MULTI_CHANNEL = "jcifs.client.useMultiChannel";
+public static final String MAX_CHANNELS = "jcifs.client.maxChannels";
+public static final String CHANNEL_BINDING_POLICY = "jcifs.client.channelBindingPolicy";
+public static final String LOAD_BALANCING_STRATEGY = "jcifs.client.loadBalancingStrategy";
+public static final String CHANNEL_HEALTH_CHECK_INTERVAL = "jcifs.client.channelHealthCheckInterval";
 
 public boolean isUseMultiChannel() {
     return getBooleanProperty(USE_MULTI_CHANNEL, true);
@@ -1076,8 +1076,8 @@ public void testChannelFailover() throws Exception {
 public void testMultiChannelThroughput() throws Exception {
     // Requires multi-NIC test environment
     CIFSContext context = getTestContext();
-    context.getConfig().setProperty("org.codelibs.jcifs.smb.impl.client.useMultiChannel", "true");
-    context.getConfig().setProperty("org.codelibs.jcifs.smb.impl.client.maxChannels", "4");
+    context.getConfig().setProperty("jcifs.client.useMultiChannel", "true");
+    context.getConfig().setProperty("jcifs.client.maxChannels", "4");
     
     SmbFile file = new SmbFile("smb://server/share/largefile.dat", context);
     

--- a/docs/smb3-features/04-directory-leasing-design.md
+++ b/docs/smb3-features/04-directory-leasing-design.md
@@ -775,11 +775,11 @@ public void logoff() throws IOException {
 ### 6.1 Configuration Properties
 ```java
 // In PropertyConfiguration.java
-public static final String USE_DIRECTORY_LEASING = "org.codelibs.jcifs.smb.impl.client.useDirectoryLeasing";
-public static final String DIRECTORY_CACHE_SCOPE = "org.codelibs.jcifs.smb.impl.client.directoryCacheScope";
-public static final String DIRECTORY_CACHE_TIMEOUT = "org.codelibs.jcifs.smb.impl.client.directoryCacheTimeout";
-public static final String DIRECTORY_NOTIFICATIONS_ENABLED = "org.codelibs.jcifs.smb.impl.client.directoryNotificationsEnabled";
-public static final String MAX_DIRECTORY_CACHE_ENTRIES = "org.codelibs.jcifs.smb.impl.client.maxDirectoryCacheEntries";
+public static final String USE_DIRECTORY_LEASING = "jcifs.client.useDirectoryLeasing";
+public static final String DIRECTORY_CACHE_SCOPE = "jcifs.client.directoryCacheScope";
+public static final String DIRECTORY_CACHE_TIMEOUT = "jcifs.client.directoryCacheTimeout";
+public static final String DIRECTORY_NOTIFICATIONS_ENABLED = "jcifs.client.directoryNotificationsEnabled";
+public static final String MAX_DIRECTORY_CACHE_ENTRIES = "jcifs.client.maxDirectoryCacheEntries";
 
 public boolean isUseDirectoryLeasing() {
     return getBooleanProperty(USE_DIRECTORY_LEASING, true);
@@ -946,7 +946,7 @@ public void testDirectoryLeaseManager() {
 @Test
 public void testDirectoryListingCache() throws Exception {
     CIFSContext context = getTestContext();
-    context.getConfig().setProperty("org.codelibs.jcifs.smb.impl.client.useDirectoryLeasing", "true");
+    context.getConfig().setProperty("jcifs.client.useDirectoryLeasing", "true");
     
     SmbFile dir = new SmbFile("smb://server/share/testdir/", context);
     
@@ -967,7 +967,7 @@ public void testDirectoryListingCache() throws Exception {
 @Test
 public void testDirectoryChangeNotification() throws Exception {
     CIFSContext context = getTestContext();
-    context.getConfig().setProperty("org.codelibs.jcifs.smb.impl.client.directoryNotificationsEnabled", "true");
+    context.getConfig().setProperty("jcifs.client.directoryNotificationsEnabled", "true");
     
     SmbFile dir = new SmbFile("smb://server/share/testdir/", context);
     SmbFile testFile = new SmbFile("smb://server/share/testdir/newfile.txt", context);

--- a/docs/smb3-features/05-rdma-smb-direct-design.md
+++ b/docs/smb3-features/05-rdma-smb-direct-design.md
@@ -883,12 +883,12 @@ public static class RdmaChannelInfo {
 ### 6.1 Configuration Properties
 ```java
 // In PropertyConfiguration.java
-public static final String USE_RDMA = "org.codelibs.jcifs.smb.impl.client.useRDMA";
-public static final String RDMA_PROVIDER = "org.codelibs.jcifs.smb.impl.client.rdmaProvider";
-public static final String RDMA_READ_WRITE_THRESHOLD = "org.codelibs.jcifs.smb.impl.client.rdmaReadWriteThreshold";
-public static final String RDMA_MAX_SEND_SIZE = "org.codelibs.jcifs.smb.impl.client.rdmaMaxSendSize";
-public static final String RDMA_MAX_RECEIVE_SIZE = "org.codelibs.jcifs.smb.impl.client.rdmaMaxReceiveSize";
-public static final String RDMA_CREDITS = "org.codelibs.jcifs.smb.impl.client.rdmaCredits";
+public static final String USE_RDMA = "jcifs.client.useRDMA";
+public static final String RDMA_PROVIDER = "jcifs.client.rdmaProvider";
+public static final String RDMA_READ_WRITE_THRESHOLD = "jcifs.client.rdmaReadWriteThreshold";
+public static final String RDMA_MAX_SEND_SIZE = "jcifs.client.rdmaMaxSendSize";
+public static final String RDMA_MAX_RECEIVE_SIZE = "jcifs.client.rdmaMaxReceiveSize";
+public static final String RDMA_CREDITS = "jcifs.client.rdmaCredits";
 
 public boolean isUseRDMA() {
     String value = getProperty(USE_RDMA, "auto");
@@ -975,7 +975,7 @@ public void testRdmaBufferManager() throws Exception {
 @EnabledIfSystemProperty(named = "rdma.test.enabled", matches = "true")
 public void testRdmaLargeFileTransfer() throws Exception {
     CIFSContext context = getTestContext();
-    context.getConfig().setProperty("org.codelibs.jcifs.smb.impl.client.useRDMA", "true");
+    context.getConfig().setProperty("jcifs.client.useRDMA", "true");
     
     SmbFile file = new SmbFile("smb://server/share/largefile.dat", context);
     
@@ -1011,8 +1011,8 @@ public void testRdmaLargeFileTransfer() throws Exception {
 public void testRdmaFallbackToTcp() throws Exception {
     // Test that we properly fall back to TCP when RDMA is not available
     CIFSContext context = getTestContext();
-    context.getConfig().setProperty("org.codelibs.jcifs.smb.impl.client.useRDMA", "true");
-    context.getConfig().setProperty("org.codelibs.jcifs.smb.impl.client.rdmaProvider", "nonexistent");
+    context.getConfig().setProperty("jcifs.client.useRDMA", "true");
+    context.getConfig().setProperty("jcifs.client.rdmaProvider", "nonexistent");
     
     SmbFile file = new SmbFile("smb://server/share/test.txt", context);
     

--- a/docs/smb3-features/06-witness-protocol-design.md
+++ b/docs/smb3-features/06-witness-protocol-design.md
@@ -900,11 +900,11 @@ protected void handleConnectionLoss(IOException error) {
 ### 6.1 Configuration Properties
 ```java
 // In PropertyConfiguration.java
-public static final String USE_WITNESS = "org.codelibs.jcifs.smb.impl.client.useWitness";
-public static final String WITNESS_HEARTBEAT_TIMEOUT = "org.codelibs.jcifs.smb.impl.client.witnessHeartbeatTimeout";
-public static final String WITNESS_REGISTRATION_TIMEOUT = "org.codelibs.jcifs.smb.impl.client.witnessRegistrationTimeout";
-public static final String WITNESS_RECONNECT_DELAY = "org.codelibs.jcifs.smb.impl.client.witnessReconnectDelay";
-public static final String WITNESS_SERVICE_DISCOVERY = "org.codelibs.jcifs.smb.impl.client.witnessServiceDiscovery";
+public static final String USE_WITNESS = "jcifs.client.useWitness";
+public static final String WITNESS_HEARTBEAT_TIMEOUT = "jcifs.client.witnessHeartbeatTimeout";
+public static final String WITNESS_REGISTRATION_TIMEOUT = "jcifs.client.witnessRegistrationTimeout";
+public static final String WITNESS_RECONNECT_DELAY = "jcifs.client.witnessReconnectDelay";
+public static final String WITNESS_SERVICE_DISCOVERY = "jcifs.client.witnessServiceDiscovery";
 
 public boolean isUseWitness() {
     return getBooleanProperty(USE_WITNESS, false);  // Disabled by default
@@ -994,7 +994,7 @@ public void testWitnessClientMock() throws Exception {
 public void testWitnessFailover() throws Exception {
     // Requires cluster environment for testing
     CIFSContext context = getTestContext();
-    context.getConfig().setProperty("org.codelibs.jcifs.smb.impl.client.useWitness", "true");
+    context.getConfig().setProperty("jcifs.client.useWitness", "true");
     
     SmbFile file = new SmbFile("smb://cluster-server/share/test.txt", context);
     file.createNewFile();
@@ -1015,8 +1015,8 @@ public void testWitnessFailover() throws Exception {
 @Test
 public void testWitnessServiceDiscovery() throws Exception {
     CIFSContext context = getTestContext();
-    context.getConfig().setProperty("org.codelibs.jcifs.smb.impl.client.useWitness", "true");
-    context.getConfig().setProperty("org.codelibs.jcifs.smb.impl.client.witnessServiceDiscovery", "true");
+    context.getConfig().setProperty("jcifs.client.useWitness", "true");
+    context.getConfig().setProperty("jcifs.client.witnessServiceDiscovery", "true");
     
     SmbSession session = new SmbSession(context, transport);
     session.initializeWitnessSupport();

--- a/src/main/java/org/codelibs/jcifs/smb/Config.java
+++ b/src/main/java/org/codelibs/jcifs/smb/Config.java
@@ -170,7 +170,7 @@ public class Config {
             try {
                 return InetAddress.getByName(addr);
             } catch (final UnknownHostException uhe) {
-                log.error("Ignoring org.codelibs.jcifs.smb.impl.client.laddr address: " + addr, uhe);
+                log.error("Ignoring jcifs.client.laddr address: " + addr, uhe);
             }
         }
 

--- a/src/main/java/org/codelibs/jcifs/smb/Configuration.java
+++ b/src/main/java/org/codelibs/jcifs/smb/Configuration.java
@@ -43,7 +43,7 @@ public interface Configuration {
     /**
      *
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.dfs.ttl} (int, default 300)
+     * Property {@code jcifs.client.dfs.ttl} (int, default 300)
      *
      * @return title to live, in seconds, for DFS cache entries
      */
@@ -51,7 +51,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.dfs.strictView} (boolean, default false)
+     * Property {@code jcifs.client.dfs.strictView} (boolean, default false)
      *
      * @return whether a authentication failure during DFS resolving will throw an exception
      */
@@ -59,7 +59,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.dfs.disabled} (boolean, default false)
+     * Property {@code jcifs.client.dfs.disabled} (boolean, default false)
      *
      * @return whether DFS lookup is disabled
      */
@@ -71,7 +71,7 @@ public interface Configuration {
      * This works by appending the domain name to the netbios short name and will fail horribly if this mapping is not
      * correct for your domain.
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.dfs.convertToFQDN} (boolean, default false)
+     * Property {@code jcifs.client.dfs.convertToFQDN} (boolean, default false)
      *
      * @return whether to convert NetBIOS names returned by DFS to FQDNs
      */
@@ -83,7 +83,10 @@ public interface Configuration {
      * When true, preserve the original case of share names instead of converting to uppercase.
      * This is required for DFS namespaces with case-sensitive link names.
      *
-     * Property {@code jcifs.smb.client.preserveShareCase} (boolean, default false)
+     * Property {@code jcifs.client.preserveShareCase} (boolean, default false)
+     *
+     * The 3.0.1 spelling {@code jcifs.smb.client.preserveShareCase} is still honoured
+     * but deprecated.
      *
      * @return whether to preserve share name case
      */
@@ -92,7 +95,7 @@ public interface Configuration {
     /**
      * Minimum protocol version
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.minVersion} (string, default SMB1)
+     * Property {@code jcifs.client.minVersion} (string, default SMB1)
      *
      * @see DialectVersion
      * @return minimum protocol version to use/allow
@@ -103,7 +106,7 @@ public interface Configuration {
     /**
      * Maximum protocol version
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.maxVersion} (string, default SMB210)
+     * Property {@code jcifs.client.maxVersion} (string, default SMB210)
      *
      * @see DialectVersion
      * @return maximum protocol version to use/allow
@@ -114,7 +117,7 @@ public interface Configuration {
     /**
      * Use SMB2 non-backward compatible negotiation style
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.useSMB2Negotiation} (boolean, default false)
+     * Property {@code jcifs.client.useSMB2Negotiation} (boolean, default false)
      *
      * @return whether to use non-backward compatible protocol negotiation
      */
@@ -123,7 +126,7 @@ public interface Configuration {
     /**
      * Enforce secure negotiation
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.requireSecureNegotiate} (boolean, default true)
+     * Property {@code jcifs.client.requireSecureNegotiate} (boolean, default true)
      *
      * This does not provide any actual downgrade protection if SMB1 is allowed.
      *
@@ -136,7 +139,7 @@ public interface Configuration {
     /**
      * Enable port 139 failover
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.port139.enabled} (boolean, default false)
+     * Property {@code jcifs.client.port139.enabled} (boolean, default false)
      *
      * @return whether to failover to legacy transport on port 139
      */
@@ -144,7 +147,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.useUnicode} (boolean, default true)
+     * Property {@code jcifs.client.useUnicode} (boolean, default true)
      *
      * @return whether to announce support for unicode
      */
@@ -152,7 +155,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.forceUnicode} (boolean, default false)
+     * Property {@code jcifs.client.forceUnicode} (boolean, default false)
      *
      * @return whether to use unicode, even if the server does not announce it
      */
@@ -160,7 +163,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.useBatching} (boolean, default false)
+     * Property {@code jcifs.client.useBatching} (boolean, default false)
      *
      * @return whether to enable support for SMB1 AndX command batching
      */
@@ -168,7 +171,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.nativeOs} (string, default {@code os.name})
+     * Property {@code jcifs.client.nativeOs} (string, default {@code os.name})
      *
      * @return OS string to report
      */
@@ -176,7 +179,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.nativeLanMan} (string, default {@code jCIFS})
+     * Property {@code jcifs.client.nativeLanMan} (string, default {@code jCIFS})
      *
      * @return Lanman string to report
      */
@@ -184,7 +187,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.rcv_buf_size} (int, default 65535)
+     * Property {@code jcifs.client.rcv_buf_size} (int, default 65535)
      *
      * @return receive buffer size, in bytes
      * @deprecated use getReceiveBufferSize instead
@@ -194,7 +197,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.rcv_buf_size} (int, default 65535)
+     * Property {@code jcifs.client.rcv_buf_size} (int, default 65535)
      *
      * @return receive buffer size, in bytes
      */
@@ -202,7 +205,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.snd_buf_size} (int, default 65535)
+     * Property {@code jcifs.client.snd_buf_size} (int, default 65535)
      *
      * @return send buffer size, in bytes
      */
@@ -210,7 +213,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.soTimeout} (int, default 35000)
+     * Property {@code jcifs.client.soTimeout} (int, default 35000)
      *
      * @return socket timeout, in milliseconds
      */
@@ -218,14 +221,14 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.connTimeout} (int, default 35000)
+     * Property {@code jcifs.client.connTimeout} (int, default 35000)
      *
      * @return timeout for establishing a socket connection, in milliseconds
      */
     int getConnTimeout();
 
     /**
-     * Property {@code org.codelibs.jcifs.smb.impl.client.sessionTimeout} (int, default 35000)
+     * Property {@code jcifs.client.sessionTimeout} (int, default 35000)
      *
      *
      * @return timeout for SMB sessions, in milliseconds
@@ -234,7 +237,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.responseTimeout} (int, default 30000)
+     * Property {@code jcifs.client.responseTimeout} (int, default 30000)
      *
      * @return timeout for SMB responses, in milliseconds
      */
@@ -242,7 +245,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.lport} (int)
+     * Property {@code jcifs.client.lport} (int)
      *
      * @return local port to use for outgoing connections
      */
@@ -250,7 +253,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.laddr} (string)
+     * Property {@code jcifs.client.laddr} (string)
      *
      * @return local address to use for outgoing connections
      */
@@ -266,7 +269,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.logonShare}
+     * Property {@code jcifs.client.logonShare}
      *
      * @return share to connect to during authentication, if unset connect to IPC$
      */
@@ -275,7 +278,7 @@ public interface Configuration {
     /**
      *
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.domain}
+     * Property {@code jcifs.client.domain}
      *
      * @return default credentials, domain name
      */
@@ -283,7 +286,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.username}
+     * Property {@code jcifs.client.username}
      *
      * @return default credentials, user name
      */
@@ -291,7 +294,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.password}
+     * Property {@code jcifs.client.password}
      *
      * @return default credentials, password
      */
@@ -320,7 +323,7 @@ public interface Configuration {
      * </table>
      *
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.lmCompatibility} (int, default 3)
+     * Property {@code jcifs.lmCompatibility} (int, default 3)
      *
      * @return lanman compatibility level, defaults to 3 i.e. NTLMv2 only
      */
@@ -328,14 +331,14 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.allowNTLMFallback} (boolean, default true)
+     * Property {@code jcifs.allowNTLMFallback} (boolean, default true)
      *
      * @return whether to allow fallback from kerberos to NTLM
      */
     boolean isAllowNTLMFallback();
 
     /**
-     * Property {@code org.codelibs.jcifs.smb.impl.useRawNTLM} (boolean, default false)
+     * Property {@code jcifs.useRawNTLM} (boolean, default false)
      *
      * @return whether to use raw NTLMSSP tokens instead of SPNEGO wrapped ones
      * @since 2.1
@@ -344,7 +347,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.disablePlainTextPasswords} (boolean, default true)
+     * Property {@code jcifs.client.disablePlainTextPasswords} (boolean, default true)
      *
      * @return whether the usage of plaintext passwords is prohibited, defaults to false
      */
@@ -410,7 +413,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.capabilities} (int)
+     * Property {@code jcifs.client.capabilities} (int)
      *
      * @return custom capabilities
      */
@@ -419,7 +422,7 @@ public interface Configuration {
     /**
      *
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.flags2} (int)
+     * Property {@code jcifs.client.flags2} (int)
      *
      * @return custom flags2
      */
@@ -427,7 +430,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.ssnLimit} (int, 250)
+     * Property {@code jcifs.client.ssnLimit} (int, 250)
      *
      * @return maximum number of sessions on a single connection
      */
@@ -457,7 +460,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.maxMpxCount} (int, default 10)
+     * Property {@code jcifs.client.maxMpxCount} (int, default 10)
      *
      * @return maximum count of concurrent commands to announce
      */
@@ -465,7 +468,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.signingPreferred} (boolean, default false)
+     * Property {@code jcifs.client.signingPreferred} (boolean, default false)
      *
      * @return whether to enable SMB signing (for everything), if available
      */
@@ -473,7 +476,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.ipcSigningEnforced} (boolean, default true)
+     * Property {@code jcifs.client.ipcSigningEnforced} (boolean, default true)
      *
      * @return whether to enforce SMB signing for IPC connections
      */
@@ -481,14 +484,14 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.signingEnforced} (boolean, default false)
+     * Property {@code jcifs.client.signingEnforced} (boolean, default false)
      *
      * @return whether to enforce SMB signing (for everything)
      */
     boolean isSigningEnforced();
 
     /**
-     * Property {@code org.codelibs.jcifs.smb.impl.client.encryptionEnabled} (boolean, default false)
+     * Property {@code jcifs.client.encryptionEnabled} (boolean, default false)
      *
      * This is an experimental option allowing to indicate support during protocol
      * negotiation, SMB encryption is not implemented yet.
@@ -500,7 +503,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.forceExtendedSecurity} (boolean, default false)
+     * Property {@code jcifs.client.forceExtendedSecurity} (boolean, default false)
      *
      * @return whether to force extended security usage
      */
@@ -573,7 +576,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.transaction_buf_size} (int, default 65535)
+     * Property {@code jcifs.client.transaction_buf_size} (int, default 65535)
      *
      * @return maximum data size for SMB transactions
      */
@@ -581,7 +584,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.maxBuffers} (int, default 16)
+     * Property {@code jcifs.maxBuffers} (int, default 16)
      *
      * @return number of buffers to keep in cache
      */
@@ -589,7 +592,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.listCount} (int, default 200)
+     * Property {@code jcifs.client.listCount} (int, default 200)
      *
      * @return maxmimum number of elements to request in a list request
      */
@@ -597,7 +600,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.listSize} (int, default 65435)
+     * Property {@code jcifs.client.listSize} (int, default 65435)
      *
      * @return maximum data size for list/info requests (known overhead is subtracted)
      */
@@ -606,7 +609,7 @@ public interface Configuration {
     /**
      *
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.attrExpirationPeriod} (int, 5000)
+     * Property {@code jcifs.client.attrExpirationPeriod} (int, 5000)
      *
      * @return timeout of file attribute cache
      */
@@ -615,7 +618,7 @@ public interface Configuration {
     /**
      *
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.ignoreCopyToException} (boolean, false)
+     * Property {@code jcifs.client.ignoreCopyToException} (boolean, false)
      *
      * @return whether to ignore exceptions that occur during file copy
      */
@@ -631,7 +634,7 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.notify_buf_size} (int, default 1024)
+     * Property {@code jcifs.client.notify_buf_size} (int, default 1024)
      *
      * @return the size of the requested server notify buffer
      */
@@ -640,14 +643,14 @@ public interface Configuration {
     /**
      *
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.maxRequestRetries} (int, default 2)
+     * Property {@code jcifs.client.maxRequestRetries} (int, default 2)
      *
      * @return retry SMB requests on failure up to n times
      */
     int getMaxRequestRetries();
 
     /**
-     * Property {@code org.codelibs.jcifs.smb.impl.client.strictResourceLifecycle} (bool, default false)
+     * Property {@code jcifs.client.strictResourceLifecycle} (bool, default false)
      *
      * If enabled, SmbFile instances starting with their first use will hold a reference to their tree.
      * This means that trees/sessions/connections won't be idle-disconnected even if there are no other active
@@ -689,7 +692,7 @@ public interface Configuration {
     /**
      *
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.disableSpnegoIntegrity} (boolean, false)
+     * Property {@code jcifs.client.disableSpnegoIntegrity} (boolean, false)
      *
      * @return whether to disable sending/verifying SPNEGO mechanismListMIC
      */
@@ -697,35 +700,35 @@ public interface Configuration {
 
     /**
      *
-     * Property {@code org.codelibs.jcifs.smb.impl.client.enforceSpnegoIntegrity} (boolean, false)
+     * Property {@code jcifs.client.enforceSpnegoIntegrity} (boolean, false)
      *
      * @return whether to enforce verifying SPNEGO mechanismListMIC
      */
     boolean isEnforceSpnegoIntegrity();
 
     /**
-     * Property {@code org.codelibs.jcifs.smb.impl.client.SendNTLMTargetName} (boolean, true)
+     * Property {@code jcifs.client.SendNTLMTargetName} (boolean, true)
      *
      * @return whether to send an AvTargetName with the NTLM exchange
      */
     boolean isSendNTLMTargetName();
 
     /**
-     * Property {@code org.codelibs.jcifs.smb.impl.client.guestPassword}, defaults to empty string
+     * Property {@code jcifs.client.guestPassword}, defaults to empty string
      *
      * @return password used when guest authentication is requested
      */
     String getGuestPassword();
 
     /**
-     * Property {@code org.codelibs.jcifs.smb.impl.client.guestUsername}, defaults to GUEST
+     * Property {@code jcifs.client.guestUsername}, defaults to GUEST
      *
      * @return username used when guest authentication is requested
      */
     String getGuestUsername();
 
     /**
-     * Property {@code org.codelibs.jcifs.smb.impl.client.allowGuestFallback}, defaults to false
+     * Property {@code jcifs.client.allowGuestFallback}, defaults to false
      *
      * @return whether to permit guest logins when user authentication is requested
      */

--- a/src/main/java/org/codelibs/jcifs/smb/SmbTransportPool.java
+++ b/src/main/java/org/codelibs/jcifs/smb/SmbTransportPool.java
@@ -135,7 +135,7 @@ public interface SmbTransportPool {
      * valid, the method will return without throwing an exception. See the
      * last <a href="../../../faq.html">FAQ</a> question.
      * <p>
-     * See also the <code>org.codelibs.jcifs.smb.impl.client.logonShare</code> property.
+     * See also the <code>jcifs.client.logonShare</code> property.
      *
      * @param dc the domain controller address
      * @param tc the CIFS context containing credentials
@@ -155,7 +155,7 @@ public interface SmbTransportPool {
      * valid, the method will return without throwing an exception. See the
      * last <a href="../../../faq.html">FAQ</a> question.
      * <p>
-     * See also the <code>org.codelibs.jcifs.smb.impl.client.logonShare</code> property.
+     * See also the <code>jcifs.client.logonShare</code> property.
      *
      * @param dc the domain controller address
      * @param port the port number

--- a/src/main/java/org/codelibs/jcifs/smb/config/PropertyConfiguration.java
+++ b/src/main/java/org/codelibs/jcifs/smb/config/PropertyConfiguration.java
@@ -18,6 +18,8 @@
 package org.codelibs.jcifs.smb.config;
 
 import java.net.InetAddress;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Properties;
 
 import org.codelibs.jcifs.smb.CIFSException;
@@ -25,6 +27,8 @@ import org.codelibs.jcifs.smb.Config;
 import org.codelibs.jcifs.smb.Configuration;
 import org.codelibs.jcifs.smb.DialectVersion;
 import org.codelibs.jcifs.smb.SmbConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Configuration implementation reading the classic org.codelibs.jcifs.smb settings from properties
@@ -33,6 +37,63 @@ import org.codelibs.jcifs.smb.SmbConstants;
  *
  */
 public final class PropertyConfiguration extends BaseConfiguration implements Configuration {
+
+    private static final Logger log = LoggerFactory.getLogger(PropertyConfiguration.class);
+
+    /** Property controlling whether share names keep the case they were given in. */
+    private static final String PRESERVE_SHARE_CASE = "jcifs.client.preserveShareCase";
+
+    /** Spelling of {@link #PRESERVE_SHARE_CASE} shipped in 3.0.1, still honoured. */
+    private static final String LEGACY_PRESERVE_SHARE_CASE = "jcifs.smb.client.preserveShareCase";
+
+    /**
+     * Property prefixes used before 3.0.0, mapped to the prefix that replaced them.
+     *
+     * Ordered longest first so that the most specific prefix wins.
+     */
+    private static final Map<String, String> LEGACY_PREFIXES = new LinkedHashMap<>();
+
+    static {
+        // 2.x legacy SMB1 stack
+        LEGACY_PREFIXES.put("jcifs.smb1.smb.client.", "jcifs.client.");
+        // names taken from the Configuration javadoc before it was corrected
+        LEGACY_PREFIXES.put("org.codelibs.jcifs.smb.impl.client.", "jcifs.client.");
+        LEGACY_PREFIXES.put("org.codelibs.jcifs.smb.impl.", "jcifs.");
+        // 2.x main stack
+        LEGACY_PREFIXES.put("jcifs.smb.client.", "jcifs.client.");
+        LEGACY_PREFIXES.put("jcifs.smb.", "jcifs.");
+    }
+
+    /**
+     * Warns about properties that carry a prefix this version no longer reads.
+     *
+     * Only the property names are logged, never their values, so that credentials
+     * carried by keys such as {@code jcifs.smb.client.password} are not exposed.
+     *
+     * @param p properties handed to this configuration
+     */
+    private static void warnLegacyPropertyNames(final Properties p) {
+        if (!log.isWarnEnabled()) {
+            return;
+        }
+        for (final String name : p.stringPropertyNames()) {
+            if (LEGACY_PRESERVE_SHARE_CASE.equals(name)) {
+                if (!p.containsKey(PRESERVE_SHARE_CASE)) {
+                    log.warn("Property '{}' is deprecated, use '{}' instead", name, PRESERVE_SHARE_CASE);
+                }
+                continue;
+            }
+            for (final Map.Entry<String, String> e : LEGACY_PREFIXES.entrySet()) {
+                if (name.startsWith(e.getKey())) {
+                    log.warn(
+                            "Property '{}' is not read by this version and has no effect. "
+                                    + "Configuration property prefixes changed in 3.0.0, use '{}' instead",
+                            name, e.getValue() + name.substring(e.getKey().length()));
+                    break;
+                }
+            }
+        }
+    }
 
     /**
      * Constructs a PropertyConfiguration from the provided properties.
@@ -43,6 +104,8 @@ public final class PropertyConfiguration extends BaseConfiguration implements Co
      *
      */
     public PropertyConfiguration(final Properties p) throws CIFSException {
+        warnLegacyPropertyNames(p);
+
         this.useBatching = Config.getBoolean(p, "jcifs.client.useBatching", false);
         this.useUnicode = Config.getBoolean(p, "jcifs.client.useUnicode", true);
         this.useLargeReadWrite = Config.getBoolean(p, "jcifs.client.useLargeReadWrite", true);
@@ -104,7 +167,7 @@ public final class PropertyConfiguration extends BaseConfiguration implements Co
         this.dfsTTL = Config.getLong(p, "jcifs.client.dfs.ttl", 300);
         this.dfsStrictView = Config.getBoolean(p, "jcifs.client.dfs.strictView", false);
         this.dfsConvertToFqdn = Config.getBoolean(p, "jcifs.client.dfs.convertToFQDN", false);
-        this.preserveShareCase = Config.getBoolean(p, "jcifs.smb.client.preserveShareCase", false);
+        this.preserveShareCase = Config.getBoolean(p, PRESERVE_SHARE_CASE, Config.getBoolean(p, LEGACY_PRESERVE_SHARE_CASE, false));
 
         this.logonShare = p.getProperty("jcifs.client.logonShare", null);
 

--- a/src/main/java/org/codelibs/jcifs/smb/http/NtlmHttpFilter.java
+++ b/src/main/java/org/codelibs/jcifs/smb/http/NtlmHttpFilter.java
@@ -329,7 +329,7 @@ public class NtlmHttpFilter implements Filter {
             if (!tf.hasDefaultCredentials()) {
                 trans.ensureConnected();
                 log.warn("""
-                        Default credentials (jcifs.smb.client.username/password)\
+                        Default credentials (jcifs.client.username/password)\
                          not specified. SMB signing may not work propertly.\
                           Skipping DC interrogation.""");
             } else {

--- a/src/main/java/org/codelibs/jcifs/smb/http/NtlmServlet.java
+++ b/src/main/java/org/codelibs/jcifs/smb/http/NtlmServlet.java
@@ -46,7 +46,7 @@ import jakarta.servlet.http.HttpSession;
  * to protect content with NTLM HTTP Authentication. Servlets that
  * extend this abstract base class may be authenticated against an SMB
  * server or domain controller depending on how the
- * {@code org.codelibs.jcifs.smb.impl.client.domain} or {@code org.codelibs.jcifs.smb.http.domainController}
+ * {@code jcifs.client.domain} or {@code org.codelibs.jcifs.smb.http.domainController}
  * properties are be specified. <b>With later containers the
  * {@code NtlmHttpFilter} should be used</b>. For custom NTLM HTTP Authentication schemes the {@code NtlmSsp} may be
  * used.

--- a/src/main/java/org/codelibs/jcifs/smb/impl/NtlmPasswordAuthentication.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/NtlmPasswordAuthentication.java
@@ -26,8 +26,8 @@ import org.codelibs.jcifs.smb.CIFSContext;
 
 /**
  * This class stores and encrypts NTLM user credentials. The default
- * credentials are retrieved from the {@code org.codelibs.jcifs.smb.impl.client.domain},
- * {@code org.codelibs.jcifs.smb.impl.client.username}, and {@code org.codelibs.jcifs.smb.impl.client.password}
+ * credentials are retrieved from the {@code jcifs.client.domain},
+ * {@code jcifs.client.username}, and {@code jcifs.client.password}
  * properties.
  * <p>
  * Read <a href="../../../authhandler.html">jCIFS Exceptions and
@@ -85,8 +85,8 @@ public class NtlmPasswordAuthentication extends NtlmPasswordAuthenticator {
     /**
      * Create an {@code NtlmPasswordAuthentication} object from a
      * domain, username, and password. Parameters that are {@code null}
-     * will be substituted with {@code org.codelibs.jcifs.smb.impl.client.domain},
-     * {@code org.codelibs.jcifs.smb.impl.client.username}, {@code org.codelibs.jcifs.smb.impl.client.password}
+     * will be substituted with {@code jcifs.client.domain},
+     * {@code jcifs.client.username}, {@code jcifs.client.password}
      * property values.
      *
      * @param tc

--- a/src/main/java/org/codelibs/jcifs/smb/impl/NtlmPasswordAuthenticator.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/NtlmPasswordAuthenticator.java
@@ -506,7 +506,7 @@ public class NtlmPasswordAuthenticator implements Principal, CredentialsInternal
              * all be cleaned up an normalized in JCIFS 2.x.
              */
             throw new SmbException(
-                    "NTLMv2 requires extended security (org.codelibs.jcifs.smb.impl.client.useExtendedSecurity must be true if org.codelibs.jcifs.smb.impl.lmCompatibility >= 3)");
+                    "NTLMv2 requires extended security (jcifs.client.useExtendedSecurity must be true if jcifs.lmCompatibility >= 3)");
         }
         return null;
     }

--- a/src/test/java/org/codelibs/jcifs/smb/config/PropertyConfigurationTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/config/PropertyConfigurationTest.java
@@ -309,7 +309,7 @@ class PropertyConfigurationTest extends BaseTest {
     void testPreserveShareCaseTrue() throws CIFSException {
         // Given
         Properties props = new Properties();
-        props.setProperty("jcifs.smb.client.preserveShareCase", "true");
+        props.setProperty("jcifs.client.preserveShareCase", "true");
 
         // When
         PropertyConfiguration testConfig = new PropertyConfiguration(props);
@@ -323,7 +323,7 @@ class PropertyConfigurationTest extends BaseTest {
     void testPreserveShareCaseFalse() throws CIFSException {
         // Given
         Properties props = new Properties();
-        props.setProperty("jcifs.smb.client.preserveShareCase", "false");
+        props.setProperty("jcifs.client.preserveShareCase", "false");
 
         // When
         PropertyConfiguration testConfig = new PropertyConfiguration(props);
@@ -344,5 +344,55 @@ class PropertyConfigurationTest extends BaseTest {
 
         // Then
         assertFalse(testConfig.isPreserveShareCase());
+    }
+
+    @Test
+    @DisplayName("Should still honour the deprecated preserveShareCase spelling")
+    void testPreserveShareCaseLegacyKey() throws CIFSException {
+        // Given
+        Properties props = new Properties();
+        props.setProperty("jcifs.smb.client.preserveShareCase", "true");
+
+        // When
+        PropertyConfiguration testConfig = new PropertyConfiguration(props);
+
+        // Then
+        assertTrue(testConfig.isPreserveShareCase());
+    }
+
+    @Test
+    @DisplayName("Should let the current preserveShareCase key win over the deprecated one")
+    void testPreserveShareCaseCurrentKeyWins() throws CIFSException {
+        // Given
+        Properties props = new Properties();
+        props.setProperty("jcifs.smb.client.preserveShareCase", "true");
+        props.setProperty("jcifs.client.preserveShareCase", "false");
+
+        // When
+        PropertyConfiguration testConfig = new PropertyConfiguration(props);
+
+        // Then
+        assertFalse(testConfig.isPreserveShareCase());
+    }
+
+    @Test
+    @DisplayName("Should ignore properties carrying a pre-3.0.0 prefix")
+    void testLegacyPrefixesAreIgnored() throws CIFSException {
+        // Given
+        Properties props = new Properties();
+        props.setProperty("jcifs.smb.client.connTimeout", "12345");
+        props.setProperty("jcifs.smb1.smb.client.soTimeout", "12345");
+        props.setProperty("org.codelibs.jcifs.smb.impl.client.responseTimeout", "12345");
+        props.setProperty("jcifs.smb.lmCompatibility", "0");
+
+        // When
+        PropertyConfiguration testConfig = new PropertyConfiguration(props);
+        PropertyConfiguration defaults = new PropertyConfiguration(new Properties());
+
+        // Then
+        assertEquals(defaults.getConnTimeout(), testConfig.getConnTimeout());
+        assertEquals(defaults.getSoTimeout(), testConfig.getSoTimeout());
+        assertEquals(defaults.getResponseTimeout(), testConfig.getResponseTimeout());
+        assertEquals(defaults.getLanManCompatibility(), testConfig.getLanManCompatibility());
     }
 }


### PR DESCRIPTION
Fixes #81.

## What is wrong

`#56` (`39a27d6`, released as `jcifs-3.0.0`) renamed the package **and** the configuration
keys, but the code and the documentation were rewritten with two different substitutions.
Three spellings have coexisted since:

| where | `minVersion` reads as | works? |
| --- | --- | --- |
| `PropertyConfiguration` (the code) | `jcifs.client.minVersion` | yes |
| `Configuration` javadoc | `org.codelibs.jcifs.smb.impl.client.minVersion` | no |
| `README.md`, `CLAUDE.md`, tests | `jcifs.smb.client.minVersion` | no |

199 occurrences of the working spelling, 119 of the javadoc one, 62 of the README one.
The reporter tried the two documented forms in order and only found the right key by
reading `PropertyConfiguration.java`.

Two things make this worse than a typo:

* **The rename was never documented.** The README migration guide mentions the package
  move but not the property move, and there are no GitHub releases for this repository.
* **Old keys are silently ignored.** `Config.getX` is a plain `Properties#getProperty`
  with a default, so a 2.x configuration comes up entirely on defaults — including
  `signingEnforced`, `encryptionEnabled` and `disableSMB1`.

`preserveShareCase` is the one place where the code itself is inconsistent: `#63`
(`3.0.1`) added it as `jcifs.smb.client.preserveShareCase`, the old prefix.

## What this changes

**Documentation.** Every documented property name now matches what is read, across
`Configuration`, `Config`, `SmbTransportPool`, `NtlmPasswordAuthentication`,
`NtlmPasswordAuthenticator`, `NtlmServlet`, `NtlmHttpFilter`, `README.md`, `CLAUDE.md`
and `docs/`. The README migration guide gains a table of the 2.x to 3.x prefix mapping.

Two examples in the README named properties that do not exist under any prefix and are
removed:

* `jcifs.smb.client.enableSMB2Signing` — signing is `signingPreferred` / `signingEnforced`.
* `jcifs.util.loglevel` — only the legacy `smb1` stack reads it; the modern stack logs
  through SLF4J.

**A warning instead of silence.** `PropertyConfiguration` now logs a WARN for every
property it is handed under a prefix this version no longer reads, naming the
replacement:

```
WARN PropertyConfiguration - Property 'jcifs.smb.client.connTimeout' is not read by this
version and has no effect. Configuration property prefixes changed in 3.0.0, use
'jcifs.client.connTimeout' instead
```

It covers `jcifs.smb.client.`, `jcifs.smb.`, `jcifs.smb1.smb.client.` and the
`org.codelibs.jcifs.smb.impl.` spelling the old javadoc suggested, so both wrong turns
in the issue now produce a diagnostic. Only property *names* are logged, never values,
so a key such as `jcifs.smb.client.password` does not put a password in the log.

**`preserveShareCase` normalised.** It is now read as `jcifs.client.preserveShareCase`.
The `jcifs.smb.client.preserveShareCase` spelling shipped in 3.0.1 is still honoured so
that existing configurations keep working, and warns as deprecated.

## Deliberately not in this PR

* **No aliasing of old keys.** Accepting `jcifs.smb.client.*` as a silent alias would keep
  two namespaces alive forever, and `jcifs.smb.client.X` and `jcifs.smb1.smb.client.X`
  both map onto `jcifs.client.X`, so a configuration setting both would need a conflict
  rule. A warning that names the replacement seemed the better trade. Happy to revisit.

* **The test suite still uses the old prefix**, and that is hiding real behaviour.
  `PropertyConfigurationEdgeCaseTest` sets 31 properties under `jcifs.smb.client.` and
  therefore tests defaults, not the values it thinks it sets. Correcting only the prefix
  in that file turns 54/54 green into 4 failures and 3 errors:

  * `minVersion=INVALID` throws `IllegalArgumentException: No enum constant` out of the
    constructor (which declares `throws CIFSException`); the test asserts it falls back
    to a default.
  * Version names are not case-insensitive — `smb1` throws; the test asserts they are.
  * Negative `connTimeout`, `ssnLimit`, `rcv_buf_size` and `dfs.ttl` are accepted as-is,
    with no validation or clamping; the tests assert a fallback to defaults.

  None of that is a regression from `#56` — it is inherited behaviour that the wrong
  prefix has been masking. Deciding whether to validate the input or to re-baseline the
  expectations is a separate call, so I left the file alone rather than pick one here.
  With this PR the vacuous cases at least announce themselves in the test log.

* `Configuration#getLocalAddr()` documents `jcifs.client.laddr`, but
  `PropertyConfiguration` never reads it — only `Config.getLocalHost(Properties)` does,
  and nothing in `src/main` calls that. The prefix is corrected here; the property is
  still not honoured.

## Verification

* `mvn test` — 8569 tests, 0 failures, 0 errors.
* `mvn -B package` — BUILD SUCCESS (same command as CI).
* `mvn formatter:validate` — clean.
* New tests in `PropertyConfigurationTest` pin the three behaviours: the deprecated
  `preserveShareCase` key is still honoured, the current key wins when both are set, and
  properties under a legacy prefix leave the configuration at its defaults.
