### PR TITLE
fix: compare strings by value when reading jcifs.maskSecretValue

### DIFF
--- a/src/main/java/org/codelibs/jcifs/smb/util/Strings.java
+++ b/src/main/java/org/codelibs/jcifs/smb/util/Strings.java
@@ -38,7 +38,7 @@ public final class Strings {
     private static final Charset UNI_ENCODING = Charset.forName("UTF-16LE");
     private static final Charset ASCII_ENCODING = Charset.forName("US-ASCII");
 
-    private static final boolean MASK_SECRET_VALUE = System.getProperty("jcifs.maskSecretValue", "true") == "true";
+    private static final boolean MASK_SECRET_VALUE = Boolean.parseBoolean(System.getProperty("jcifs.maskSecretValue", "true"));
     private static final String SECRET_PATTERN = "^(smb.*:).*(@.*)$";
     private static final String SECRET_MASK_REPLACE = "$1******$2";
 

--- a/src/main/java/org/codelibs/jcifs/smb1/Dfs.java
+++ b/src/main/java/org/codelibs/jcifs/smb1/Dfs.java
@@ -77,7 +77,7 @@ public class Dfs {
      * @throws SmbAuthException if authentication fails
      */
     public HashMap getTrustedDomains(final NtlmPasswordAuthentication auth) throws SmbAuthException {
-        if (DISABLED || auth.domain == "?") {
+        if (DISABLED || "?".equals(auth.domain)) {
             return null;
         }
 


### PR DESCRIPTION
## The bug

`Strings` decides whether to mask credentials in SMB URLs with a **reference**
comparison:

```java
private static final boolean MASK_SECRET_VALUE =
        System.getProperty("jcifs.maskSecretValue", "true") == "true";
```

When the property is absent, `getProperty` hands back the interned literal supplied as
the default, so `==` is true and masking is on — correct by accident. A value that
arrives any other way is a different `String` object:

```
$ java MaskProbe.java                                 # property absent
absent           -> true
set to "true"    -> true                              # System.setProperty with a literal
  equals variant -> true
set to "false"   -> false

$ java -Djcifs.maskSecretValue=true MaskProbe2.java
-D true          -> false                             # <-- masking OFF
```

So `-Djcifs.maskSecretValue=true`, the one spelling an operator would reach for to
*assert* that masking stays on, silently turns it off. `SmbFile#toString()` calls
`Strings.maskSecretValue(url.toString())`, so with masking off a password carried in
an SMB URL userinfo goes verbatim into every log line and exception message that prints
an `SmbFile` — including `SmbException` messages that reach stack traces. Both the modern and the legacy `smb1` `SmbFile` route through it.

`false` still worked, so the flag looked functional: the only broken input is the one
that means "yes".

## The fix

Read the flag with `Boolean.parseBoolean`. Absent stays `true`, `"false"` stays
`false`, and `"true"` now means true however it was supplied.

## Same defect, second site

`Dfs#getTrustedDomains` in the legacy stack tested its "no domain" sentinel the same
way:

```java
if (DISABLED || auth.domain == "?") {
```

This one is currently harmless: both writers of that field pass the interned literal
(`Config.getProperty("jcifs.client.domain", "?")` falling through to its default, and
the `GUEST` constant), so the sentinel matches. It is one runtime-built `"?"` away from
skipping the guard and doing a trusted-domain lookup against a bogus domain, and
`NtlmPasswordAuthentication` already compares the same sentinel with `equals`. Changed
to `"?".equals(auth.domain)` for consistency — happy to drop this hunk if you would
rather keep the legacy stack untouched.

A grep for `[!=]= *"` over `src/main/java` finds no other occurrences.

## Verification

* `mvn -B package` — 8586 tests, 0 failures, 0 errors, BUILD SUCCESS.
* `mvn formatter:validate` — clean.
* The transcript above is the actual output of a two-class probe run on this JDK;
  no unit test is added because `MASK_SECRET_VALUE` is a `static final` resolved at
  class initialisation, so the broken input cannot be exercised in-process.
