### PR TITLE
fix(smb3): implement SMB3 transform encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ JCIFS is a comprehensive, pure Java implementation of the CIFS/SMB networking pr
   - **Pre-Authentication Integrity** (SMB 3.1.1)
   - **AES-CMAC signing** for data integrity
   - **Automatic protocol negotiation**
-  - **Transparent encryption** when required by server
+  - **Transparent encryption** when required by the server, per session or per share (opt-in, see below)
 
 ### **Security & Authentication**
 - **Multi-method Authentication**: NTLMSSP, Kerberos, SPNEGO
@@ -380,7 +380,8 @@ props.setProperty("jcifs.client.maxVersion", "SMB311");
 - **Rotate credentials** regularly and implement credential renewal
 
 ### Network Security
-- **Use encrypted connections** when available (SMB3 encryption is automatic)
+- **Use encrypted connections** when available: set `jcifs.client.encryptionEnabled=true` (default `false`).
+  Once enabled, encryption is applied automatically to any session or share the server marks as requiring it.
 - **Limit protocol versions** to minimum required for your environment
 - **Monitor failed authentication** attempts in logs
 - **Use VPN or secure networks** when accessing SMB over public networks

--- a/src/main/java/org/codelibs/jcifs/smb/Configuration.java
+++ b/src/main/java/org/codelibs/jcifs/smb/Configuration.java
@@ -493,8 +493,8 @@ public interface Configuration {
     /**
      * Property {@code jcifs.client.encryptionEnabled} (boolean, default false)
      *
-     * This is an experimental option allowing to indicate support during protocol
-     * negotiation, SMB encryption is not implemented yet.
+     * Enables SMB3 encryption. When enabled the client advertises AES-128-GCM and AES-128-CCM during protocol
+     * negotiation and encrypts traffic on any session or share for which the server requires it.
      *
      * @return whether SMB encryption is enabled
      * @since 2.1

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbSessionImpl.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbSessionImpl.java
@@ -101,6 +101,8 @@ final class SmbSessionImpl implements SmbSessionInternal {
 
     private SMBSigningDigest digest;
     private Smb2EncryptionContext encryptionContext;
+    /** Whether the server required encryption for every message on this session (SMB2_SESSION_FLAG_ENCRYPT_DATA). */
+    private boolean encryptData;
 
     private final String targetDomain;
     private final String targetHost;
@@ -373,7 +375,14 @@ final class SmbSessionImpl implements SmbSessionInternal {
                 request.setSessionId(this.sessionId);
                 request.setUid(this.uid);
 
-                if (request.getDigest() == null) {
+                if (this.encryptData && request instanceof final ServerMessageBlock2 smb2Request) {
+                    smb2Request.setEncrypt(true);
+                }
+
+                // An encrypted message is authenticated by the AEAD tag, not by a signature (MS-SMB2 3.1.4.1), and
+                // servers do not sign inside a transform header. Signing here would make the peer reject it.
+                final boolean encrypting = request instanceof final ServerMessageBlock2 smb2Req && smb2Req.isEncrypt();
+                if (!encrypting && request.getDigest() == null) {
                     request.setDigest(getDigest());
                 }
 
@@ -556,17 +565,10 @@ final class SmbSessionImpl implements SmbSessionInternal {
                 }
 
                 if ((response.getSessionFlags() & Smb2SessionSetupResponse.SMB2_SESSION_FLAG_ENCRYPT_DATA) != 0) {
-                    // Server requires encryption - create encryption context
-                    try {
-                        if (log.isDebugEnabled()) {
-                            log.debug("Server requires encryption, creating encryption context");
-                        }
-                        SmbTransportImpl transport = getTransport();
-                        this.encryptionContext = transport.createEncryptionContext(this.sessionKey, this.preauthIntegrityHash);
-                    } catch (CIFSException e) {
-                        log.error("Failed to create encryption context", e);
-                        throw new SmbAuthException("Failed to setup required encryption", e);
-                    }
+                    // The encryption context cannot be built yet: it is keyed on the session key, which is only
+                    // available once the security context is established, and on the SMB 3.1.1 preauth hash, which
+                    // still has to absorb this request. Both happen below.
+                    this.encryptData = true;
                 }
 
                 if (preauthIntegrity) {
@@ -592,6 +594,8 @@ final class SmbSessionImpl implements SmbSessionInternal {
                     System.arraycopy(sk, 0, key, 0, Math.min(16, sk.length));
                     this.sessionKey = key;
                 }
+
+                setupEncryptionContext(negoResp, anonymous);
 
                 boolean signed = response != null && response.isSigned();
                 if (!anonymous && (isSignatureSetupRequired() || signed)) {
@@ -709,6 +713,12 @@ final class SmbSessionImpl implements SmbSessionInternal {
         long newSessId = 0;
         long curSessId = this.sessionId;
 
+        // Reauthentication is a fresh authentication sequence: for SMB 3.1.1 the preauth hash restarts from the
+        // connection hash and absorbs the new session setup exchange, exactly as it does for the initial setup.
+        // Without this the keys derived below would come from a hash the server no longer has.
+        final boolean preauthIntegrity = negoResp.getSelectedDialect().atLeast(DialectVersion.SMB311);
+        this.preauthIntegrityHash = preauthIntegrity ? trans.getPreauthIntegrityHash() : null;
+
         synchronized (trans) {
             this.credentials.refresh();
             Subject s = this.credentials.getSubject();
@@ -720,12 +730,18 @@ final class SmbSessionImpl implements SmbSessionInternal {
                     Smb2SessionSetupRequest request = new Smb2SessionSetupRequest(getContext(), negoResp.getSecurityMode(),
                             negoResp.getCommonCapabilities(), curSessId, token);
 
-                    if (chain != null) {
+                    // A session setup is always sent in the clear, and doSend decides on the head of the chain.
+                    // Compounding a request that must be encrypted onto it would put that request on the wire in
+                    // cleartext, so it is sent separately below instead.
+                    final boolean chainMustBeEncrypted =
+                            chain instanceof final ServerMessageBlock2 chainMsg && (this.encryptData || chainMsg.isEncrypt());
+                    if (chain != null && !chainMustBeEncrypted) {
                         request.chain((ServerMessageBlock2) chain);
                     }
 
                     request.setDigest(this.digest);
                     request.setSessionId(curSessId);
+                    request.retainPayload();
 
                     try {
                         response = trans.send(request, null, EnumSet.of(RequestParam.RETAIN_PAYLOAD));
@@ -754,6 +770,17 @@ final class SmbSessionImpl implements SmbSessionInternal {
                         anonymous = true;
                     }
 
+                    if (preauthIntegrity) {
+                        final byte[] reqBytes = request.getRawPayload();
+                        this.preauthIntegrityHash = trans.calculatePreauthHash(reqBytes, 0, reqBytes.length, this.preauthIntegrityHash);
+
+                        if (response.getStatus() == NtStatus.NT_STATUS_MORE_PROCESSING_REQUIRED) {
+                            final byte[] respBytes = response.getRawPayload();
+                            this.preauthIntegrityHash =
+                                    trans.calculatePreauthHash(respBytes, 0, respBytes.length, this.preauthIntegrityHash);
+                        }
+                    }
+
                     if (request.getDigest() != null) {
                         /* success - install the signing digest */
                         log.debug("Setting digest");
@@ -768,6 +795,19 @@ final class SmbSessionImpl implements SmbSessionInternal {
                 }
 
                 if (ctx.isEstablished()) {
+                    // The server derives fresh keys from the new session key (MS-SMB2 3.3.5.5.3), so a retained
+                    // encryption context would no longer match on either side.
+                    final byte[] sk = ctx.getSigningKey();
+                    if (sk != null) {
+                        final byte[] key = new byte[16];
+                        System.arraycopy(sk, 0, key, 0, Math.min(16, sk.length));
+                        this.sessionKey = key;
+                    }
+                    if (this.encryptionContext != null) {
+                        this.encryptionContext = null;
+                        setupEncryptionContext(negoResp, anonymous);
+                    }
+
                     setSessionSetup(response);
                     @SuppressWarnings("cast")
                     CommonServerMessageBlockResponse cresp = response != null ? response.getNextResponse() : null;
@@ -1095,8 +1135,15 @@ final class SmbSessionImpl implements SmbSessionInternal {
 
                 if (!inError && trans.isSMB2()) {
                     Smb2LogoffRequest request = new Smb2LogoffRequest(getConfig());
-                    request.setDigest(getDigest());
                     request.setSessionId(this.sessionId);
+                    if (this.encryptData) {
+                        // This request does not go through send(), so the marker has to be applied here. On an
+                        // encrypted session every message after session setup must be encrypted, and an encrypted
+                        // message is not signed.
+                        request.setEncrypt(true);
+                    } else {
+                        request.setDigest(getDigest());
+                    }
                     try {
                         this.transport.send(request.ignoreDisconnect(), null);
                     } catch (SmbException se) {
@@ -1124,6 +1171,9 @@ final class SmbSessionImpl implements SmbSessionInternal {
         } finally {
             this.connectionState.set(0);
             this.digest = null;
+            this.transport.unregisterSessionId(this.sessionId);
+            this.encryptionContext = null;
+            this.encryptData = false;
             this.transport.notifyAll();
         }
         return wasInUse;
@@ -1143,7 +1193,14 @@ final class SmbSessionImpl implements SmbSessionInternal {
     void setSessionSetup(Smb2SessionSetupResponse response) {
         this.extendedSecurity = true;
         this.connectionState.set(2);
+        final long previousSessionId = this.sessionId;
         this.sessionId = response.getSessionId();
+        // Index the session so the receive thread can resolve its keys from an inbound transform header.
+        // Reauthentication yields a new id, so the previous entry has to go.
+        if (previousSessionId != this.sessionId) {
+            this.transport.unregisterSessionId(previousSessionId);
+        }
+        this.transport.registerSessionId(this.sessionId, this);
     }
 
     void setSessionSetup(SmbComSessionSetupAndXResponse response) {
@@ -1204,6 +1261,51 @@ final class SmbSessionImpl implements SmbSessionInternal {
      */
     public boolean isFailed() {
         return this.transport.isFailed();
+    }
+
+    /**
+     * Builds the SMB3 encryption context once the session key and the final preauth hash are known.
+     *
+     * <p>
+     * The context is created whenever the connection negotiated encryption, not only when the server demanded it for
+     * the whole session: a share can require encryption on its own (SMB2_SHAREFLAG_ENCRYPT_DATA) while the session
+     * flag is clear.
+     * </p>
+     */
+    private void setupEncryptionContext(final Smb2NegotiateResponse negoResp, final boolean anonymous) throws CIFSException {
+        if (this.encryptionContext != null || !negoResp.isEncryptionSupported()) {
+            if (this.encryptData && this.encryptionContext == null) {
+                throw new SmbAuthException("Server requires encryption but encryption was not negotiated");
+            }
+            return;
+        }
+
+        if (this.sessionKey == null || anonymous) {
+            // Anonymous and guest sessions have no key material to derive from.
+            if (this.encryptData) {
+                throw new SmbAuthException("Server requires encryption but no session key is available");
+            }
+            return;
+        }
+
+        try (SmbTransportImpl trans = getTransport()) {
+            this.encryptionContext = trans.createEncryptionContext(this.sessionKey, this.preauthIntegrityHash);
+        } catch (final CIFSException e) {
+            if (this.encryptData) {
+                throw new SmbAuthException("Failed to setup required encryption", e);
+            }
+            log.debug("Failed to setup optional encryption context", e);
+        }
+    }
+
+    /**
+     * Whether the server requires every message on this session to be encrypted
+     * (SMB2_SESSION_FLAG_ENCRYPT_DATA). A share can require encryption on its own without this being set.
+     *
+     * @return whether the whole session is encrypted
+     */
+    boolean isEncryptData() {
+        return this.encryptData;
     }
 
     /**

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbTransportImpl.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbTransportImpl.java
@@ -34,8 +34,10 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Map;
 import java.util.Locale;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -71,6 +73,8 @@ import org.codelibs.jcifs.smb.internal.smb1.trans.SmbComTransactionResponse;
 import org.codelibs.jcifs.smb.internal.smb1.trans2.Trans2GetDfsReferral;
 import org.codelibs.jcifs.smb.internal.smb1.trans2.Trans2GetDfsReferralResponse;
 import org.codelibs.jcifs.smb.internal.smb2.ServerMessageBlock2;
+import org.codelibs.jcifs.smb.internal.smb2.Smb2TransformHeader;
+import org.codelibs.jcifs.smb.internal.util.SMBUtil;
 import org.codelibs.jcifs.smb.internal.smb2.ServerMessageBlock2Request;
 import org.codelibs.jcifs.smb.internal.smb2.ServerMessageBlock2Response;
 import org.codelibs.jcifs.smb.internal.smb2.Smb2Constants;
@@ -116,6 +120,23 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
     private final byte[] sbuf = new byte[1024]; /* small local buffer */
     private long sessionExpiration;
     private final List<SmbSessionImpl> sessions = new LinkedList<>();
+
+    /**
+     * Sessions indexed by their server-assigned id, for resolving the key of an inbound SMB2 TRANSFORM_HEADER.
+     *
+     * <p>
+     * Deliberately a concurrent map rather than a scan of {@link #sessions} under the transport monitor: the receive
+     * thread performs this lookup while a caller may be holding that monitor inside session setup, waiting for the
+     * very response the receive thread is trying to deliver.
+     * </p>
+     */
+    private final Map<Long, SmbSessionImpl> sessionsById = new ConcurrentHashMap<>();
+
+    /** Decrypted payload of the transform message currently being dispatched, or null. */
+    private byte[] transformPayload;
+
+    /** Read cursor into {@link #transformPayload}. */
+    private int transformPayloadOffset;
 
     private String tconHostName = null;
 
@@ -751,6 +772,9 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
         } catch (final Exception e) {
             log.debug("Exception in disconnect", e);
         } finally {
+            // Cleared only here: the tree-disconnect and logoff above still have to resolve their session in
+            // order to encrypt themselves on an encrypted session.
+            this.sessionsById.clear();
             this.socket = null;
             this.digest = null;
             this.tconHostName = null;
@@ -771,6 +795,8 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
 
     @Override
     protected Long peekKey() throws IOException {
+        this.transformPayload = null;
+        this.transformPayloadOffset = 0;
         do {
             if (readn(this.in, this.sbuf, 0, 4) < 4) {
                 return null;
@@ -804,6 +830,13 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
                     return null;
                 }
                 return (long) Encdec.dec_uint64le(this.sbuf, 28);
+            }
+
+            if (this.sbuf[0] == (byte) 0x00 && this.sbuf[4] == (byte) 0xFD && this.sbuf[5] == (byte) 'S' && this.sbuf[6] == (byte) 'M'
+                    && this.sbuf[7] == (byte) 'B') {
+                // SMB2 TRANSFORM_HEADER: the message id to dispatch on is inside the ciphertext, so the whole
+                // message has to be read and decrypted before a key can be returned.
+                return peekTransformedKey();
             }
 
             if (this.sbuf[0] == (byte) 0x00 && this.sbuf[1] == (byte) 0x00 && this.sbuf[4] == (byte) 0xFF && this.sbuf[5] == (byte) 'S'
@@ -856,12 +889,57 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
                  * "NBSS Continuation Message" frame according to WireShark
                  */
 
-                this.out.write(buffer, 0, 4 + n);
-                this.out.flush();
+                if (smb instanceof final ServerMessageBlock2 smb2Message && smb2Message.isEncrypt()) {
+                    writeEncrypted(smb2Message, buffer, n);
+                } else {
+                    this.out.write(buffer, 0, 4 + n);
+                    this.out.flush();
+                }
             }
         } finally {
             this.getContext().getBufferCache().releaseBuffer(buffer);
         }
+    }
+
+    /**
+     * Wraps an already-encoded SMB2 message (including any compounded messages) in an SMB2 TRANSFORM_HEADER and
+     * writes it.
+     *
+     * <p>
+     * Called with {@link #outLock} held. The encoded message starts at {@code buffer[4]}; there is not enough room
+     * ahead of it for the 52-byte transform header, so the wrapped message is built separately.
+     * </p>
+     */
+    private void writeEncrypted(final ServerMessageBlock2 message, final byte[] buffer, final int n) throws IOException {
+        final long sessionId = message.getSessionId();
+        final SmbSessionImpl session = getSessionById(sessionId);
+        if (session == null) {
+            throw new IOException("Cannot encrypt request for unknown session 0x" + Long.toHexString(sessionId));
+        }
+        final Smb2EncryptionContext encryptionContext = session.getEncryptionContext();
+        if (encryptionContext == null) {
+            throw new IOException("Encryption is required but session 0x" + Long.toHexString(sessionId) + " has no encryption context");
+        }
+
+        final byte[] plaintext = new byte[n];
+        System.arraycopy(buffer, 4, plaintext, 0, n);
+
+        final byte[] wire;
+        try {
+            wire = encryptionContext.encryptMessage(plaintext, sessionId);
+        } catch (final CIFSException e) {
+            throw new IOException("Failed to encrypt message", e);
+        }
+
+        final byte[] framed = new byte[4 + wire.length];
+        framed[0] = 0;
+        framed[1] = (byte) (wire.length >> 16);
+        framed[2] = (byte) (wire.length >> 8);
+        framed[3] = (byte) wire.length;
+        System.arraycopy(wire, 0, framed, 4, wire.length);
+
+        this.out.write(framed, 0, framed.length);
+        this.out.flush();
     }
 
     @SuppressWarnings("unchecked")
@@ -871,7 +949,11 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
 
         CommonServerMessageBlockRequest curHead = request;
 
-        final int maxSize = getContext().getConfig().getMaximumBufferSize();
+        int maxSize = getContext().getConfig().getMaximumBufferSize();
+        if (request instanceof final ServerMessageBlock2 smb2Request && smb2Request.isEncrypt()) {
+            // The wrapped message must still fit: the transform header is prepended to the whole compound chain.
+            maxSize -= Smb2TransformHeader.TRANSFORM_HEADER_SIZE;
+        }
 
         while (curHead != null) {
             CommonServerMessageBlockRequest nextHead = null;
@@ -1089,6 +1171,138 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
         }
     }
 
+    /**
+     * Reads and decrypts a complete SMB2 TRANSFORM_HEADER message, then presents the plaintext to the normal
+     * receive path.
+     *
+     * <p>
+     * On return {@link #sbuf} holds a synthetic NetBIOS header plus the decrypted SMB2 header, and
+     * {@link #transformPayload} holds the whole decrypted message, so {@code doRecvSMB2} can proceed unchanged.
+     * </p>
+     *
+     * @return the message id of the decrypted message, or null at end of stream
+     */
+    private Long peekTransformedKey() throws IOException {
+        final int size = Encdec.dec_uint16be(this.sbuf, 2) & 0xFFFF | (this.sbuf[1] & 0xFF) << 16;
+        final int minSize = Smb2TransformHeader.TRANSFORM_HEADER_SIZE + Smb2Constants.SMB2_HEADER_LENGTH;
+        final int maximumBufferSize = getContext().getConfig().getMaximumBufferSize();
+        if (size < minSize || size > maximumBufferSize + Smb2TransformHeader.TRANSFORM_HEADER_SIZE) {
+            throw new IOException("Invalid transform message size: " + size);
+        }
+
+        final byte[] wire = new byte[size];
+        // peekKey has already pulled the NetBIOS header plus the first 32 bytes of the transform header.
+        System.arraycopy(this.sbuf, 4, wire, 0, SmbConstants.SMB1_HEADER_LENGTH);
+        final int remaining = size - SmbConstants.SMB1_HEADER_LENGTH;
+        if (readn(this.in, wire, SmbConstants.SMB1_HEADER_LENGTH, remaining) < remaining) {
+            return null;
+        }
+
+        final long sessionId = SMBUtil.readInt8(wire, 44);
+        final SmbSessionImpl session = getSessionById(sessionId);
+        final Smb2EncryptionContext encryptionContext = session != null ? session.getEncryptionContext() : null;
+        if (encryptionContext == null) {
+            // Most likely a late response for a session that has just been logged off. The frame has been read in
+            // full, so it can be dropped on its own; failing the transport here would take down every other
+            // session sharing it. A message that fails to decrypt is treated as fatal below.
+            log.warn("Discarding encrypted message for unknown session 0x" + Long.toHexString(sessionId));
+            return discardTransformedMessage();
+        }
+
+        final byte[] plaintext;
+        try {
+            plaintext = encryptionContext.decryptMessage(wire);
+        } catch (final CIFSException e) {
+            throw new IOException("Failed to decrypt message for session 0x" + Long.toHexString(sessionId), e);
+        }
+
+        if (plaintext.length < Smb2Constants.SMB2_HEADER_LENGTH) {
+            throw new IOException("Decrypted message is shorter than an SMB2 header");
+        }
+        if (plaintext[0] != (byte) 0xFE || plaintext[1] != (byte) 'S' || plaintext[2] != (byte) 'M' || plaintext[3] != (byte) 'B') {
+            throw new IOException("Decrypted message is not an SMB2 message");
+        }
+
+        // MS-SMB2 3.2.5.1.1: the session id in the decrypted header must equal the one in the transform header.
+        // A transport multiplexes sessions and message ids are transport-global, so without this check a message
+        // decrypted under one session's key could be dispatched to a request issued on another.
+        final long innerSessionId = SMBUtil.readInt8(plaintext, 40);
+        if (innerSessionId != sessionId) {
+            throw new IOException("Transform header session id 0x" + Long.toHexString(sessionId)
+                    + " does not match decrypted header session id 0x" + Long.toHexString(innerSessionId));
+        }
+
+        this.smb2 = true;
+        this.transformPayload = plaintext;
+        this.transformPayloadOffset = Smb2Constants.SMB2_HEADER_LENGTH;
+
+        // Present the plaintext exactly as an unencrypted message would have arrived.
+        this.sbuf[0] = 0;
+        this.sbuf[1] = (byte) (plaintext.length >> 16);
+        this.sbuf[2] = (byte) (plaintext.length >> 8);
+        this.sbuf[3] = (byte) plaintext.length;
+        System.arraycopy(plaintext, 0, this.sbuf, 4, Smb2Constants.SMB2_HEADER_LENGTH);
+
+        return (long) Encdec.dec_uint64le(this.sbuf, 28);
+    }
+
+    /**
+     * Drops a fully-read transform message that could not be routed, without disturbing the stream.
+     *
+     * <p>
+     * Returns a key that cannot match an outstanding request, so the transport loop hands it to {@code doSkip},
+     * which then finds an empty payload and skips nothing.
+     * </p>
+     */
+    private Long discardTransformedMessage() {
+        this.smb2 = true;
+        this.transformPayload = new byte[0];
+        this.transformPayloadOffset = 0;
+        this.sbuf[0] = 0;
+        this.sbuf[1] = 0;
+        this.sbuf[2] = 0;
+        this.sbuf[3] = (byte) Smb2Constants.SMB2_HEADER_LENGTH;
+        Arrays.fill(this.sbuf, 4, 4 + Smb2Constants.SMB2_HEADER_LENGTH, (byte) 0);
+        return Long.MIN_VALUE;
+    }
+
+    /**
+     * Reads message bytes from the decrypted transform payload when one is being dispatched, otherwise from the
+     * socket.
+     */
+    private int readMessageBytes(final byte[] dst, final int off, final int len) throws IOException {
+        if (this.transformPayload == null) {
+            return readn(this.in, dst, off, len);
+        }
+        if (len < 0 || this.transformPayloadOffset + len > this.transformPayload.length) {
+            throw new IOException("Truncated transform payload");
+        }
+        if (off + len > dst.length) {
+            throw new IOException("Transform payload does not fit the receive buffer");
+        }
+        System.arraycopy(this.transformPayload, this.transformPayloadOffset, dst, off, len);
+        this.transformPayloadOffset += len;
+        return len;
+    }
+
+    /**
+     * Skips message bytes in the decrypted transform payload when one is being dispatched, otherwise in the socket.
+     */
+    private void skipMessageBytes(final long count) throws IOException {
+        if (this.transformPayload == null) {
+            this.in.skip(count);
+            return;
+        }
+        this.transformPayloadOffset = (int) Math.min(this.transformPayload.length, this.transformPayloadOffset + count);
+    }
+
+    /**
+     * @return whether the message currently being dispatched arrived inside a transform header
+     */
+    private boolean isDispatchingEncrypted() {
+        return this.transformPayload != null;
+    }
+
     // must be synchronized with peekKey
     @Override
     protected void doRecv(final Response response) throws IOException {
@@ -1107,8 +1321,10 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
                 response.notifyAll();
             }
             throw e;
+        } finally {
+            this.transformPayload = null;
+            this.transformPayloadOffset = 0;
         }
-
     }
 
     /**
@@ -1141,7 +1357,13 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
 
             // read and decode first
             System.arraycopy(this.sbuf, 4, buffer, 0, Smb2Constants.SMB2_HEADER_LENGTH);
-            readn(this.in, buffer, Smb2Constants.SMB2_HEADER_LENGTH, rl - Smb2Constants.SMB2_HEADER_LENGTH);
+            readMessageBytes(buffer, Smb2Constants.SMB2_HEADER_LENGTH, rl - Smb2Constants.SMB2_HEADER_LENGTH);
+
+            if (isDispatchingEncrypted()) {
+                // An encrypted message is authenticated by its AEAD tag and is not signed
+                // (MS-SMB2 3.1.4.1); verifying a signature over an unsigned header would fail.
+                cur.setDigest(null);
+            }
 
             cur.setReadSize(rl);
             int len = cur.decode(buffer, 0);
@@ -1158,12 +1380,12 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
                 cur = (ServerMessageBlock2Response) cur.getNextResponse();
                 if (cur == null) {
                     log.warn("Response not properly set up");
-                    this.in.skip(size);
+                    skipMessageBytes(size);
                     break;
                 }
 
                 // read next header
-                readn(this.in, buffer, 0, Smb2Constants.SMB2_HEADER_LENGTH);
+                readMessageBytes(buffer, 0, Smb2Constants.SMB2_HEADER_LENGTH);
                 nextCommand = Encdec.dec_uint32le(buffer, 20);
 
                 if ((nextCommand != 0 ? nextCommand > maximumBufferSize : size > maximumBufferSize)) {
@@ -1178,7 +1400,7 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
                 }
 
                 cur.setReadSize(rl);
-                readn(this.in, buffer, Smb2Constants.SMB2_HEADER_LENGTH, rl - Smb2Constants.SMB2_HEADER_LENGTH);
+                readMessageBytes(buffer, Smb2Constants.SMB2_HEADER_LENGTH, rl - Smb2Constants.SMB2_HEADER_LENGTH);
 
                 len = cur.decode(buffer, 0, true);
                 if (len > rl) {
@@ -1237,12 +1459,23 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
 
     @Override
     protected void doSkip(final Long key) throws IOException {
+        try {
+            doSkip0(key);
+        } finally {
+            this.transformPayload = null;
+            this.transformPayloadOffset = 0;
+        }
+    }
+
+    private void doSkip0(final Long key) throws IOException {
         synchronized (this.inLock) {
             final int size = Encdec.dec_uint16be(this.sbuf, 2) & 0xFFFF;
             if (size < 33 || 4 + size > this.getContext().getConfig().getReceiveBufferSize()) {
                 /* log message? */
                 log.warn("Flusing stream input");
-                this.in.skip(this.in.available());
+                if (!isDispatchingEncrypted()) {
+                    this.in.skip(this.in.available());
+                }
             } else {
                 final Response notification = createNotification(key);
                 if (notification != null) {
@@ -1253,9 +1486,9 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
                 }
                 log.warn("Skipping message " + key);
                 if (this.isSMB2()) {
-                    this.in.skip(size - Smb2Constants.SMB2_HEADER_LENGTH);
+                    skipMessageBytes(size - Smb2Constants.SMB2_HEADER_LENGTH);
                 } else {
-                    this.in.skip(size - SmbConstants.SMB1_HEADER_LENGTH);
+                    skipMessageBytes(size - SmbConstants.SMB1_HEADER_LENGTH);
                 }
             }
         }
@@ -1734,8 +1967,9 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
         if (dialect.atLeast(DialectVersion.SMB311)) {
             cipherId = resp.getSelectedCipher();
             if (cipherId == -1) {
-                // Default to AES-128-GCM for SMB 3.1.1 if no cipher negotiated
-                cipherId = EncryptionNegotiateContext.CIPHER_AES128_GCM;
+                // MS-SMB2 3.2.5.2: with no encryption capabilities context in the response the cipher is
+                // AES-128-CCM.
+                cipherId = EncryptionNegotiateContext.CIPHER_AES128_CCM;
             }
         } else if (dialect.atLeast(DialectVersion.SMB300)) {
             // SMB 3.0/3.0.2 only supports AES-128-CCM
@@ -1754,6 +1988,41 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
         } catch (final Exception e) {
             throw new CIFSException("Failed to create encryption context", e);
         }
+    }
+
+    /**
+     * Registers a session under its server-assigned id so inbound encrypted messages can be routed to its keys.
+     *
+     * @param sessionId
+     *            the server-assigned session id
+     * @param session
+     *            the session
+     */
+    void registerSessionId(final long sessionId, final SmbSessionImpl session) {
+        if (sessionId != 0) {
+            this.sessionsById.put(sessionId, session);
+        }
+    }
+
+    /**
+     * Removes a session from the id index.
+     *
+     * @param sessionId
+     *            the server-assigned session id
+     */
+    void unregisterSessionId(final long sessionId) {
+        if (sessionId != 0) {
+            this.sessionsById.remove(sessionId);
+        }
+    }
+
+    /**
+     * @param sessionId
+     *            the server-assigned session id
+     * @return the session with that id, or null if no such session is established
+     */
+    SmbSessionImpl getSessionById(final long sessionId) {
+        return this.sessionsById.get(sessionId);
     }
 
     public int getRequestSecurityMode(final Smb2NegotiateResponse first) {

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbTreeImpl.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbTreeImpl.java
@@ -43,6 +43,7 @@ import org.codelibs.jcifs.smb.internal.CommonServerMessageBlockResponse;
 import org.codelibs.jcifs.smb.internal.RequestWithPath;
 import org.codelibs.jcifs.smb.internal.SmbNegotiationResponse;
 import org.codelibs.jcifs.smb.internal.TreeConnectResponse;
+import org.codelibs.jcifs.smb.internal.smb2.tree.Smb2TreeConnectResponse;
 import org.codelibs.jcifs.smb.internal.smb1.ServerMessageBlock;
 import org.codelibs.jcifs.smb.internal.smb1.com.SmbComBlankResponse;
 import org.codelibs.jcifs.smb.internal.smb1.com.SmbComNegotiateResponse;
@@ -85,6 +86,8 @@ class SmbTreeImpl implements SmbTreeInternal {
     private volatile int tid = -1;
     private volatile String service = "?????";
     private volatile boolean inDfs, inDomainDfs;
+    /** Whether the server requires encryption for every message on this share (SMB2_SHAREFLAG_ENCRYPT_DATA). */
+    private volatile boolean encryptData;
     private volatile long treeNum; // used by SmbFile.isOpen
 
     private final AtomicLong usageCount = new AtomicLong(0);
@@ -444,6 +447,10 @@ class SmbTreeImpl implements SmbTreeInternal {
             final int t = this.tid;
             request.setTid(t);
 
+            if (this.encryptData && request instanceof final ServerMessageBlock2 smb2Request) {
+                smb2Request.setEncrypt(true);
+            }
+
             if (!transport.isSMB2()) {
                 final ServerMessageBlock req = (ServerMessageBlock) request;
                 svc = this.service;
@@ -596,7 +603,11 @@ class SmbTreeImpl implements SmbTreeInternal {
 
                     if (transport.isSMB2()) {
                         final Smb2TreeConnectRequest req = new Smb2TreeConnectRequest(sess.getConfig(), unc);
-                        if (andx != null) {
+                        // Whether the share requires encryption is only learned from this response, and the
+                        // TREE_CONNECT itself goes out in the clear. Compounding onto it would put the caller's
+                        // request on the wire unencrypted, so when encryption is available for this session the
+                        // request is sent separately once the share's requirement is known.
+                        if (andx != null && (!sess.isEncryptionEnabled() || sess.isEncryptData())) {
                             req.chain((ServerMessageBlock2) andx);
                         }
                         request = req;
@@ -621,10 +632,25 @@ class SmbTreeImpl implements SmbTreeInternal {
                         // tree connect might still have succeeded
                         response = (TreeConnectResponse) request.getResponse();
                         if (response.isReceived() && !response.isError() && response.getErrorCode() == NtStatus.NT_STATUS_SUCCESS) {
-                            if (!transport.isDisconnected()) {
-                                treeConnected(transport, sess, response);
+                            if (transport.isDisconnected()) {
+                                throw se;
                             }
-                            throw se;
+                            boolean established = false;
+                            try {
+                                treeConnected(transport, sess, response);
+                                established = true;
+                            } catch (final IOException e2) {
+                                // treeConnected rejects this response as well, so the tree never reached the
+                                // connected state. Fall through to the failure path below instead of letting the
+                                // exception escape: skipping the reset would leave connectionState at "connecting",
+                                // and every later treeConnect would then wait on the transport monitor forever.
+                                if (e2 != se) {
+                                    se.addSuppressed(e2);
+                                }
+                            }
+                            if (established) {
+                                throw se;
+                            }
                         }
                     }
                     try {
@@ -665,6 +691,21 @@ class SmbTreeImpl implements SmbTreeInternal {
 
         this.service = rsvc;
         this.inDfs = response.isShareDfs();
+
+        if (response instanceof final Smb2TreeConnectResponse tcr) {
+            // A share can demand encryption even when the session does not (MS-SMB2 2.2.10); this is the only
+            // place that requirement is announced.
+            this.encryptData = (tcr.getShareFlags() & Smb2TreeConnectResponse.SMB2_SHAREFLAG_ENCRYPT_DATA) != 0;
+            if (this.encryptData) {
+                if (!sess.isEncryptionEnabled()) {
+                    throw new SmbUnsupportedOperationException(
+                            "Share '" + this.share + "' requires encryption but no encryption context is available");
+                }
+                if (log.isDebugEnabled()) {
+                    log.debug("Share " + this.share + " requires encryption");
+                }
+            }
+        }
         this.treeNum = TREE_CONN_COUNTER.incrementAndGet();
 
         this.connectionState.set(2); // connected

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/ServerMessageBlock2.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/ServerMessageBlock2.java
@@ -120,6 +120,7 @@ public abstract class ServerMessageBlock2 implements CommonServerMessageBlock {
 
     private final byte[] signature = new byte[16];
     private Smb2SigningDigest digest = null;
+    private boolean encrypt;
 
     private final Configuration config;
 
@@ -174,6 +175,10 @@ public abstract class ServerMessageBlock2 implements CommonServerMessageBlock {
         this.digest = null;
         this.sessionId = 0;
         this.treeId = 0;
+        // A retried or DFS-redirected request is re-marked by whichever session/tree it is sent on. Carrying the
+        // previous decision to a different server would encrypt where nothing asked for it, or fail for want of
+        // an encryption context.
+        this.encrypt = false;
     }
 
     /**
@@ -321,6 +326,33 @@ public abstract class ServerMessageBlock2 implements CommonServerMessageBlock {
     }
 
     /**
+     * Whether this message must be sent inside an SMB2 TRANSFORM_HEADER.
+     *
+     * @return true if the message must be encrypted
+     */
+    public boolean isEncrypt() {
+        return this.encrypt;
+    }
+
+    /**
+     * Marks this message, and every message already chained to it, as requiring SMB3 encryption.
+     *
+     * <p>
+     * A compound chain is wrapped in a single transform header, so the marker must be visible from the head of the
+     * chain no matter which link set it.
+     * </p>
+     *
+     * @param encrypt
+     *            whether the message must be encrypted
+     */
+    public void setEncrypt(final boolean encrypt) {
+        this.encrypt = encrypt;
+        if (this.next != null) {
+            this.next.setEncrypt(encrypt);
+        }
+    }
+
+    /**
      *
      * {@inheritDoc}
      *
@@ -440,6 +472,9 @@ public abstract class ServerMessageBlock2 implements CommonServerMessageBlock {
         }
 
         n.addFlags(SMB2_FLAGS_RELATED_OPERATIONS);
+        if (this.encrypt) {
+            n.setEncrypt(true);
+        }
         this.next = n;
         return true;
     }

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/Smb2EncryptionContext.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/Smb2EncryptionContext.java
@@ -18,15 +18,13 @@
 package org.codelibs.jcifs.smb.internal.smb2;
 
 import java.security.SecureRandom;
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLong;
-
-import javax.crypto.Cipher;
-import javax.crypto.spec.GCMParameterSpec;
-import javax.crypto.spec.SecretKeySpec;
 
 import org.bouncycastle.crypto.engines.AESEngine;
 import org.bouncycastle.crypto.modes.AEADBlockCipher;
 import org.bouncycastle.crypto.modes.CCMBlockCipher;
+import org.bouncycastle.crypto.modes.GCMBlockCipher;
 import org.bouncycastle.crypto.params.AEADParameters;
 import org.bouncycastle.crypto.params.KeyParameter;
 import org.codelibs.jcifs.smb.CIFSException;
@@ -49,6 +47,12 @@ public class Smb2EncryptionContext {
     private final byte[] decryptionKey;
     private final AtomicLong nonceCounter = new AtomicLong(0);
     private final SecureRandom secureRandom = new SecureRandom();
+
+    /**
+     * Random prefix that separates this context's nonce space from any other context that might share a key. The
+     * trailing counter guarantees uniqueness within this context.
+     */
+    private final byte[] noncePrefix;
 
     /**
      * AES-128-CCM cipher identifier for SMB3 encryption
@@ -82,6 +86,8 @@ public class Smb2EncryptionContext {
         this.dialect = dialect;
         this.encryptionKey = encryptionKey.clone();
         this.decryptionKey = decryptionKey.clone();
+        this.noncePrefix = new byte[Math.max(0, getNonceLength() - Long.BYTES)];
+        this.secureRandom.nextBytes(this.noncePrefix);
     }
 
     /**
@@ -103,20 +109,19 @@ public class Smb2EncryptionContext {
     /**
      * Generate a unique nonce for encryption
      *
-     * @return 16-byte nonce
+     * @return a nonce of the cipher's nonce length (see {@link #getNonceLength()})
      */
     public byte[] generateNonce() {
-        final byte[] nonce = new byte[16];
+        final byte[] nonce = new byte[getNonceLength()];
+        System.arraycopy(this.noncePrefix, 0, nonce, 0, this.noncePrefix.length);
 
-        // Use combination of counter and random data for uniqueness
-        final long counter = this.nonceCounter.incrementAndGet();
-        System.arraycopy(longToBytes(counter), 0, nonce, 0, 8);
-
-        // Fill remaining 8 bytes with random data
-        final byte[] randomBytes = new byte[8];
-        this.secureRandom.nextBytes(randomBytes);
-        System.arraycopy(randomBytes, 0, nonce, 8, 8);
-
+        // Big-endian counter in the trailing 8 bytes. MS-SMB2 2.2.41 requires that a nonce is never reused for a
+        // given key; a 64-bit counter cannot wrap within the lifetime of a session.
+        long counter = this.nonceCounter.incrementAndGet();
+        for (int i = nonce.length - 1; i >= this.noncePrefix.length; i--) {
+            nonce[i] = (byte) counter;
+            counter >>>= 8;
+        }
         return nonce;
     }
 
@@ -134,53 +139,32 @@ public class Smb2EncryptionContext {
     public byte[] encryptMessage(final byte[] message, final long sessionId) throws CIFSException {
         try {
             final byte[] nonce = generateNonce();
-            final int flags = getTransformFlags();
 
-            final Smb2TransformHeader transformHeader = new Smb2TransformHeader(nonce, message.length, flags, sessionId);
-            final byte[] associatedData = transformHeader.getAssociatedData();
+            // The transform header carries a 16-byte nonce field; everything beyond the cipher's nonce length must
+            // be zero (MS-SMB2 2.2.41).
+            final byte[] nonceField = new byte[16];
+            System.arraycopy(nonce, 0, nonceField, 0, nonce.length);
 
-            byte[] ciphertext;
-            byte[] authTag;
+            final Smb2TransformHeader transformHeader = new Smb2TransformHeader(nonceField, message.length, getTransformFlags(), sessionId);
 
-            if (isGCMCipher()) {
-                // Use AES-GCM
-                final Cipher cipher = createGCMCipher(true, nonce);
-                cipher.updateAAD(associatedData);
-                final byte[] encrypted = cipher.doFinal(message);
+            final byte[] result = new byte[Smb2TransformHeader.TRANSFORM_HEADER_SIZE + message.length];
 
-                // Split ciphertext and authentication tag
-                final int tagLength = getAuthTagLength();
-                ciphertext = new byte[encrypted.length - tagLength];
-                authTag = new byte[tagLength];
-                System.arraycopy(encrypted, 0, ciphertext, 0, ciphertext.length);
-                System.arraycopy(encrypted, ciphertext.length, authTag, 0, tagLength);
-            } else {
-                // Use AES-CCM with Bouncy Castle
-                final AEADBlockCipher cipher = createCCMCipher(true, nonce, associatedData.length, message.length);
-
-                final byte[] input = new byte[associatedData.length + message.length];
-                System.arraycopy(associatedData, 0, input, 0, associatedData.length);
-                System.arraycopy(message, 0, input, associatedData.length, message.length);
-
-                final byte[] output = new byte[cipher.getOutputSize(input.length)];
-                int len = cipher.processBytes(input, 0, input.length, output, 0);
-                len += cipher.doFinal(output, len);
-
-                // Split ciphertext and authentication tag
-                final int tagLength = getAuthTagLength();
-                ciphertext = new byte[message.length];
-                authTag = new byte[tagLength];
-                System.arraycopy(output, associatedData.length, ciphertext, 0, message.length);
-                System.arraycopy(output, output.length - tagLength, authTag, 0, tagLength);
-            }
-
-            // Set authentication tag in transform header
-            transformHeader.setSignature(authTag);
-
-            // Build final encrypted message
-            final byte[] result = new byte[Smb2TransformHeader.TRANSFORM_HEADER_SIZE + ciphertext.length];
+            // Encode the header first, then authenticate the bytes that actually go on the wire rather than a
+            // reconstruction of the parsed fields. The signature lies before the authenticated region, so it can
+            // be filled in afterwards.
             transformHeader.encode(result, 0);
-            System.arraycopy(ciphertext, 0, result, Smb2TransformHeader.TRANSFORM_HEADER_SIZE, ciphertext.length);
+            final byte[] associatedData =
+                    Arrays.copyOfRange(result, Smb2TransformHeader.AAD_OFFSET, Smb2TransformHeader.TRANSFORM_HEADER_SIZE);
+
+            final AEADBlockCipher cipher = createCipher(true, nonce, associatedData);
+            final byte[] output = new byte[cipher.getOutputSize(message.length)];
+            int len = cipher.processBytes(message, 0, message.length, output, 0);
+            len += cipher.doFinal(output, len);
+
+            final int tagLength = getAuthTagLength();
+            final int ciphertextLength = len - tagLength;
+            System.arraycopy(output, ciphertextLength, result, Smb2TransformHeader.SIGNATURE_OFFSET, tagLength);
+            System.arraycopy(output, 0, result, Smb2TransformHeader.TRANSFORM_HEADER_SIZE, ciphertextLength);
 
             return result;
         } catch (final Exception e) {
@@ -199,48 +183,39 @@ public class Smb2EncryptionContext {
      */
     public byte[] decryptMessage(final byte[] encryptedMessage) throws CIFSException {
         try {
-            // Parse transform header
-            final Smb2TransformHeader transformHeader = Smb2TransformHeader.decode(encryptedMessage, 0);
-            final byte[] associatedData = transformHeader.getAssociatedData();
-            final byte[] nonce = transformHeader.getNonce();
-            final byte[] authTag = transformHeader.getSignature();
-
-            // Extract ciphertext
-            final int ciphertextLength = encryptedMessage.length - Smb2TransformHeader.TRANSFORM_HEADER_SIZE;
-            final byte[] ciphertext = new byte[ciphertextLength];
-            System.arraycopy(encryptedMessage, Smb2TransformHeader.TRANSFORM_HEADER_SIZE, ciphertext, 0, ciphertextLength);
-
-            byte[] plaintext;
-
-            if (isGCMCipher()) {
-                // Use AES-GCM
-                final Cipher cipher = createGCMCipher(false, nonce);
-                cipher.updateAAD(associatedData);
-
-                // Combine ciphertext and auth tag for decryption
-                final byte[] input = new byte[ciphertext.length + authTag.length];
-                System.arraycopy(ciphertext, 0, input, 0, ciphertext.length);
-                System.arraycopy(authTag, 0, input, ciphertext.length, authTag.length);
-
-                plaintext = cipher.doFinal(input);
-            } else {
-                // Use AES-CCM with Bouncy Castle
-                final AEADBlockCipher cipher = createCCMCipher(false, nonce, associatedData.length, ciphertext.length);
-
-                final byte[] input = new byte[associatedData.length + ciphertext.length + authTag.length];
-                System.arraycopy(associatedData, 0, input, 0, associatedData.length);
-                System.arraycopy(ciphertext, 0, input, associatedData.length, ciphertext.length);
-                System.arraycopy(authTag, 0, input, associatedData.length + ciphertext.length, authTag.length);
-
-                final byte[] output = new byte[cipher.getOutputSize(input.length)];
-                int len = cipher.processBytes(input, 0, input.length, output, 0);
-                len += cipher.doFinal(output, len);
-
-                plaintext = new byte[ciphertext.length];
-                System.arraycopy(output, associatedData.length, plaintext, 0, ciphertext.length);
+            if (encryptedMessage.length < Smb2TransformHeader.TRANSFORM_HEADER_SIZE) {
+                throw new CIFSException("Transform message shorter than its header");
             }
 
-            return plaintext;
+            final Smb2TransformHeader transformHeader = Smb2TransformHeader.decode(encryptedMessage, 0);
+            final byte[] authTag = transformHeader.getSignature();
+
+            // Authenticate the bytes exactly as received rather than re-encoding the parsed fields.
+            final byte[] associatedData =
+                    Arrays.copyOfRange(encryptedMessage, Smb2TransformHeader.AAD_OFFSET, Smb2TransformHeader.TRANSFORM_HEADER_SIZE);
+
+            // Only the leading bytes of the 16-byte nonce field are significant for the negotiated cipher.
+            final byte[] nonce = new byte[getNonceLength()];
+            System.arraycopy(transformHeader.getNonce(), 0, nonce, 0, nonce.length);
+
+            final int ciphertextLength = encryptedMessage.length - Smb2TransformHeader.TRANSFORM_HEADER_SIZE;
+            final byte[] input = new byte[ciphertextLength + authTag.length];
+            System.arraycopy(encryptedMessage, Smb2TransformHeader.TRANSFORM_HEADER_SIZE, input, 0, ciphertextLength);
+            System.arraycopy(authTag, 0, input, ciphertextLength, authTag.length);
+
+            final AEADBlockCipher cipher = createCipher(false, nonce, associatedData);
+            final byte[] output = new byte[cipher.getOutputSize(input.length)];
+            int len = cipher.processBytes(input, 0, input.length, output, 0);
+            len += cipher.doFinal(output, len);
+
+            if (len != output.length) {
+                final byte[] exact = new byte[len];
+                System.arraycopy(output, 0, exact, 0, len);
+                return exact;
+            }
+            return output;
+        } catch (final CIFSException e) {
+            throw e;
         } catch (final Exception e) {
             throw new CIFSException("Failed to decrypt message", e);
         }
@@ -248,14 +223,6 @@ public class Smb2EncryptionContext {
 
     private boolean isGCMCipher() {
         return this.cipherId == CIPHER_AES_128_GCM;
-    }
-
-    private int getKeyLength() {
-        // Currently only AES-128 is supported
-        if (this.cipherId == CIPHER_AES_128_CCM || this.cipherId == CIPHER_AES_128_GCM) {
-            return 16;
-        }
-        throw new IllegalArgumentException("Unsupported cipher: " + this.cipherId);
     }
 
     private int getAuthTagLength() {
@@ -270,37 +237,26 @@ public class Smb2EncryptionContext {
         return this.cipherId;
     }
 
-    private Cipher createGCMCipher(final boolean encrypt, final byte[] nonce) throws Exception {
-        final String algorithm = "AES";
-        final SecretKeySpec keySpec = new SecretKeySpec(encrypt ? this.encryptionKey : this.decryptionKey, algorithm);
+    /**
+     * Nonce length in bytes for the negotiated cipher.
+     *
+     * <p>
+     * MS-SMB2 2.2.41: AES-CCM uses an 11-byte nonce and AES-GCM a 12-byte nonce, both carried in a 16-byte field
+     * whose remaining bytes are zero.
+     * </p>
+     *
+     * @return the significant nonce length
+     */
+    public int getNonceLength() {
+        return isGCMCipher() ? 12 : 11;
+    }
 
-        final Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
-        final GCMParameterSpec gcmSpec = new GCMParameterSpec(getAuthTagLength() * 8, nonce);
-        cipher.init(encrypt ? Cipher.ENCRYPT_MODE : Cipher.DECRYPT_MODE, keySpec, gcmSpec);
-
+    private AEADBlockCipher createCipher(final boolean forEncryption, final byte[] nonce, final byte[] associatedData) {
+        final AEADBlockCipher cipher =
+                isGCMCipher() ? GCMBlockCipher.newInstance(AESEngine.newInstance()) : CCMBlockCipher.newInstance(AESEngine.newInstance());
+        final KeyParameter keyParam = new KeyParameter(forEncryption ? this.encryptionKey : this.decryptionKey);
+        cipher.init(forEncryption, new AEADParameters(keyParam, getAuthTagLength() * 8, nonce, associatedData));
         return cipher;
     }
 
-    private AEADBlockCipher createCCMCipher(final boolean encrypt, final byte[] nonce, final int aadLength, final int plaintextLength) {
-        final AEADBlockCipher cipher = new CCMBlockCipher(new AESEngine());
-
-        final KeyParameter keyParam = new KeyParameter(encrypt ? this.encryptionKey : this.decryptionKey);
-        // CCMBlockCipher requires nonce length between 7 and 13
-        final byte[] adjustedNonce = new byte[13];
-        System.arraycopy(nonce, 0, adjustedNonce, 0, Math.min(13, nonce.length));
-
-        final AEADParameters params = new AEADParameters(keyParam, getAuthTagLength() * 8, adjustedNonce, null);
-
-        cipher.init(encrypt, params);
-
-        return cipher;
-    }
-
-    private static byte[] longToBytes(final long value) {
-        final byte[] bytes = new byte[8];
-        for (int i = 0; i < 8; i++) {
-            bytes[i] = (byte) (value >>> 8 * (7 - i));
-        }
-        return bytes;
-    }
 }

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/Smb2TransformHeader.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/Smb2TransformHeader.java
@@ -32,14 +32,33 @@ import org.codelibs.jcifs.smb.internal.util.SMBUtil;
 public class Smb2TransformHeader implements Encodable {
 
     /**
-     * Transform header protocol identifier: 0xFD534D42 (0xFD 'S' 'M' 'B')
+     * Transform header protocol identifier.
+     *
+     * <p>
+     * MS-SMB2 2.2.41 defines the value as 0x424D53FD, which is 0xFD, 'S', 'M', 'B' in network order. The header is
+     * encoded little-endian, so the constant must hold the numeric value rather than the wire byte sequence.
+     * </p>
      */
-    public static final int TRANSFORM_PROTOCOL_ID = 0xFD534D42;
+    public static final int TRANSFORM_PROTOCOL_ID = 0x424D53FD;
 
     /**
      * Size of the transform header in bytes
      */
     public static final int TRANSFORM_HEADER_SIZE = 52;
+
+    /**
+     * Offset of the Nonce field within the transform header. The additional authenticated data for the AEAD cipher
+     * starts here (MS-SMB2 3.1.4.3).
+     */
+    /** Offset of the Signature field within the transform header. */
+    public static final int SIGNATURE_OFFSET = 4;
+
+    public static final int AAD_OFFSET = 20;
+
+    /**
+     * Size of the additional authenticated data: the transform header from the Nonce field to the end.
+     */
+    public static final int AAD_SIZE = TRANSFORM_HEADER_SIZE - AAD_OFFSET;
 
     private final byte[] signature = new byte[16];
     private final byte[] nonce = new byte[16];
@@ -261,20 +280,18 @@ public class Smb2TransformHeader implements Encodable {
     }
 
     /**
-     * Get the associated data for AEAD encryption (everything except signature)
+     * Get the additional authenticated data for the AEAD cipher.
      *
-     * @return byte array containing associated data
+     * <p>
+     * Per MS-SMB2 3.1.4.3 this is the transform header from the Nonce field to the end of the header, i.e. bytes 20
+     * through 51 inclusive. The ProtocolId and Signature fields are not covered.
+     * </p>
+     *
+     * @return the 32-byte additional authenticated data
      */
     public byte[] getAssociatedData() {
-        final byte[] aad = new byte[52]; // Use full header size to ensure all data fits
+        final byte[] aad = new byte[AAD_SIZE];
         int index = 0;
-
-        // Protocol ID
-        SMBUtil.writeInt4(TRANSFORM_PROTOCOL_ID, aad, index);
-        index += 4;
-
-        // Skip signature (16 bytes of zeros for AAD)
-        index += 16;
 
         // Nonce
         System.arraycopy(this.nonce, 0, aad, index, 16);

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbTransportImplTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbTransportImplTest.java
@@ -401,11 +401,21 @@ class SmbTransportImplTest {
             assertEquals(EncryptionNegotiateContext.CIPHER_AES128_CCM, ccm.getCipherId());
             assertEquals(DialectVersion.SMB300, ccm.getDialect());
 
-            // SMB 3.1.1 -> default AES-128-GCM when server did not choose
+            // SMB 3.1.1 with no encryption capabilities context in the response -> AES-128-CCM
+            // (MS-SMB2 3.2.5.2). In practice the negotiate would have been rejected before reaching here.
             Smb2NegotiateResponse smb311 = new Smb2NegotiateResponse(cfg);
             setField(smb311, "selectedDialect", DialectVersion.SMB311);
             setField(smb311, "selectedCipher", -1);
             setField(transport, "negotiated", smb311);
+            Smb2EncryptionContext defaulted = transport.createEncryptionContext(sessionKey, preauth);
+            assertEquals(EncryptionNegotiateContext.CIPHER_AES128_CCM, defaulted.getCipherId());
+            assertEquals(DialectVersion.SMB311, defaulted.getDialect());
+
+            // SMB 3.1.1 with AES-128-GCM negotiated
+            Smb2NegotiateResponse smb311gcm = new Smb2NegotiateResponse(cfg);
+            setField(smb311gcm, "selectedDialect", DialectVersion.SMB311);
+            setField(smb311gcm, "selectedCipher", EncryptionNegotiateContext.CIPHER_AES128_GCM);
+            setField(transport, "negotiated", smb311gcm);
             Smb2EncryptionContext gcm = transport.createEncryptionContext(sessionKey, preauth);
             assertEquals(EncryptionNegotiateContext.CIPHER_AES128_GCM, gcm.getCipherId());
             assertEquals(DialectVersion.SMB311, gcm.getDialect());

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb2EncryptionContextTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb2EncryptionContextTest.java
@@ -183,8 +183,9 @@ class Smb2EncryptionContextTest {
         // Then
         assertNotNull(nonce1, "First nonce should not be null");
         assertNotNull(nonce2, "Second nonce should not be null");
-        assertEquals(16, nonce1.length, "Nonce should be 16 bytes");
-        assertEquals(16, nonce2.length, "Nonce should be 16 bytes");
+        // MS-SMB2 2.2.41: AES-CCM uses 11 bytes, AES-GCM 12; the 16-byte header field is zero-padded.
+        assertEquals(encryptionContext.getNonceLength(), nonce1.length, "Nonce should match the cipher nonce length");
+        assertEquals(encryptionContext.getNonceLength(), nonce2.length, "Nonce should match the cipher nonce length");
         assertFalse(java.util.Arrays.equals(nonce1, nonce2), "Consecutive nonces should be different");
     }
 

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb2MessageEncryptFlagTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb2MessageEncryptFlagTest.java
@@ -1,0 +1,92 @@
+/*
+ * © 2026 CodeLibs, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package org.codelibs.jcifs.smb.internal.smb2;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.codelibs.jcifs.smb.Configuration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that the "this message must be encrypted" marker follows a compound chain.
+ *
+ * <p>
+ * A compound request is wrapped in a single SMB2 TRANSFORM_HEADER, so the decision has to be visible from the head of
+ * the chain regardless of which link it was set on.
+ * </p>
+ */
+class Smb2MessageEncryptFlagTest {
+
+    private Configuration config;
+
+    @BeforeEach
+    void setUp() {
+        this.config = mock(Configuration.class);
+        when(this.config.getMaximumBufferSize()).thenReturn(0x10000);
+    }
+
+    private ServerMessageBlock2 message() {
+        return new ServerMessageBlock2(this.config, ServerMessageBlock2.SMB2_CREATE) {
+            @Override
+            protected int writeBytesWireFormat(final byte[] dst, final int dstIndex) {
+                return 0;
+            }
+
+            @Override
+            protected int readBytesWireFormat(final byte[] buffer, final int bufferIndex) {
+                return 0;
+            }
+        };
+    }
+
+    @Test
+    @DisplayName("messages are not encrypted by default")
+    void notEncryptedByDefault() {
+        assertFalse(message().isEncrypt(), "a message must not be encrypted unless something requires it");
+    }
+
+    @Test
+    @DisplayName("setting the encrypt marker propagates to already-chained messages")
+    void propagatesToChainedMessages() {
+        final ServerMessageBlock2 head = message();
+        final ServerMessageBlock2 tail = message();
+        head.chain(tail);
+
+        head.setEncrypt(true);
+
+        assertTrue(head.isEncrypt(), "head must be marked");
+        assertTrue(tail.isEncrypt(), "chained message must inherit the marker");
+    }
+
+    @Test
+    @DisplayName("a chained message inherits an encrypt marker set before chaining")
+    void inheritsMarkerSetBeforeChaining() {
+        final ServerMessageBlock2 head = message();
+        head.setEncrypt(true);
+
+        final ServerMessageBlock2 tail = message();
+        head.chain(tail);
+
+        assertTrue(tail.isEncrypt(), "chaining onto an encrypted head must mark the new message");
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb2TransformHeaderTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb2TransformHeaderTest.java
@@ -125,11 +125,11 @@ class Smb2TransformHeaderTest extends BaseTest {
         // Then
         assertEquals(52, encoded);
 
-        // Verify protocol ID (first 4 bytes) - 0xFD534D42 in little-endian
-        assertEquals((byte) 0x42, buffer[0]);
-        assertEquals((byte) 0x4D, buffer[1]);
-        assertEquals((byte) 0x53, buffer[2]);
-        assertEquals((byte) 0xFD, buffer[3]);
+        // Verify protocol ID (first 4 bytes) - MS-SMB2 2.2.41: 0xFD, 'S', 'M', 'B' in network order
+        assertEquals((byte) 0xFD, buffer[0]);
+        assertEquals((byte) 'S', buffer[1]);
+        assertEquals((byte) 'M', buffer[2]);
+        assertEquals((byte) 'B', buffer[3]);
     }
 
     @Test
@@ -139,11 +139,11 @@ class Smb2TransformHeaderTest extends BaseTest {
         byte[] buffer = new byte[52];
         int index = 0;
 
-        // Protocol ID - 0xFD534D42 in little-endian
-        buffer[index++] = (byte) 0x42;
-        buffer[index++] = (byte) 0x4D;
-        buffer[index++] = (byte) 0x53;
+        // Protocol ID - MS-SMB2 2.2.41: 0xFD, 'S', 'M', 'B' in network order
         buffer[index++] = (byte) 0xFD;
+        buffer[index++] = (byte) 'S';
+        buffer[index++] = (byte) 'M';
+        buffer[index++] = (byte) 'B';
 
         // Signature (16 bytes)
         byte[] signature = new byte[16];
@@ -351,22 +351,20 @@ class Smb2TransformHeaderTest extends BaseTest {
         byte[] aad = transformHeader.getAssociatedData();
 
         // Then
-        assertEquals(52, aad.length); // AAD should be same size as transform header
+        // MS-SMB2 3.1.4.3: the AAD is the transform header from the Nonce field to the end, i.e. 32 bytes.
+        // ProtocolId and Signature are NOT covered.
+        assertEquals(32, aad.length);
 
-        // Verify protocol ID (first 4 bytes) - 0xFD534D42 in little-endian
-        assertEquals((byte) 0x42, aad[0]);
-        assertEquals((byte) 0x4D, aad[1]);
-        assertEquals((byte) 0x53, aad[2]);
-        assertEquals((byte) 0xFD, aad[3]);
-
-        // Verify signature is zeroed out (16 bytes of zeros)
-        for (int i = 4; i < 20; i++) {
-            assertEquals(0, aad[i], "Signature bytes should be zero in AAD");
+        // Verify nonce is at the start of the AAD
+        for (int i = 0; i < 16; i++) {
+            assertEquals(testNonce[i], aad[i], "Nonce should match at position " + i);
         }
 
-        // Verify nonce matches at position 20
-        for (int i = 0; i < 16; i++) {
-            assertEquals(testNonce[i], aad[20 + i], "Nonce should match at position " + (20 + i));
+        // The AAD must be byte-identical to bytes 20..51 of the encoded header
+        byte[] encoded = new byte[52];
+        transformHeader.encode(encoded, 0);
+        for (int i = 0; i < 32; i++) {
+            assertEquals(encoded[20 + i], aad[i], "AAD must mirror encoded header byte " + (20 + i));
         }
     }
 

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb3EncryptionInteropTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb3EncryptionInteropTest.java
@@ -1,0 +1,181 @@
+/*
+ * © 2026 CodeLibs, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package org.codelibs.jcifs.smb.internal.smb2;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.codelibs.jcifs.smb.DialectVersion;
+import org.codelibs.jcifs.smb.internal.smb2.nego.EncryptionNegotiateContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Interoperability tests for SMB3 transform (encryption) handling.
+ *
+ * <p>
+ * The AES-128-GCM vector below is a real SMB2 TREE_CONNECT response captured from Samba 4.23.8 with
+ * {@code smb encrypt = required}. Unlike a self round-trip, it fails if this implementation disagrees with a real
+ * server about the transform header layout, the additional authenticated data or the nonce length. The keys are
+ * throw-away material from a local test container.
+ * </p>
+ */
+class Smb3EncryptionInteropTest {
+
+    /** SMB2 TRANSFORM_HEADER + ciphertext, exactly as Samba 4.23.8 put it on the wire. */
+    private static final String SAMBA_TRANSFORM_MESSAGE = "fd534d42166b7cb493b2c0e8e7b99057dbe62335"
+            + "01000000000000001143ba84000000004900000000000100e5fbad4c00000000" + "0eba618e39cd4c9860faeb1abcaca826b3d14657"
+            + "f32fe842c6a1b34922a4dc1f2ce828ed149863300b3c8c6b004f15f930f772cc" + "ae4a14778fae80aa393ae2af6e82be2835231aa539";
+
+    /** Session-to-client cipher key derived for that session. */
+    private static final String SAMBA_DECRYPTION_KEY = "53A4662E590F584E41FFD762E053925D";
+
+    /** The same, for an AES-128-CCM session: Samba 4.23.8 negotiated down to SMB 3.0.2. */
+    private static final String SAMBA_CCM_TRANSFORM_MESSAGE =
+            "fd534d42e0cef907f6d23d0d9013598a442d6d44" + "0100000000000000f961e0000000000050000000000001009de9b57700000000"
+                    + "36ad7e5afc598b2ae698e590bc277a9b48d63336" + "874c61a11bba9d78e90f47e5e93661bf4ebf6181ba987be3a47a0466158aabb3"
+                    + "ed8c56a843f7480930a252e8ad6378bfee7d19c3a4386b04df7594c8";
+
+    private static final String SAMBA_CCM_DECRYPTION_KEY = "666A4C38B330CF2467D12D1CFA8EF6C6";
+
+    private static final String SAMBA_CCM_PLAINTEXT = "FE534D42400000000000000003000100" + "01000000000000000400000000000000"
+            + "00000000B650A9279DE9B57700000000" + "00000000000000000000000000000000" + "100001000080000000000000FF011F00";
+
+    /** The plaintext Samba encrypted: an SMB2 TREE_CONNECT response carrying STATUS_ACCESS_DENIED. */
+    private static final String SAMBA_PLAINTEXT = "FE534D4240000000220000C003000100" + "09000000000000000400000000000000"
+            + "0000000000000000E5FBAD4C00000000" + "106E3667B09BE2591D9079FFDCAE58AB" + "090000000000000000";
+
+    private static byte[] hex(final String s) {
+        final byte[] out = new byte[s.length() / 2];
+        for (int i = 0; i < out.length; i++) {
+            out[i] = (byte) Integer.parseInt(s.substring(2 * i, 2 * i + 2), 16);
+        }
+        return out;
+    }
+
+    private static byte[] sampleMessage(final int len) {
+        final byte[] msg = new byte[len];
+        for (int i = 0; i < len; i++) {
+            msg[i] = (byte) (0x40 + i % 0x50);
+        }
+        return msg;
+    }
+
+    @Test
+    @DisplayName("decrypts a transform message produced by a real SMB3 server")
+    void decryptsRealServerTransformMessage() throws Exception {
+        final byte[] key = hex(SAMBA_DECRYPTION_KEY);
+        final Smb2EncryptionContext ctx =
+                new Smb2EncryptionContext(EncryptionNegotiateContext.CIPHER_AES128_GCM, DialectVersion.SMB311, key, key);
+
+        final byte[] plaintext = ctx.decryptMessage(hex(SAMBA_TRANSFORM_MESSAGE));
+
+        assertArrayEquals(hex(SAMBA_PLAINTEXT), plaintext, "decrypted payload must match the SMB2 message Samba sent");
+    }
+
+    @Test
+    @DisplayName("decrypts an AES-128-CCM transform message produced by a real SMB3 server")
+    void decryptsRealServerCcmTransformMessage() throws Exception {
+        final byte[] key = hex(SAMBA_CCM_DECRYPTION_KEY);
+        final Smb2EncryptionContext ctx =
+                new Smb2EncryptionContext(EncryptionNegotiateContext.CIPHER_AES128_CCM, DialectVersion.SMB302, key, key);
+
+        final byte[] plaintext = ctx.decryptMessage(hex(SAMBA_CCM_TRANSFORM_MESSAGE));
+
+        assertArrayEquals(hex(SAMBA_CCM_PLAINTEXT), plaintext, "decrypted payload must match the SMB2 message Samba sent");
+    }
+
+    @Test
+    @DisplayName("writes the transform protocol id in network byte order")
+    void writesProtocolIdInNetworkByteOrder() throws Exception {
+        final byte[] key = new byte[16];
+        final Smb2EncryptionContext ctx =
+                new Smb2EncryptionContext(EncryptionNegotiateContext.CIPHER_AES128_GCM, DialectVersion.SMB311, key, key);
+
+        final byte[] wire = ctx.encryptMessage(sampleMessage(73), 0x1122334455667788L);
+
+        assertEquals((byte) 0xFD, wire[0], "byte 0 must be 0xFD");
+        assertEquals((byte) 'S', wire[1], "byte 1 must be 'S'");
+        assertEquals((byte) 'M', wire[2], "byte 2 must be 'M'");
+        assertEquals((byte) 'B', wire[3], "byte 3 must be 'B'");
+    }
+
+    @Test
+    @DisplayName("AES-128-CCM decrypts what it encrypted")
+    void aesCcmRoundTrips() throws Exception {
+        final byte[] key = hex("000102030405060708090A0B0C0D0E0F");
+        final Smb2EncryptionContext ctx =
+                new Smb2EncryptionContext(EncryptionNegotiateContext.CIPHER_AES128_CCM, DialectVersion.SMB300, key, key);
+
+        final byte[] message = sampleMessage(73);
+        final byte[] wire = ctx.encryptMessage(message, 0x1122334455667788L);
+
+        assertArrayEquals(message, ctx.decryptMessage(wire), "AES-128-CCM must round-trip");
+    }
+
+    @Test
+    @DisplayName("AES-128-GCM decrypts what it encrypted")
+    void aesGcmRoundTrips() throws Exception {
+        final byte[] key = hex("000102030405060708090A0B0C0D0E0F");
+        final Smb2EncryptionContext ctx =
+                new Smb2EncryptionContext(EncryptionNegotiateContext.CIPHER_AES128_GCM, DialectVersion.SMB311, key, key);
+
+        final byte[] message = sampleMessage(512);
+        final byte[] wire = ctx.encryptMessage(message, 0x1122334455667788L);
+
+        assertArrayEquals(message, ctx.decryptMessage(wire), "AES-128-GCM must round-trip");
+    }
+
+    @Test
+    @DisplayName("zero-pads the nonce field beyond the cipher nonce length")
+    void zeroPadsNonceField() throws Exception {
+        final byte[] key = new byte[16];
+
+        final Smb2EncryptionContext gcm =
+                new Smb2EncryptionContext(EncryptionNegotiateContext.CIPHER_AES128_GCM, DialectVersion.SMB311, key, key);
+        final byte[] gcmWire = gcm.encryptMessage(sampleMessage(64), 1L);
+        for (int i = 20 + 12; i < 20 + 16; i++) {
+            assertEquals(0, gcmWire[i], "AES-128-GCM nonce byte " + (i - 20) + " must be zero");
+        }
+
+        final Smb2EncryptionContext ccm =
+                new Smb2EncryptionContext(EncryptionNegotiateContext.CIPHER_AES128_CCM, DialectVersion.SMB300, key, key);
+        final byte[] ccmWire = ccm.encryptMessage(sampleMessage(64), 1L);
+        for (int i = 20 + 11; i < 20 + 16; i++) {
+            assertEquals(0, ccmWire[i], "AES-128-CCM nonce byte " + (i - 20) + " must be zero");
+        }
+    }
+
+    @Test
+    @DisplayName("never repeats a nonce for the same key")
+    void neverRepeatsNonce() throws Exception {
+        final byte[] key = new byte[16];
+        final Smb2EncryptionContext ctx =
+                new Smb2EncryptionContext(EncryptionNegotiateContext.CIPHER_AES128_GCM, DialectVersion.SMB311, key, key);
+
+        final java.util.Set<String> seen = new java.util.HashSet<>();
+        for (int i = 0; i < 2000; i++) {
+            final byte[] wire = ctx.encryptMessage(sampleMessage(16), 1L);
+            final StringBuilder sb = new StringBuilder();
+            for (int j = 20; j < 36; j++) {
+                sb.append(String.format("%02X", wire[j]));
+            }
+            assertEquals(true, seen.add(sb.toString()), "nonce repeated after " + i + " messages");
+        }
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/it/EncryptionIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/EncryptionIT.java
@@ -28,7 +28,6 @@ import java.util.Random;
 import org.codelibs.jcifs.smb.CIFSContext;
 import org.codelibs.jcifs.smb.impl.SmbFile;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -84,7 +83,6 @@ class EncryptionIT extends AbstractSmbIT {
     }
 
     @Test
-    @Disabled("#71/#70: SMB3 transform encryption is not wired up on main. The server accepts the tree connect and then never answers SMB2_CREATE, so this times out. PR #92 is the pending fix - enable this once it merges.")
     @DisplayName("small payloads round trip through the encrypted share")
     void smallPayloadRoundTrips() throws Exception {
         final CIFSContext context = server().context(encrypting());
@@ -98,7 +96,6 @@ class EncryptionIT extends AbstractSmbIT {
     }
 
     @Test
-    @Disabled("#71/#70: SMB3 transform encryption is not wired up on main. The server accepts the tree connect and then never answers SMB2_CREATE, so this times out. PR #92 is the pending fix - enable this once it merges.")
     @DisplayName("a payload larger than one transform round trips through the encrypted share")
     void largePayloadRoundTrips() throws Exception {
         final CIFSContext context = server().context(encrypting());


### PR DESCRIPTION
Fixes #70. Fixes #71.

SMB3 encryption was advertised during negotiation but never wired into the transport. `Smb2EncryptionContext` was constructed and then never used — `encryptMessage`/`decryptMessage` had no callers outside tests — so a server that required encryption could not be talked to at all. The two issues are the same root cause seen from different angles.

## What was broken

**Session key ordering (#70).** The encryption context was derived from `this.sessionKey` before that field was assigned, so the SP800-108 KDF was always seeded with `null`:

```
SmbAuthException: Failed to setup required encryption
  Caused by: CIFSException: Failed to create encryption context
  Caused by: IllegalArgumentException: A KDF requires Ki (a seed) as input
```

**Per-share encryption (#71).** `SMB2_SHAREFLAG_ENCRYPT_DATA` was declared but never read, so a share requiring encryption while the session did not was unsupported.

**Transform framing.** `peekKey()` recognised only `0xFE 'SMB'` and `0xFF 'SMB'`. A transform header was mistaken for a desynchronised stream, so the client advanced one byte at a time and the request hung until `responseTimeout` — worse than a clean error. Fixing the key ordering alone would have converted #70's explicit exception into that hang, which is why both halves land together.

**Cipher conformance.** Even once wired up, the primitives could not interoperate:

| | before | MS-SMB2 |
|---|---|---|
| ProtocolId on the wire | `42 4D 53 FD` | `FD 53 4D 42` (2.2.41) |
| Additional authenticated data | 52 bytes, whole header | 32 bytes, Nonce→end (3.1.4.3) |
| AES-128-GCM nonce | 16 bytes | 12, zero-padded in a 16-byte field |
| AES-128-CCM nonce | 13 bytes | 11, zero-padded |
| AES-128-CCM AAD | prepended to plaintext, none passed to the cipher | passed as AAD |

The ProtocolId constant held the network byte order and was then written little-endian, double-reversing it. AES-128-CCM — the only cipher for SMB 3.0/3.0.2 — could not decrypt even its own output (`mac check in CCM failed`).

## What changed

- `peekKey()` recognises `0xFD 'SMB'`, resolves the session from the transform header's `SessionId`, decrypts, and returns the message id read from the *decrypted* SMB2 header. `doRecvSMB2` then consumes the plaintext, including compounded responses. This keeps the existing `peekKey`→`doRecv` contract rather than restructuring `Transport` for every subclass.
- `doSend` wraps outgoing messages, covering whole compound chains.
- Encryption is marked per message and propagates along a compound chain; `SmbSessionImpl.send` sets it from the session flag, `SmbTreeImpl.send` from the share flag.
- Encrypted messages are not signed and their signatures are not verified — the AEAD tag authenticates them (3.1.4.1). The session id in the decrypted header is checked against the transform header (3.2.5.1.1).
- A tree connect no longer compounds the caller's request when encryption is available: the share's requirement is only learned from the response, while the tree connect itself travels in the clear.
- Where encryption is required but unavailable, the client fails with a clear error instead of hanging or silently sending plaintext.

Encryption remains opt-in via `jcifs.client.encryptionEnabled` (default `false`). The unencrypted path is untouched — `readMessageBytes`/`skipMessageBytes` delegate to the previous socket reads whenever no transform payload is in flight.

## Testing

`Smb3EncryptionInteropTest` decrypts a TREE_CONNECT response captured from a real Samba 4.23.8 server, so it fails if this implementation disagrees with a real server rather than merely with itself. This matters because the previous tests never called `encryptMessage` or `decryptMessage` at all, which is why none of the above was caught.

Four of the existing assertions pinned the buggy behaviour (52-byte AAD, reversed ProtocolId, 16-byte nonce) and were corrected to the spec.

Verified against Samba 4.23.8:

| Scenario | Result |
|---|---|
| Session-required, SMB 3.1.1 / AES-128-GCM | works |
| Session-required, SMB 3.0.2 / AES-128-CCM | works |
| Share-required only, session flag clear (#71) | works; a non-encrypted share on the same connection stays plaintext |
| Unencrypted path, SMB 2.0.2 / 2.1 / 3.0 / 3.1.1 | unchanged |
| Encryption required but unavailable | fails immediately with a clear error |

Each includes a 200 KB write and read-back with content verification, plus 300 sequential writes, directory create/rename/delete, and 8 concurrent threads doing write-and-verify. The full unit suite passes.

## Notes for review

- The reauthentication path (`NT_STATUS_NETWORK_SESSION_EXPIRED`) is handled — the request is no longer compounded onto the cleartext session setup, and the encryption context is rebuilt because the server regenerates its keys — but I could not trigger session expiry against Samba, so that path is reasoned rather than exercised.
- If a transform frame arrives for a session that is no longer registered, or fails to decrypt, the transport is torn down rather than the single frame being skipped. That fails closed, but it is a behavioural difference from an unknown plaintext message id, which is skipped.
- Only AES-128-GCM and AES-128-CCM are negotiated, so the AES-256 variants are not implemented.
