### PR TITLE
fix: resolve tree referrals on path element boundaries, most specific first

### DIFF
--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbTreeImpl.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbTreeImpl.java
@@ -327,21 +327,40 @@ class SmbTreeImpl implements SmbTreeInternal {
     }
 
     /**
+     * Looks up the referral covering the given UNC path.
+     *
+     * The keys of this map are UNC paths, so a match has to end on a path element boundary: a referral for
+     * {@code \\reports} covers {@code \\reports\\q1.xlsx} but not {@code \\reports2024\\q1.xlsx}. Candidates are tried
+     * from the most specific one up, so a referral for a nested link wins over the one for its parent, and the
+     * whole tree referral - keyed by a lone separator - is the last candidate. This mirrors how
+     * {@code DfsImpl} walks up its own link cache.
+     *
      * @param path
-     * @return the treeReferral
+     *            UNC path to look up
+     * @return the treeReferral, or {@code null} if no referral covers the path
      */
     public DfsReferralData getTreeReferral(final String path) {
-        if (path != null) {
-            log.debug("Finding tree referral for path [{}]", path);
-            for (final String link : this.treeReferrals.keySet()) {
-                if (path.startsWith(link)) {
-                    final DfsReferralData referral = this.treeReferrals.get(link);
-                    log.debug("Found tree referral [{}] for path [{}]", referral, path);
-                    return this.treeReferrals.get(link);
-                }
-            }
-            log.debug("No tree referral found for path [{}]", path);
+        if (path == null || path.isEmpty()) {
+            return null;
         }
+        log.debug("Finding tree referral for path [{}]", path);
+        for (int end = path.length(); end > 0;) {
+            final DfsReferralData referral = this.treeReferrals.get(path.substring(0, end));
+            if (referral != null) {
+                log.debug("Found tree referral [{}] for path [{}]", referral, path);
+                return referral;
+            }
+            if (end == 1) {
+                break;
+            }
+            final int sep = path.lastIndexOf('\\', end - 1);
+            if (sep < 0) {
+                break;
+            }
+            // a separator at the start denotes the whole tree referral, which is the last candidate
+            end = sep == 0 ? 1 : sep;
+        }
+        log.debug("No tree referral found for path [{}]", path);
         return null;
     }
 

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbTreeImplTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbTreeImplTest.java
@@ -3,6 +3,7 @@ package org.codelibs.jcifs.smb.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -342,22 +343,26 @@ class SmbTreeImplTest {
     void testGetTreeReferral_prefixMatching() {
         SmbTreeImpl tree = new SmbTreeImpl(session, "SHARE", "A:");
 
-        // Create mock referral
+        // Create mock referral. The keys of this cache are UNC paths, so the separator is a backslash.
         DfsReferralData referral = mock(DfsReferralData.class);
-        when(referral.getLink()).thenReturn("/root/dir");
+        when(referral.getLink()).thenReturn("\\root\\dir");
 
-        tree.setTreeReferral(referral, "/root/dir");
+        tree.setTreeReferral(referral, "\\root\\dir");
 
         // Exact match should work
-        assertNotNull(tree.getTreeReferral("/root/dir"));
+        assertNotNull(tree.getTreeReferral("\\root\\dir"));
 
-        // Prefix match should work (path starts with registered path)
-        assertNotNull(tree.getTreeReferral("/root/dir/subdir"));
-        assertNotNull(tree.getTreeReferral("/root/dir/subdir/file.txt"));
+        // Paths below the referral should work
+        assertNotNull(tree.getTreeReferral("\\root\\dir\\subdir"));
+        assertNotNull(tree.getTreeReferral("\\root\\dir\\subdir\\file.txt"));
 
         // Non-matching prefix should return null
-        assertNull(tree.getTreeReferral("/other/path"));
-        assertNull(tree.getTreeReferral("/root")); // Partial match of path component
+        assertNull(tree.getTreeReferral("\\other\\path"));
+        assertNull(tree.getTreeReferral("\\root")); // Partial match of path component
+
+        // A sibling that merely shares a name prefix is not below the referral
+        assertNull(tree.getTreeReferral("\\root\\dir2"));
+        assertNull(tree.getTreeReferral("\\root\\dir2024\\q1.xlsx"));
     }
 
     /**
@@ -369,21 +374,51 @@ class SmbTreeImplTest {
 
         // Create mock referrals with overlapping paths
         DfsReferralData referral1 = mock(DfsReferralData.class);
-        when(referral1.getLink()).thenReturn("/root");
+        when(referral1.getLink()).thenReturn("\\root");
         when(referral1.getServer()).thenReturn("server1");
 
         DfsReferralData referral2 = mock(DfsReferralData.class);
-        when(referral2.getLink()).thenReturn("/root/subdir");
+        when(referral2.getLink()).thenReturn("\\root\\subdir");
         when(referral2.getServer()).thenReturn("server2");
 
-        tree.setTreeReferral(referral1, "/root");
-        tree.setTreeReferral(referral2, "/root/subdir");
+        tree.setTreeReferral(referral1, "\\root");
+        tree.setTreeReferral(referral2, "\\root\\subdir");
 
-        // When multiple prefixes match, should return one of them
-        // (The implementation returns the first match found)
-        DfsReferralData result = tree.getTreeReferral("/root/subdir/file.txt");
-        assertNotNull(result);
-        assertTrue(result == referral1 || result == referral2);
+        // The most specific referral covering the path wins
+        assertSame(referral2, tree.getTreeReferral("\\root\\subdir\\file.txt"));
+        assertSame(referral2, tree.getTreeReferral("\\root\\subdir"));
+
+        // Paths that the nested referral does not cover fall back to its parent
+        assertSame(referral1, tree.getTreeReferral("\\root\\other\\file.txt"));
+        assertSame(referral1, tree.getTreeReferral("\\root"));
+
+        // A sibling of the nested link is not covered by it
+        assertSame(referral1, tree.getTreeReferral("\\root\\subdir2\\file.txt"));
+    }
+
+    /**
+     * The referral for the whole tree is keyed by a lone separator and is the last candidate.
+     */
+    @Test
+    void testGetTreeReferral_wholeTreeReferralIsFallback() {
+        SmbTreeImpl tree = new SmbTreeImpl(session, "SHARE", "A:");
+
+        DfsReferralData wholeTree = mock(DfsReferralData.class);
+        when(wholeTree.getLink()).thenReturn("\\");
+
+        DfsReferralData link = mock(DfsReferralData.class);
+        when(link.getLink()).thenReturn("\\link");
+
+        tree.setTreeReferral(wholeTree, null);
+        tree.setTreeReferral(link, "\\link");
+
+        // The more specific link wins where it applies
+        assertSame(link, tree.getTreeReferral("\\link\\file.txt"));
+
+        // Everything else falls back to the whole tree referral
+        assertSame(wholeTree, tree.getTreeReferral("\\other\\file.txt"));
+        assertSame(wholeTree, tree.getTreeReferral("\\linked\\file.txt"));
+        assertSame(wholeTree, tree.getTreeReferral("\\"));
     }
 
     /**


### PR DESCRIPTION
Follow-up to #86: the same unbounded prefix match, in the DFS tree referral cache.

## Problem

`SmbTreeImpl.getTreeReferral()` scanned the key set and returned the first key the requested path started with:

```java
for (final String link : this.treeReferrals.keySet()) {
    if (path.startsWith(link)) {
        final DfsReferralData referral = this.treeReferrals.get(link);
        log.debug("Found tree referral [{}] for path [{}]", referral, path);
        return this.treeReferrals.get(link);
    }
}
```

The keys are UNC paths, written by `setTreeReferral()` from `DfsReferralData.getLink()` and from `SmbResourceLocator.getUNCPath()`. Two things go wrong.

### 1. The match does not have to end on a path element boundary

A referral cached for the DFS link `\reports` is returned for `\reports2024\q1.xlsx`.

`SmbTreeConnection.resolveDfs0()` passes the result to `SmbResourceLocatorImpl.handleDFSReferral()`, which strips `getPathConsumed()` characters off the request path:

```java
String dunc = oldUncPath.substring(pathConsumed);
...
if (dunc.charAt(0) != '\\') {
    log.warn("No slash at start of remaining DFS path " + dunc);
}
```

With `pathConsumed` = 8 (`\reports`) applied to `\reports2024\q1.xlsx` the remainder is `2024\q1.xlsx` — the warning above fires and the request is issued against the wrong location on the referral target. The operation does not fail; it silently addresses a different path.

### 2. First match, not most specific match

`ConcurrentHashMap.keySet()` has no meaningful order, so when one cached link sits below another — nested DFS links resolving into the same target share, or any link under the whole tree referral — which one is returned depends on hash order. A nested link can silently resolve through its parent's referral, with the parent's `pathConsumed`.

Observed on the current code, with the referral for `\root` and for `\root\subdir` both cached:

| lookup | before | expected |
| --- | --- | --- |
| `\reports2024\q1.xlsx` (only `\reports` cached) | `\reports` referral | none |
| `\root\subdir\file.txt` | `\root` referral | `\root\subdir` referral |
| `\linked\file.txt` (with `\link` cached) | `\link` referral | whole tree referral |

## Fix

Walk up the requested path one element at a time and look each candidate up directly, which is what `DfsImpl.getLinkReferral()` already does for its own link cache:

```java
for (int end = path.length(); end > 0;) {
    final DfsReferralData referral = this.treeReferrals.get(path.substring(0, end));
    if (referral != null) {
        return referral;
    }
    if (end == 1) {
        break;
    }
    final int sep = path.lastIndexOf('\\', end - 1);
    if (sep < 0) {
        break;
    }
    // a separator at the start denotes the whole tree referral, which is the last candidate
    end = sep == 0 ? 1 : sep;
}
```

The most specific referral covering the path wins, and the whole tree referral — keyed by a lone separator, written when a share root is reached through a referral — stays reachable as the last candidate. As a side effect the lookup is O(path depth) exact lookups instead of an O(n) scan of the whole map, and it no longer reads the matching entry twice.

## Tests

`testGetTreeReferral_prefixMatching` and `testGetTreeReferral_multiplePrefixMatches` used POSIX separators for values that are always UNC paths (`getUNCPath()` maps `/` to `\`), so the boundary they described could not be the one that exists in production; their fixtures now use backslashes. Every assertion they already made is kept, plus the sibling-prefix cases.

`testGetTreeReferral_multiplePrefixMatches` previously accepted either referral (`assertTrue(result == referral1 || result == referral2)`); it now asserts the specific one. `testGetTreeReferral_wholeTreeReferralIsFallback` is new and covers the lone-separator entry.

All three test methods fail against the current implementation.

Full suite: 8583 tests, 0 failures.

## Not addressed here

`treeReferrals` has further weaknesses that are not lookup correctness and would change DFS behaviour, so they are left out of this change: entries never expire (`DfsReferralData.getExpiration()` is not consulted, unlike `DfsImpl.CacheEntry`), and nothing removes them on `treeDisconnect()` / reconnect, so a pooled tree can serve referrals from an older topology and the map grows for the lifetime of the session.
