### PR TITLE
fix: keep the path separator when resolving a child resource

### DIFF
--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbFile.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbFile.java
@@ -419,6 +419,9 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
      * as a file or directory. The second parameter is a relative path from
      * the <code>parent SmbFile</code>. See the description above for examples
      * of using the second <code>name</code> parameter.
+     * <p>
+     * The <code>context</code> is always treated as the directory the name is resolved in, even if its URL does not
+     * carry the trailing slash that a directory URL is required to have.
      *
      * @param context
      *            A base <code>SmbFile</code> that serves as the parent resource
@@ -432,7 +435,7 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
      */
     public SmbFile(final SmbResource context, final String name) throws MalformedURLException, UnknownHostException {
         this(isWorkgroup(context) ? new URL(null, "smb://" + checkName(name), context.getContext().getUrlHandler())
-                : new URL(context.getLocator().getURL(), encodeRelativePath(checkName(name)), context.getContext().getUrlHandler()),
+                : new URL(getBaseURL(context), encodeRelativePath(checkName(name)), context.getContext().getUrlHandler()),
                 context.getContext());
         setContext(context, name);
     }
@@ -470,8 +473,7 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
     SmbFile(final SmbResource context, final String name, final boolean loadedAttributes, final int type, final int attributes,
             final long createTime, final long lastModified, final long lastAccess, final long size) throws MalformedURLException {
         this(isWorkgroup(context) ? new URL(null, "smb://" + checkName(name) + "/", context.getContext().getUrlHandler())
-                : new URL(context.getLocator().getURL(),
-                        encodeRelativePath(checkName(name)) + ((attributes & ATTR_DIRECTORY) > 0 ? "/" : "")),
+                : new URL(getBaseURL(context), encodeRelativePath(checkName(name)) + ((attributes & ATTR_DIRECTORY) > 0 ? "/" : "")),
                 context.getContext());
 
         if (!isWorkgroup(context)) {
@@ -493,6 +495,29 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
         if (loadedAttributes) {
             this.attrExpiration = this.sizeExpiration = System.currentTimeMillis() + getContext().getConfig().getAttributeCacheTimeout();
         }
+    }
+
+    /**
+     * Returns the URL a relative child name has to be resolved against.
+     *
+     * <p>
+     * Relative resolution as implemented by {@link URL} replaces the last path segment when the base does not end with a
+     * slash. A parent resource always has to be treated as a directory here, otherwise the child would silently be
+     * resolved as a sibling and diverge from the UNC path built by
+     * {@link SmbResourceLocatorImpl#resolveInContext(org.codelibs.jcifs.smb.SmbResourceLocator, String)}.
+     * </p>
+     *
+     * @param context the parent resource
+     * @return the parent URL in directory form
+     * @throws MalformedURLException if the directory form of the parent URL cannot be constructed
+     */
+    private static URL getBaseURL(final SmbResource context) throws MalformedURLException {
+        final URL u = context.getLocator().getURL();
+        final String path = u.getPath();
+        if (path == null || path.isEmpty() || path.charAt(path.length() - 1) == '/') {
+            return u;
+        }
+        return new URL(u, path + "/", context.getContext().getUrlHandler());
     }
 
     private static String encodeRelativePath(String name) {

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbResourceLocatorImpl.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbResourceLocatorImpl.java
@@ -111,6 +111,7 @@ class SmbResourceLocatorImpl implements SmbResourceLocatorInternal, Cloneable {
         if (shr != null) {
             this.dfsReferral = context.getDfsReferral();
         }
+        final boolean absolute = name.startsWith("/");
         final int last = name.length() - 1;
         boolean trailingSlash = false;
         if (last >= 0 && name.charAt(last) == '/') {
@@ -148,14 +149,14 @@ class SmbResourceLocatorImpl implements SmbResourceLocatorInternal, Cloneable {
                 }
             }
         } else {
+            // The context is the parent directory the name is resolved against, so both prefixes have to be
+            // terminated properly. Otherwise the name is glued to the last segment of the context path (issue #83).
+            // Absolute names carry their own leading separator.
             final String uncPath = context.getUNCPath();
-            if (uncPath.equals("\\")) {
-                // context share != null, so the remainder is path
-                this.unc = '\\' + name.replace('/', '\\') + (trailingSlash ? "\\" : "");
-            } else {
-                this.unc = uncPath + name.replace('/', '\\') + (trailingSlash ? "\\" : "");
-            }
-            this.canon = context.getURLPath() + name + (trailingSlash ? "/" : "");
+            this.unc =
+                    (absolute || uncPath.endsWith("\\") ? uncPath : uncPath + '\\') + name.replace('/', '\\') + (trailingSlash ? "\\" : "");
+            final String urlPath = context.getURLPath();
+            this.canon = (absolute || urlPath.endsWith("/") ? urlPath : urlPath + '/') + name + (trailingSlash ? "/" : "");
             this.share = shr;
         }
     }

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbFileResolveChildTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbFileResolveChildTest.java
@@ -1,0 +1,112 @@
+/*
+ * © 2025 CodeLibs, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package org.codelibs.jcifs.smb.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.SmbConstants;
+import org.codelibs.jcifs.smb.context.SingletonContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for issue #83: a child resolved below a resource that does not carry a trailing slash was glued to
+ * the last segment of the parent path.
+ */
+class SmbFileResolveChildTest {
+
+    private static CIFSContext context() {
+        return SingletonContext.getInstance();
+    }
+
+    @Test
+    @DisplayName("resolve() below a directory without a trailing slash yields a child, not a glued sibling")
+    void testResolveChildOfDirectoryWithoutTrailingSlash() throws Exception {
+        try (SmbFile root = new SmbFile("smb://host/testshare/", context());
+                SmbFile nested = (SmbFile) root.resolve("nested");
+                SmbFile child = (SmbFile) nested.resolve("a.txt")) {
+            assertEquals("/testshare/nested", nested.getLocator().getURLPath());
+
+            assertEquals("a.txt", child.getName());
+            assertEquals("/testshare/nested/a.txt", child.getLocator().getURLPath());
+            assertEquals("\\nested\\a.txt", child.getLocator().getUNCPath());
+            assertEquals("smb://host/testshare/nested/a.txt", child.getURL().toString());
+            assertEquals("smb://host/testshare/nested/a.txt", child.getCanonicalPath());
+        }
+    }
+
+    @Test
+    @DisplayName("enumerated children of a resource resolved without a trailing slash keep their own name")
+    void testEnumeratedChildOfDirectoryWithoutTrailingSlash() throws Exception {
+        try (SmbFile root = new SmbFile("smb://host/testshare/", context()); SmbFile nested = (SmbFile) root.resolve("nested")) {
+            // this is what DirFileEntryAdapterIterator#adapt does for every directory entry
+            try (SmbFile file = new SmbFile(nested, "a.txt", true, SmbConstants.TYPE_FILESYSTEM, 0, 0L, 0L, 0L, 0L);
+                    SmbFile dir = new SmbFile(nested, "level2", true, SmbConstants.TYPE_FILESYSTEM, SmbConstants.ATTR_DIRECTORY, 0L, 0L, 0L,
+                            0L)) {
+                assertEquals("a.txt", file.getName());
+                assertEquals("\\nested\\a.txt", file.getLocator().getUNCPath());
+                assertEquals("smb://host/testshare/nested/a.txt", file.getURL().toString());
+
+                assertEquals("level2/", dir.getName());
+                assertEquals("\\nested\\level2\\", dir.getLocator().getUNCPath());
+                assertEquals("smb://host/testshare/nested/level2/", dir.getURL().toString());
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("a resolve() chain below a share root keeps every segment")
+    void testResolveChainKeepsEverySegment() throws Exception {
+        try (SmbFile root = new SmbFile("smb://host/testshare/", context());
+                SmbFile l1 = (SmbFile) root.resolve("nested");
+                SmbFile l2 = (SmbFile) l1.resolve("level2");
+                SmbFile l3 = (SmbFile) l2.resolve("level3")) {
+            assertEquals("level3", l3.getName());
+            assertEquals("/testshare/nested/level2/level3", l3.getLocator().getURLPath());
+            assertEquals("\\nested\\level2\\level3", l3.getLocator().getUNCPath());
+            assertEquals("smb://host/testshare/nested/level2/level3", l3.getURL().toString());
+        }
+    }
+
+    @Test
+    @DisplayName("resolving below a share URL without a trailing slash keeps the share")
+    void testResolveBelowShareWithoutTrailingSlash() throws Exception {
+        try (SmbFile share = new SmbFile("smb://host/testshare", context()); SmbFile child = (SmbFile) share.resolve("a.txt")) {
+            assertEquals("a.txt", child.getName());
+            assertEquals("testshare", child.getLocator().getShare());
+            assertEquals("/testshare/a.txt", child.getLocator().getURLPath());
+            assertEquals("\\a.txt", child.getLocator().getUNCPath());
+            assertEquals("smb://host/testshare/a.txt", child.getURL().toString());
+        }
+    }
+
+    @Test
+    @DisplayName("an explicit trailing slash keeps working unchanged")
+    void testResolveWithTrailingSlashUnchanged() throws Exception {
+        try (SmbFile root = new SmbFile("smb://host/testshare/", context());
+                SmbFile nested = (SmbFile) root.resolve("nested/");
+                SmbFile child = (SmbFile) nested.resolve("a.txt")) {
+            assertEquals("nested/", nested.getName());
+            assertEquals("a.txt", child.getName());
+            assertEquals("/testshare/nested/a.txt", child.getLocator().getURLPath());
+            assertEquals("\\nested\\a.txt", child.getLocator().getUNCPath());
+            assertEquals("smb://host/testshare/nested/a.txt", child.getURL().toString());
+        }
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbResourceLocatorImplTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbResourceLocatorImplTest.java
@@ -445,4 +445,56 @@ class SmbResourceLocatorImplTest {
         assertEquals("\\sub\\child", base2.getUNCPath());
         assertEquals("share", base2.getShare());
     }
+
+    @Test
+    @DisplayName("resolveInContext separates the name from a context path without a trailing slash (issue #83)")
+    void testResolveInContextWithoutTrailingSlash() {
+        SmbResourceLocatorImpl base = locator("smb://server/share/nested/a.txt");
+        SmbResourceLocator context = mock(SmbResourceLocator.class);
+        when(context.getShare()).thenReturn("share");
+        when(context.getDfsReferral()).thenReturn(null);
+        // a resource obtained through resolve("nested") carries no trailing slash
+        when(context.getUNCPath()).thenReturn("\\nested");
+        when(context.getURLPath()).thenReturn("/share/nested");
+        when(context.getServer()).thenReturn("server");
+
+        base.resolveInContext(context, "a.txt");
+        assertEquals("/share/nested/a.txt", base.getURLPath());
+        assertEquals("\\nested\\a.txt", base.getUNCPath());
+        assertEquals("a.txt", base.getName());
+        assertEquals("share", base.getShare());
+    }
+
+    @Test
+    @DisplayName("resolveInContext keeps a share root context without a trailing slash separated")
+    void testResolveInContextShareRootWithoutTrailingSlash() {
+        SmbResourceLocatorImpl base = locator("smb://server/share/dir");
+        SmbResourceLocator context = mock(SmbResourceLocator.class);
+        when(context.getShare()).thenReturn("share");
+        when(context.getDfsReferral()).thenReturn(null);
+        when(context.getUNCPath()).thenReturn("\\");
+        when(context.getURLPath()).thenReturn("/share");
+        when(context.getServer()).thenReturn("server");
+
+        base.resolveInContext(context, "dir/");
+        assertEquals("/share/dir/", base.getURLPath());
+        assertEquals("\\dir\\", base.getUNCPath());
+        assertEquals("share", base.getShare());
+    }
+
+    @Test
+    @DisplayName("resolveInContext does not duplicate the separator of an absolute name")
+    void testResolveInContextAbsoluteName() {
+        SmbResourceLocatorImpl base = locator("smb://server/share/zig/zag");
+        SmbResourceLocator context = mock(SmbResourceLocator.class);
+        when(context.getShare()).thenReturn("share");
+        when(context.getDfsReferral()).thenReturn(null);
+        when(context.getUNCPath()).thenReturn("\\zig\\zag");
+        when(context.getURLPath()).thenReturn("/share/zig/zag");
+        when(context.getServer()).thenReturn("server");
+
+        base.resolveInContext(context, "/");
+        assertEquals("/share/zig/zag/", base.getURLPath());
+        assertEquals("\\zig\\zag\\", base.getUNCPath());
+    }
 }


### PR DESCRIPTION
Fixes #83.

## Problem

`SmbResourceLocatorImpl.resolveInContext()` built the canonical URL path and the UNC path of a child by plain string concatenation:

```java
this.unc   = uncPath + name.replace('/', '\\') + ...;
this.canon = context.getURLPath() + name + ...;
```

This relies on the invariant stated in the class javadoc ("a directory resource must have a trailing slash/backslash for both URL and UNC path at all times"). `SmbResource.resolve(name)` cannot uphold it: it has no way of knowing whether `name` denotes a directory, so `root.resolve("nested")` yields `canon=/share/nested`, `unc=\nested`, and the next child is glued onto the last segment:

```
root.resolve("nested").children()  ->  nesteda.txt, nestedb.txt
```

The child is not merely mislabelled. Its UNC path is `\nesteda.txt`, which does not exist on the server, so `exists()` returns false and every read, write or attribute lookup on it fails.

The URL was wrong too, but differently: `java.net.URL` relative resolution replaces the last segment of a base that does not end with a slash, so the same object reported `getURL()` / `getPath()` as `smb://host/share/a.txt` while `getName()` / `getUncPath()` / `getCanonicalPath()` reported the glued form. Any code that logs one and requests the other saw two different wrong paths.

The same happened for a parent obtained from a share URL without a trailing slash (`smb://host/share` + `a.txt` -> `/sharea.txt`), and after a DFS referral, which can strip the trailing backslash from the parent UNC path.

Note that the session dependency described in the issue is not part of the cause. The defect is pure URL/path string math at construction time and reproduces on a brand new context whose very first operation is the resolve chain.

## Fix

1. `resolveInContext()` terminates both prefixes before appending the name. Names that are already absolute carry their own leading separator and are left untouched, so the documented behaviour of `smb://host/share/zig/zag` + `/` is preserved. The former special case for a `\` context UNC path is subsumed by this.
2. The two `SmbFile(SmbResource context, String name, ...)` constructors resolve the child URL against the directory form of the parent URL, so URL, canonical path and UNC path agree again.

## Verification

- New regression tests: `SmbFileResolveChildTest` (5 cases through the public API, including the enumeration path used by `children()`) and three additional cases in `SmbResourceLocatorImplTest`. Six of them fail on the current `main`.
- Whole suite green, including the Samba container based `SmbFileIntegrationTest`.
- Reproduced and confirmed against a live Samba server (SMB2/SMB3) with the layout from the issue:

```
before: nested entries: [nesteda.txt, nestedb.txt]   resolve("a.txt") exists=false
after : nested entries: [a.txt, b.txt]               resolve("a.txt") exists=true
```

## Behaviour change

`new SmbFile(context, name)` with a context URL that does not end with a slash now returns a child instead of a sibling. Such URLs are documented as illegal for directories, and the previous result was internally inconsistent in any case (sibling URL, glued UNC path), so no working usage relied on it.

## Not covered

`resolve("../x")`, `resolve("./x")` and absolute names still leave dot segments unnormalised in the canonical and UNC paths while the URL side is normalised by `java.net.URL`. That divergence predates this change and is untouched here; deriving the canonical path from the URL instead is not an option because `encodeRelativePath()` rewrites `?` to `%3f` and trailing blanks to `%20`, which must not leak into a name or a UNC path.
