### PR TITLE
test(it): run the SMB integration tests against Samba and real Windows

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,8 +6,9 @@ name: Java CI with Maven
 on:
   push:
     branches: [ main ]
+  # No base branch filter: a pull request stacked on another branch needs the
+  # same checks as one aimed straight at main.
   pull_request:
-    branches: [ main ]
 
 jobs:
   build:
@@ -22,4 +23,12 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      # verify also runs the *IT integration tests, which start a Samba
+      # container. JCIFS_IT_REQUIRED makes a missing or unusable environment a
+      # failure rather than a silent skip.
+      run: mvn -B verify --file pom.xml
+      env:
+        JCIFS_IT_REQUIRED: "true"
+    - name: Check that the integration tests actually ran
+      if: always()
+      run: python3 build_helpers/check-it-reports.py

--- a/.github/workflows/smb-it-windows.yml
+++ b/.github/workflows/smb-it-windows.yml
@@ -1,0 +1,67 @@
+# Runs the SMB integration tests against a real Windows SMB server.
+#
+# windows-latest is Windows Server 2025 and the runner has administrator rights
+# with UAC disabled, so the job can create shares, mandate encryption and install
+# the DFS Namespaces role. Nothing here needs a virtual machine.
+#
+# Runs on pull requests alongside the Samba build. windows-latest is a standard
+# GitHub-hosted runner and free on public repositories, and this job is what
+# catches behaviour only a real Windows server exhibits - encryption interop, DFS
+# referrals, reparse points. The nightly run stays so that drift in the runner
+# image surfaces even when no pull request is open.
+
+name: SMB integration tests (Windows)
+
+on:
+  push:
+    branches: [ main ]
+  # No base branch filter: a pull request stacked on another branch needs the
+  # same checks as one aimed straight at main.
+  pull_request:
+  schedule:
+    - cron: '0 17 * * *'
+  workflow_dispatch:
+
+jobs:
+  windows-smb:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+
+    - name: Configure the SMB server
+      shell: pwsh
+      run: |
+        ./build_helpers/win-setup.ps1
+        "JCIFS_IT_HOST=$env:COMPUTERNAME" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+    - name: Run the integration tests
+      run: mvn -B verify --file pom.xml
+      env:
+        JCIFS_IT_BACKEND: windows
+        JCIFS_IT_USER: testuser1
+        # Throwaway credential, only valid on this runner for the life of the job.
+        JCIFS_IT_PASSWORD: 'Public-Fixture-Not-A-Secret-1!'
+        JCIFS_IT_REQUIRED: "true"
+
+    - name: Check that the integration tests actually ran
+      if: always()
+      shell: bash
+      run: python build_helpers/check-it-reports.py
+
+    - name: Upload test reports
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: windows-smb-test-reports
+        path: |
+          target/failsafe-reports/
+          target/surefire-reports/

--- a/README.md
+++ b/README.md
@@ -283,6 +283,64 @@ mvn verify
 mvn jacoco:report
 ```
 
+#### Integration tests against a real SMB server
+
+`mvn verify` also runs the `*IT` tests in `src/test/java/org/codelibs/jcifs/smb/it`,
+which talk to an actual SMB server. Two backends are supported and the same tests
+run against both.
+
+**Samba (default, no setup needed).** With Docker available, the harness builds
+and starts the container defined in `build_helpers/samba/` and points the tests at
+it. Nothing else is required:
+
+```bash
+mvn verify
+```
+
+That publishes Samba on a mapped port. A DFS referral names a host but no port,
+so the DFS tests skip unless the server answers on 445. The harness tries 445
+first and falls back, so on a machine already using that port Testcontainers logs
+one failed container start before the run continues normally. To run them anyway - on a
+machine whose own 445 is taken, for instance - put the server and the test JVM on
+the same Docker network:
+
+```bash
+./build_helpers/run-it-with-dfs.sh
+```
+
+**A real Windows server.** Run `build_helpers/win-setup.ps1` on the Windows
+machine to create the shares, symlinks and DFS namespace, then point the tests at
+it:
+
+```bash
+JCIFS_IT_BACKEND=windows \
+JCIFS_IT_HOST=<the Windows computer name> \
+JCIFS_IT_USER=testuser1 \
+JCIFS_IT_PASSWORD=<the password passed to win-setup.ps1> \
+mvn verify
+```
+
+This is what the nightly `SMB integration tests (Windows)` workflow does on a
+`windows-latest` runner, which is a Windows Server 2025 host.
+
+| Variable | Meaning |
+|---|---|
+| `JCIFS_IT_BACKEND` | `samba` or `windows`; unset starts the container |
+| `JCIFS_IT_HOST`, `JCIFS_IT_PORT` | where the server is; port defaults to 445 |
+| `JCIFS_IT_USER`, `JCIFS_IT_PASSWORD`, `JCIFS_IT_DOMAIN` | credentials |
+| `JCIFS_IT_SHARE`, `JCIFS_IT_SHARE_ENCRYPTED`, `JCIFS_IT_DFS_ROOT` | share names |
+| `JCIFS_IT_REQUIRED` | `true` makes a missing environment a failure instead of a skip |
+
+Before any test runs, a preflight check confirms the server is configured the way
+the tests assume - in particular that the encrypted share really does reject a
+client that cannot encrypt, and that a pinned dialect is actually honoured.
+Without those checks a green run would not mean much.
+
+Some tests skip by design: DFS referrals name a host but no port, so they only
+run when the server answers on 445 (a development machine that is already sharing
+files will skip them), and tests marked `@RequiresBackend` run on one backend
+only.
+
 ## ⚡ Performance Considerations
 
 ### Connection Management

--- a/build_helpers/check-it-reports.py
+++ b/build_helpers/check-it-reports.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Guards against an integration test run that passed without running anything.
+
+Failsafe reports success when its provider discovers no tests at all, which is
+exactly what happened while the JUnit 4 provider was being auto-detected: a green
+build that exercised nothing. This reads the reports back and fails if no
+integration test actually executed.
+
+It also writes the skipped tests and their reasons to the job summary, so
+disabled tests stay visible instead of quietly accumulating.
+"""
+import glob
+import os
+import sys
+
+# The only input is the failsafe report the same job just produced, so the
+# stdlib parser is fine here.
+import xml.etree.ElementTree as ET
+
+REPORT_GLOB = os.path.join("target", "failsafe-reports", "TEST-*.xml")
+
+
+def main() -> int:
+    reports = sorted(glob.glob(REPORT_GLOB))
+    if not reports:
+        print("No failsafe reports found at " + REPORT_GLOB, file=sys.stderr)
+        return 1
+
+    total = 0
+    skipped = 0
+    skipped_details = []
+
+    for report in reports:
+        root = ET.parse(report).getroot()
+        total += int(root.get("tests", "0"))
+        skipped += int(root.get("skipped", "0"))
+        for case in root.iter("testcase"):
+            marker = case.find("skipped")
+            if marker is None:
+                continue
+            name = "{}.{}".format(case.get("classname", "?"), case.get("name", "?"))
+            skipped_details.append((name, marker.get("message", "").strip()))
+
+    executed = total - skipped
+    print("integration tests: {} executed, {} skipped, across {} classes".format(executed, skipped, len(reports)))
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path and skipped_details:
+        with open(summary_path, "a", encoding="utf-8") as summary:
+            summary.write("\n### Skipped integration tests\n\n")
+            for name, message in sorted(skipped_details):
+                summary.write("- `{}` - {}\n".format(name, message or "no reason given"))
+
+    if executed <= 0:
+        print("No integration test actually executed.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build_helpers/run-it-with-dfs.sh
+++ b/build_helpers/run-it-with-dfs.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Runs the SMB integration tests against Samba listening on port 445 inside a
+# Docker network, with the test JVM on the same network.
+#
+# Plain "mvn verify" publishes Samba on a mapped port, and a DFS referral names a
+# host but no port, so the DFS tests skip there. This script gives the server the
+# default port inside the network instead, which lets them run even when the
+# host's own 445 is taken - a Mac with file sharing on, for instance.
+#
+# Any extra arguments are passed to Maven, e.g.
+#   ./build_helpers/run-it-with-dfs.sh -Dit.test=DfsIT
+set -euo pipefail
+
+NETWORK=jcifs-it-net
+CONTAINER=jcifs-it-samba-net
+IMAGE=jcifs-it-samba:local
+MAVEN_IMAGE=${MAVEN_IMAGE:-maven:3.9-eclipse-temurin-17}
+PROJECT_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+
+cleanup() {
+    docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+    docker network rm "$NETWORK" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+docker build -t "$IMAGE" "$PROJECT_ROOT/build_helpers/samba"
+docker network create "$NETWORK" >/dev/null 2>&1 || true
+
+# The DFS links have to name the host the client will reach, which inside the
+# network is the container's alias.
+docker run -d --name "$CONTAINER" --network "$NETWORK" --network-alias samba \
+    -e SMB_DFS_TARGET_HOST=samba "$IMAGE" >/dev/null
+
+# The preflight polls until the server answers, so there is nothing to wait for
+# here. Running as the invoking user keeps target/ owned by them.
+docker run --rm --network "$NETWORK" \
+    -v "$PROJECT_ROOT":/work -w /work \
+    -v "$HOME/.m2":/var/maven/.m2 \
+    -u "$(id -u):$(id -g)" \
+    -e MAVEN_CONFIG=/var/maven/.m2 \
+    -e JCIFS_IT_BACKEND=samba \
+    -e JCIFS_IT_HOST=samba \
+    -e JCIFS_IT_PORT=445 \
+    -e JCIFS_IT_USER=testuser1 \
+    -e JCIFS_IT_REQUIRED=true \
+    "$MAVEN_IMAGE" \
+    mvn -B -Duser.home=/var/maven verify "$@"

--- a/build_helpers/samba/Dockerfile
+++ b/build_helpers/samba/Dockerfile
@@ -1,0 +1,16 @@
+# Samba backend for the jcifs SMB integration tests.
+#
+# Pinned to an Alpine release rather than a floating tag so the Samba version
+# only moves when this file moves. Multi-arch, so the same image builds on the
+# amd64 CI runners and on arm64 development machines.
+FROM alpine:3.22
+
+RUN apk add --no-cache samba-server samba-client samba-common-tools
+
+COPY smb.conf /etc/samba/smb.conf
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+EXPOSE 445
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/build_helpers/samba/entrypoint.sh
+++ b/build_helpers/samba/entrypoint.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+#
+# Creates the fixture layout that the jcifs integration tests expect and then
+# runs smbd in the foreground. The layout mirrors build_helpers/win-setup.ps1 so
+# that the same tests can run against either backend.
+set -eu
+
+PASSWORD="${SMB_TEST_PASSWORD:-Public-Fixture-Not-A-Secret-1!}"
+DFS_TARGET_HOST="${SMB_DFS_TARGET_HOST:-localhost}"
+
+for share in share share-encrypted dfs public users testuser1private testuser2private; do
+    mkdir -p "/srv/${share}"
+    chmod 0777 "/srv/${share}"
+done
+
+# Deliberately outside every share, so a symlink pointing here crosses the
+# share boundary.
+mkdir -p /srv/outside
+chmod 0777 /srv/outside
+
+mkdir -p /var/log/samba /var/lib/samba/private
+
+for user in testuser1 testuser2; do
+    adduser -D -H -s /sbin/nologin "${user}"
+    printf '%s\n%s\n' "${PASSWORD}" "${PASSWORD}" | smbpasswd -a -s "${user}"
+    smbpasswd -e "${user}"
+done
+
+# ---------------------------------------------------------------- fixtures --
+printf 'target file contents\n' > /srv/share/target.txt
+mkdir -p /srv/share/subdir
+printf 'inside subdir\n' > /srv/share/subdir/inside.txt
+printf 'outside the share\n' > /srv/outside/outside.txt
+chmod -R 0777 /srv/share /srv/outside
+
+# Symlinks: inside the share, to a directory, broken, outside the share, relative.
+ln -sfn target.txt                /srv/share/link-to-file
+ln -sfn subdir                    /srv/share/link-to-dir
+ln -sfn missing.txt               /srv/share/link-broken
+ln -sfn /srv/outside/outside.txt  /srv/share/link-outside
+ln -sfn ./target.txt              /srv/share/link-relative
+
+# DFS links. "link" and "link-extra" share a prefix on purpose: unbounded
+# prefix matching has been a recurring defect class in the DFS referral code.
+ln -sfn "msdfs:${DFS_TARGET_HOST}\\share"                              /srv/dfs/link
+ln -sfn "msdfs:${DFS_TARGET_HOST}\\users"                              /srv/dfs/link-extra
+ln -sfn "msdfs:${DFS_TARGET_HOST}\\missing,${DFS_TARGET_HOST}\\share"  /srv/dfs/multi
+ln -sfn "msdfs:${DFS_TARGET_HOST}\\missing"                            /srv/dfs/broken
+
+testparm --suppress-prompt >/dev/null
+
+exec smbd --foreground --no-process-group --debug-stdout

--- a/build_helpers/samba/smb.conf
+++ b/build_helpers/samba/smb.conf
@@ -1,0 +1,70 @@
+# Samba configuration for the jcifs SMB integration tests.
+#
+# The share names here are the shared vocabulary between the two backends: the
+# Windows setup script (build_helpers/win-setup.ps1) creates shares with the
+# same names and the same meaning, so the tests only ever refer to share names.
+
+[global]
+   workgroup = WORKGROUP
+   server string = jcifs integration test server
+   security = user
+   map to guest = Bad User
+   server min protocol = SMB2_02
+   server max protocol = SMB3_11
+   # Windows Server 2025 and Windows 11 24H2 require signing by default; match
+   # that here so the PR-level Samba run exercises the same signing path.
+   server signing = mandatory
+   host msdfs = yes
+   # Samba refuses "wide links" while unix extensions are enabled, and the
+   # symlink tests need a link that points outside the share.
+   unix extensions = no
+   load printers = no
+   printing = bsd
+   disable spoolss = yes
+   log level = 1
+   log file = /var/log/samba/log.%m
+   panic action = /bin/true
+
+# Plain share, no encryption.
+[share]
+   path = /srv/share
+   read only = no
+   valid users = testuser1, testuser2
+   follow symlinks = yes
+   wide links = yes
+
+# Encryption is mandatory: an unencrypted session must be rejected.
+[share-encrypted]
+   path = /srv/share-encrypted
+   read only = no
+   valid users = testuser1, testuser2
+   smb encrypt = required
+
+# DFS namespace root. Only reachable when the server is addressed on port 445
+# under its own name - see SmbServerResolver for why the container backend
+# cannot serve referrals.
+[dfs]
+   path = /srv/dfs
+   read only = no
+   valid users = testuser1, testuser2
+   msdfs root = yes
+
+[public]
+   path = /srv/public
+   read only = no
+   guest ok = yes
+
+[users]
+   path = /srv/users
+   read only = no
+   valid users = testuser1, testuser2
+
+[testuser1private]
+   path = /srv/testuser1private
+   read only = no
+   valid users = testuser1
+
+[testuser2private]
+   path = /srv/testuser2private
+   read only = no
+   valid users = testuser2

--- a/build_helpers/win-setup.ps1
+++ b/build_helpers/win-setup.ps1
@@ -1,0 +1,144 @@
+<#
+.SYNOPSIS
+    Builds the SMB fixture layout that the jcifs integration tests expect.
+
+.DESCRIPTION
+    Creates the same share vocabulary as build_helpers/samba/entrypoint.sh, so the
+    same tests run against either backend. Intended for a GitHub Actions
+    windows-latest runner (Windows Server 2025, administrator, UAC disabled) and
+    for a local Windows VM.
+
+    DFS Namespaces is a server role. On a client SKU such as Windows 11 the DFS
+    section is skipped and the DFS tests skip with it.
+
+.PARAMETER Password
+    Password for the test accounts. This is a throwaway credential that is only
+    valid on the machine running this script.
+#>
+[CmdletBinding()]
+param(
+    [String] $Password = 'Public-Fixture-Not-A-Secret-1!',
+    [String] $Root = 'C:\smbit',
+    [String] $OutsideRoot = 'C:\smbit-outside'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$testUsers = @('testuser1', 'testuser2')
+$securePassword = ConvertTo-SecureString -String $Password -AsPlainText -Force
+
+Write-Host 'Creating local test accounts'
+foreach ($user in $testUsers) {
+    if (-not (Get-LocalUser -Name $user -ErrorAction SilentlyContinue)) {
+        New-LocalUser -Name $user -Password $securePassword -PasswordNeverExpires -AccountNeverExpires `
+            -UserMayNotChangePassword -Description 'jcifs integration test account' | Out-Null
+    }
+}
+
+Write-Host 'Creating share directories'
+$shareNames = @('share', 'share-encrypted', 'dfs', 'public', 'users', 'testuser1private', 'testuser2private')
+foreach ($name in $shareNames) {
+    New-Item -Path (Join-Path $Root $name) -ItemType Directory -Force | Out-Null
+}
+New-Item -Path $OutsideRoot -ItemType Directory -Force | Out-Null
+
+# Share level permissions are what restrict the private shares; NTFS stays open
+# so the accounts can write everywhere they are allowed to connect.
+icacls $Root /grant 'testuser1:(OI)(CI)F' 'testuser2:(OI)(CI)F' /T /Q | Out-Null
+icacls $OutsideRoot /grant 'testuser1:(OI)(CI)F' 'testuser2:(OI)(CI)F' /T /Q | Out-Null
+
+Write-Host 'Creating SMB shares'
+$sharedByBoth = @('share', 'dfs', 'public', 'users')
+foreach ($name in $sharedByBoth) {
+    if (-not (Get-SmbShare -Name $name -ErrorAction SilentlyContinue)) {
+        New-SmbShare -Name $name -Path (Join-Path $Root $name) -FullAccess $testUsers -EncryptData $false | Out-Null
+    }
+}
+if (-not (Get-SmbShare -Name 'share-encrypted' -ErrorAction SilentlyContinue)) {
+    New-SmbShare -Name 'share-encrypted' -Path (Join-Path $Root 'share-encrypted') -FullAccess $testUsers `
+        -EncryptData $true | Out-Null
+}
+foreach ($user in $testUsers) {
+    $privateShare = "${user}private"
+    if (-not (Get-SmbShare -Name $privateShare -ErrorAction SilentlyContinue)) {
+        New-SmbShare -Name $privateShare -Path (Join-Path $Root $privateShare) -FullAccess $user -EncryptData $false | Out-Null
+    }
+}
+
+Write-Host 'Requiring SMB signing'
+Set-SmbServerConfiguration -RequireSecuritySignature $true -Force
+
+Write-Host 'Creating symlink fixtures'
+$sharePath = Join-Path $Root 'share'
+[IO.File]::WriteAllText((Join-Path $sharePath 'target.txt'), "target file contents`n")
+New-Item -Path (Join-Path $sharePath 'subdir') -ItemType Directory -Force | Out-Null
+[IO.File]::WriteAllText((Join-Path $sharePath 'subdir\inside.txt'), "inside subdir`n")
+[IO.File]::WriteAllText((Join-Path $OutsideRoot 'outside.txt'), "outside the share`n")
+
+$links = @(
+    @{ Name = 'link-to-file'; Target = (Join-Path $sharePath 'target.txt') },
+    @{ Name = 'link-to-dir'; Target = (Join-Path $sharePath 'subdir') },
+    @{ Name = 'link-broken'; Target = (Join-Path $sharePath 'missing.txt') },
+    @{ Name = 'link-outside'; Target = (Join-Path $OutsideRoot 'outside.txt') }
+)
+foreach ($link in $links) {
+    $path = Join-Path $sharePath $link.Name
+    if (-not (Test-Path -LiteralPath $path)) {
+        New-Item -ItemType SymbolicLink -Path $path -Target $link.Target | Out-Null
+    }
+}
+# A relative link, created from inside the directory so the target stays relative.
+Push-Location $sharePath
+try {
+    if (-not (Test-Path -LiteralPath 'link-relative')) {
+        cmd.exe /c 'mklink link-relative target.txt' | Out-Null
+    }
+} finally {
+    Pop-Location
+}
+
+if (Get-Command -Name Install-WindowsFeature -ErrorAction SilentlyContinue) {
+    Write-Host 'Installing the DFS Namespaces role'
+    Install-WindowsFeature -Name FS-DFS-Namespace -IncludeManagementTools | Out-Null
+
+    $dfsPath = "\\$env:COMPUTERNAME\dfs"
+    if (-not (Get-DfsnRoot -Path $dfsPath -ErrorAction SilentlyContinue)) {
+        New-DfsnRoot -Path $dfsPath -TargetPath $dfsPath -Type Standalone -State Online -TargetState Online | Out-Null
+    }
+
+    Write-Host 'Creating DFS links'
+    # "link" and "link-extra" share a prefix on purpose: unbounded prefix matching
+    # in the referral code was the defect behind both #86 and #88.
+    $dfsFolders = @(
+        @{ Name = 'link'; Target = "\\$env:COMPUTERNAME\share" },
+        @{ Name = 'link-extra'; Target = "\\$env:COMPUTERNAME\users" },
+        @{ Name = 'multi'; Target = "\\$env:COMPUTERNAME\missing" },
+        @{ Name = 'broken'; Target = "\\$env:COMPUTERNAME\missing" }
+    )
+    foreach ($folder in $dfsFolders) {
+        $folderPath = "$dfsPath\$($folder.Name)"
+        if (-not (Get-DfsnFolder -Path $folderPath -ErrorAction SilentlyContinue)) {
+            New-DfsnFolder -Path $folderPath -TargetPath $folder.Target -State Online -TargetState Online | Out-Null
+        }
+    }
+    # A second, reachable target so "multi" exercises failover past the dead one.
+    $multiPath = "$dfsPath\multi"
+    $liveTarget = "\\$env:COMPUTERNAME\share"
+    if (-not (Get-DfsnFolderTarget -Path $multiPath -TargetPath $liveTarget -ErrorAction SilentlyContinue)) {
+        New-DfsnFolderTarget -Path $multiPath -TargetPath $liveTarget -State Online | Out-Null
+    }
+} else {
+    Write-Warning 'Install-WindowsFeature is unavailable (client SKU); skipping DFS. The DFS tests will skip.'
+}
+
+Write-Host 'Enabling the SMB firewall rule and starting the server service'
+Set-NetFirewallRule -Name FPS-SMB-In-TCP -Enabled True
+Set-Service -Name LanmanServer -StartupType Automatic -Status Running
+
+Write-Host ''
+Write-Host 'Share permissions as configured:'
+Get-SmbShare | Where-Object { $_.Name -ne 'IPC$' } | Get-SmbShareAccess |
+    Format-Table -AutoSize ScaleOut, Name, AccountName, AccessControlType, AccessRight | Out-String | Write-Host
+
+Write-Host ''
+Write-Host "SMB fixtures are ready. Point the tests at JCIFS_IT_HOST=$env:COMPUTERNAME"

--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,44 @@
 				</dependencies>
 			</plugin>
 			<plugin>
+				<!-- Integration tests (*IT) talk to a real SMB server and run in the
+				     verify phase. surefire only includes *Test/*Tests/*TestCase/*TestSuite,
+				     so mvn test stays offline and fast. -->
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>3.5.5</version>
+				<configuration>
+					<includes>
+						<include>**/*IT.java</include>
+					</includes>
+					<systemPropertyVariables>
+						<networkaddress.cache.ttl>-1</networkaddress.cache.ttl>
+						<networkaddress.cache.negative.ttl>-1</networkaddress.cache.negative.ttl>
+					</systemPropertyVariables>
+					<useSystemClassLoader>false</useSystemClassLoader>
+					<useModulePath>false</useModulePath>
+					<forkCount>1</forkCount>
+					<reuseForks>true</reuseForks>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+				<dependencies>
+					<!-- Without this failsafe auto-detects the JUnit 4 provider and runs
+					     none of the JUnit 5 tests while still reporting success. -->
+					<dependency>
+						<groupId>org.apache.maven.surefire</groupId>
+						<artifactId>surefire-junit-platform</artifactId>
+						<version>3.5.5</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
 				<version>0.8.14</version>
@@ -210,6 +248,9 @@
 						<exclude>*.md</exclude>
 						<exclude>build.properties</exclude>
 						<exclude>src/test/**</exclude>
+						<!-- Server-side fixtures for the integration tests: Dockerfile,
+						     smb.conf and shell/PowerShell setup scripts. -->
+						<exclude>build_helpers/**</exclude>
 						<exclude>**/*.idl</exclude>
 						<exclude>**/*.css</exclude>
 						<exclude>.*</exclude>

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbNegotiationProbe.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbNegotiationProbe.java
@@ -1,0 +1,66 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.impl;
+
+import org.codelibs.jcifs.smb.CIFSException;
+import org.codelibs.jcifs.smb.DialectVersion;
+
+/**
+ * Test-only window onto the negotiated connection state.
+ *
+ * <p>
+ * {@code SmbTransportImpl.getNegotiateResponse()} is package private, so this
+ * class lives in the implementation package purely so integration tests can ask
+ * what was actually negotiated. Without it a test can only assert that a
+ * connection succeeded, which is not enough to catch a configuration property
+ * that is silently ignored.
+ * </p>
+ */
+public final class SmbNegotiationProbe {
+
+    private SmbNegotiationProbe() {
+    }
+
+    /**
+     * Returns the dialect the server and client actually settled on.
+     *
+     * @param file any connected resource on the tree of interest
+     * @return the negotiated dialect
+     * @throws CIFSException if the connection cannot be established
+     */
+    public static DialectVersion negotiatedDialect(final SmbFile file) throws CIFSException {
+        try (SmbTreeHandleImpl tree = (SmbTreeHandleImpl) file.getTreeHandle();
+                SmbSessionImpl session = tree.getSession();
+                SmbTransportImpl transport = session.getTransport()) {
+            return transport.getNegotiateResponse().getSelectedDialect();
+        }
+    }
+
+    /**
+     * Returns whether signing was negotiated for the connection.
+     *
+     * @param file any connected resource on the tree of interest
+     * @return true if signatures are in use
+     * @throws CIFSException if the connection cannot be established
+     */
+    public static boolean signingNegotiated(final SmbFile file) throws CIFSException {
+        try (SmbTreeHandleImpl tree = (SmbTreeHandleImpl) file.getTreeHandle();
+                SmbSessionImpl session = tree.getSession();
+                SmbTransportImpl transport = session.getTransport()) {
+            return transport.getNegotiateResponse().isSigningNegotiated();
+        }
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/it/AbstractSmbIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/AbstractSmbIT.java
@@ -1,0 +1,99 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it;
+
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.impl.SmbFile;
+import org.codelibs.jcifs.smb.it.env.SmbServerExtension;
+import org.codelibs.jcifs.smb.it.env.SmbServerFixture;
+import org.codelibs.jcifs.smb.it.env.SmbServerResolver;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base class for the SMB integration tests.
+ *
+ * <p>
+ * Extending this class is what connects a test to the resolved backend and to
+ * the preflight checks; it deliberately carries no assertions of its own.
+ * </p>
+ */
+@ExtendWith(SmbServerExtension.class)
+public abstract class AbstractSmbIT {
+
+    private static final Logger log = LoggerFactory.getLogger(AbstractSmbIT.class);
+
+    /**
+     * @return the resolved server
+     */
+    protected static SmbServerFixture server() {
+        return SmbServerResolver.resolve();
+    }
+
+    /**
+     * Creates an empty directory unique to the calling test.
+     *
+     * @param context   the context to create it with
+     * @param shareName the share to create it in
+     * @return the created directory, which the caller is responsible for removing
+     * @throws Exception if the directory cannot be created
+     */
+    protected SmbFile createWorkDir(final CIFSContext context, final String shareName) throws Exception {
+        final SmbFile dir = new SmbFile(server().url(shareName, "it-" + UUID.randomUUID() + "/"), context);
+        dir.mkdirs();
+        return dir;
+    }
+
+    /**
+     * Writes a small text file.
+     *
+     * @param parent   the directory to write into
+     * @param name     the file name
+     * @param contents the contents to write
+     * @return the written file
+     * @throws Exception if the file cannot be written
+     */
+    protected SmbFile writeFile(final SmbFile parent, final String name, final String contents) throws Exception {
+        final SmbFile file = new SmbFile(parent, name);
+        try (OutputStream out = file.getOutputStream()) {
+            out.write(contents.getBytes(StandardCharsets.UTF_8));
+        }
+        return file;
+    }
+
+    /**
+     * Removes a directory tree, ignoring anything that has already gone.
+     *
+     * @param file the root of the tree to remove
+     */
+    protected void deleteQuietly(final SmbFile file) {
+        if (file == null) {
+            return;
+        }
+        try {
+            if (file.exists()) {
+                file.delete();
+            }
+        } catch (final Exception e) {
+            log.debug("Ignoring cleanup failure for {}", file, e);
+        }
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/it/AuthenticationIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/AuthenticationIT.java
@@ -1,0 +1,103 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.impl.SmbAuthException;
+import org.codelibs.jcifs.smb.impl.SmbException;
+import org.codelibs.jcifs.smb.impl.SmbFile;
+import org.codelibs.jcifs.smb.it.env.RequiresBackend;
+import org.codelibs.jcifs.smb.it.env.SmbBackend;
+import org.codelibs.jcifs.smb.it.env.SmbServerResolver;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Authentication and per-account authorization.
+ */
+class AuthenticationIT extends AbstractSmbIT {
+
+    @Test
+    @DisplayName("valid credentials reach the share")
+    void validCredentialsWork() throws Exception {
+        try (SmbFile share = new SmbFile(server().url(server().share()), server().context())) {
+            assertTrue(share.exists());
+        }
+    }
+
+    @Test
+    @DisplayName("a wrong password is rejected")
+    void wrongPasswordIsRejected() throws Exception {
+        final CIFSContext context = server().context(server().user(), "not-the-" + UUID.randomUUID());
+        assertThrows(SmbAuthException.class, () -> {
+            try (SmbFile share = new SmbFile(server().url(server().share()), context)) {
+                share.exists();
+            }
+        });
+    }
+
+    @Test
+    @DisplayName("an unknown account is rejected")
+    void unknownAccountIsRejected() throws Exception {
+        final CIFSContext context = server().context("nobody-" + UUID.randomUUID(), server().password());
+        assertThrows(SmbAuthException.class, () -> {
+            try (SmbFile share = new SmbFile(server().url(server().share()), context)) {
+                share.exists();
+            }
+        });
+    }
+
+    @Test
+    @DisplayName("an account cannot read another account's private share")
+    void privateShareIsNotReadableByAnotherAccount() throws Exception {
+        final CIFSContext context = server().context();
+        assertThrows(Exception.class, () -> {
+            try (SmbFile share = new SmbFile(server().url("testuser2private"), context)) {
+                share.listFiles();
+            }
+        }, "testuser1 must not be able to list testuser2's private share");
+    }
+
+    @Test
+    @RequiresBackend(SmbBackend.WINDOWS)
+    @Disabled("Measured on Windows Server 2025: exists() returns true for a share the account cannot connect to. "
+            + "The share ACL grants only the other account, listFiles() on the same share is still refused, and "
+            + "Samba rethrows the tree connect denial as exists() is documented to. Needs an issue before enabling.")
+    @DisplayName("a share the account cannot connect to is not reported as existing")
+    void inaccessibleShareIsNotReportedAsExisting() throws Exception {
+        final CIFSContext context = server().context();
+        assertThrows(SmbException.class, () -> {
+            try (SmbFile share = new SmbFile(server().url("testuser2private"), context)) {
+                share.exists();
+            }
+        }, "an unreachable share must not be reported as existing");
+    }
+
+    @Test
+    @DisplayName("the secondary account reaches its own private share")
+    void secondaryAccountReachesItsOwnShare() throws Exception {
+        final CIFSContext context = server().context(SmbServerResolver.secondaryUser(), server().password());
+        try (SmbFile share = new SmbFile(server().url("testuser2private"), context)) {
+            assertTrue(share.exists());
+        }
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/it/DfsIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/DfsIT.java
@@ -1,0 +1,104 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.impl.SmbFile;
+import org.codelibs.jcifs.smb.it.env.RequiresDfs;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * DFS namespace traversal.
+ *
+ * <p>
+ * The namespace deliberately contains a pair of links whose names share a
+ * prefix ({@code link} and {@code link-extra}). Unbounded prefix matching in the
+ * referral code has been a recurring defect - #86 and #88 were both instances -
+ * so the fixture keeps a permanent trap for it.
+ * </p>
+ */
+@RequiresDfs
+class DfsIT extends AbstractSmbIT {
+
+    private SmbFile workDir;
+
+    @AfterEach
+    void removeFixtureFile() {
+        deleteQuietly(this.workDir);
+    }
+
+    private String dfsPath(final String link) {
+        return server().url(server().dfsRoot(), link + "/");
+    }
+
+    @Test
+    @DisplayName("a DFS link resolves to its target share")
+    void linkResolvesToItsTarget() throws Exception {
+        final CIFSContext context = server().context();
+        final String fileName = "dfs-" + UUID.randomUUID() + ".txt";
+        final String contents = "reached through the namespace";
+
+        final SmbFile direct = new SmbFile(server().url(server().share(), fileName), context);
+        try (OutputStream out = direct.getOutputStream()) {
+            out.write(contents.getBytes(StandardCharsets.UTF_8));
+        }
+        this.workDir = direct;
+
+        try (SmbFile viaDfs = new SmbFile(dfsPath("link") + fileName, context); InputStream in = viaDfs.getInputStream()) {
+            assertArrayEquals(contents.getBytes(StandardCharsets.UTF_8), in.readAllBytes());
+        }
+    }
+
+    @Test
+    @DisplayName("a link whose name extends another link's name resolves to its own target")
+    void linkWithAnOverlappingPrefixIsNotConfusedWithTheShorterOne() throws Exception {
+        final CIFSContext context = server().context();
+        try (SmbFile shorter = new SmbFile(dfsPath("link"), context); SmbFile longer = new SmbFile(dfsPath("link-extra"), context)) {
+            assertTrue(shorter.exists(), "link should resolve");
+            assertTrue(longer.exists(), "link-extra should resolve");
+        }
+    }
+
+    @Test
+    @DisplayName("a link with a dead first target fails over to a live one")
+    void deadTargetFailsOver() throws Exception {
+        try (SmbFile viaDfs = new SmbFile(dfsPath("multi"), server().context())) {
+            assertTrue(viaDfs.exists(), "the namespace should have fallen back to the reachable target");
+        }
+    }
+
+    @Test
+    @DisplayName("a link whose every target is dead reports a failure")
+    void deadLinkFails() throws Exception {
+        final CIFSContext context = server().context();
+        assertThrows(Exception.class, () -> {
+            try (SmbFile viaDfs = new SmbFile(dfsPath("broken"), context)) {
+                viaDfs.listFiles();
+            }
+        }, "a link with no reachable target must not silently succeed");
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/it/DialectNegotiationIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/DialectNegotiationIT.java
@@ -1,0 +1,66 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Properties;
+
+import org.codelibs.jcifs.smb.DialectVersion;
+import org.codelibs.jcifs.smb.impl.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbNegotiationProbe;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/**
+ * Dialect negotiation against a real server.
+ */
+class DialectNegotiationIT extends AbstractSmbIT {
+
+    @ParameterizedTest
+    @EnumSource(value = DialectVersion.class, names = { "SMB202", "SMB210", "SMB300", "SMB302", "SMB311" })
+    @DisplayName("the negotiated dialect is the configured maximum")
+    void negotiatesTheConfiguredMaximum(final DialectVersion maximum) throws Exception {
+        final Properties props = new Properties();
+        props.setProperty("jcifs.client.maxVersion", maximum.name());
+        try (SmbFile file = new SmbFile(server().url(server().share()), server().context(props))) {
+            assertEquals(maximum, SmbNegotiationProbe.negotiatedDialect(file), "server should have accepted the client's maximum dialect");
+        }
+    }
+
+    @Test
+    @DisplayName("the default configuration reaches SMB 3.1.1")
+    void defaultConfigurationReachesSmb311() throws Exception {
+        try (SmbFile file = new SmbFile(server().url(server().share()), server().context())) {
+            assertEquals(DialectVersion.SMB311, SmbNegotiationProbe.negotiatedDialect(file));
+        }
+    }
+
+    @Test
+    @DisplayName("a raised minimum still negotiates within the allowed range")
+    void raisedMinimumStaysWithinRange() throws Exception {
+        final Properties props = new Properties();
+        props.setProperty("jcifs.client.minVersion", "SMB300");
+        props.setProperty("jcifs.client.maxVersion", "SMB311");
+        try (SmbFile file = new SmbFile(server().url(server().share()), server().context(props))) {
+            final DialectVersion negotiated = SmbNegotiationProbe.negotiatedDialect(file);
+            assertTrue(negotiated.atLeast(DialectVersion.SMB300), "negotiated " + negotiated + " below the configured minimum");
+        }
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/it/EncryptionIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/EncryptionIT.java
@@ -1,0 +1,118 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import java.util.Random;
+
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.impl.SmbFile;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * SMB3 transform encryption against a share that mandates it.
+ *
+ * <p>
+ * The server side of this is verified by the preflight check, which refuses to
+ * let the suite start unless the encrypted share really does reject a client
+ * that cannot encrypt. Without that, every test here would pass against a plain
+ * share and prove nothing.
+ * </p>
+ */
+class EncryptionIT extends AbstractSmbIT {
+
+    /** Comfortably larger than a single transform, to exercise splitting. */
+    private static final int LARGE_PAYLOAD_BYTES = 3 * 1024 * 1024;
+
+    private SmbFile workDir;
+
+    @AfterEach
+    void removeWorkDir() {
+        deleteQuietly(this.workDir);
+    }
+
+    private static Properties encrypting() {
+        final Properties props = new Properties();
+        props.setProperty("jcifs.client.encryptionEnabled", "true");
+        return props;
+    }
+
+    @Test
+    @DisplayName("a client that cannot encrypt is refused by the encrypted share")
+    void clientWithoutEncryptionIsRefused() throws Exception {
+        final Properties noEncryption = new Properties();
+        noEncryption.setProperty("jcifs.client.maxVersion", "SMB202");
+        final CIFSContext context = server().context(noEncryption);
+
+        assertThrows(Exception.class, () -> {
+            try (SmbFile share = new SmbFile(server().url(server().encryptedShare()), context)) {
+                share.exists();
+            }
+        }, "the encrypted share must not accept a client that cannot encrypt");
+    }
+
+    @Test
+    @DisplayName("the plain share is still usable with encryption enabled")
+    void plainShareWorksWithEncryptionEnabled() throws Exception {
+        final CIFSContext context = server().context(encrypting());
+        this.workDir = createWorkDir(context, server().share());
+        final SmbFile file = writeFile(this.workDir, "plain.txt", "written with encryption enabled");
+        assertTrue(file.exists());
+    }
+
+    @Test
+    @Disabled("#71/#70: SMB3 transform encryption is not wired up on main. The server accepts the tree connect and then never answers SMB2_CREATE, so this times out. PR #92 is the pending fix - enable this once it merges.")
+    @DisplayName("small payloads round trip through the encrypted share")
+    void smallPayloadRoundTrips() throws Exception {
+        final CIFSContext context = server().context(encrypting());
+        this.workDir = createWorkDir(context, server().encryptedShare());
+        final String contents = "encrypted round trip";
+        final SmbFile file = writeFile(this.workDir, "small.txt", contents);
+
+        try (InputStream in = file.getInputStream()) {
+            assertArrayEquals(contents.getBytes(StandardCharsets.UTF_8), in.readAllBytes());
+        }
+    }
+
+    @Test
+    @Disabled("#71/#70: SMB3 transform encryption is not wired up on main. The server accepts the tree connect and then never answers SMB2_CREATE, so this times out. PR #92 is the pending fix - enable this once it merges.")
+    @DisplayName("a payload larger than one transform round trips through the encrypted share")
+    void largePayloadRoundTrips() throws Exception {
+        final CIFSContext context = server().context(encrypting());
+        this.workDir = createWorkDir(context, server().encryptedShare());
+
+        final byte[] payload = new byte[LARGE_PAYLOAD_BYTES];
+        new Random(20260910L).nextBytes(payload);
+
+        final SmbFile file = new SmbFile(this.workDir, "large.bin");
+        try (OutputStream out = file.getOutputStream()) {
+            out.write(payload);
+        }
+        try (InputStream in = file.getInputStream()) {
+            assertArrayEquals(payload, in.readAllBytes(), "the encrypted payload came back different");
+        }
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/it/ErrorMappingIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/ErrorMappingIT.java
@@ -1,0 +1,69 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.UUID;
+
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.impl.NtStatus;
+import org.codelibs.jcifs.smb.impl.SmbException;
+import org.codelibs.jcifs.smb.impl.SmbFile;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * How server errors surface as exceptions.
+ */
+class ErrorMappingIT extends AbstractSmbIT {
+
+    @Test
+    @DisplayName("a missing file reports OBJECT_NAME_NOT_FOUND when opened")
+    void missingFileReportsNotFound() throws Exception {
+        final CIFSContext context = server().context();
+        try (SmbFile file = new SmbFile(server().url(server().share(), "missing-" + UUID.randomUUID() + ".txt"), context)) {
+            assertFalse(file.exists());
+            final SmbException e = assertThrows(SmbException.class, file::getInputStream);
+            assertEquals(NtStatus.NT_STATUS_OBJECT_NAME_NOT_FOUND, e.getNtStatus(),
+                    "unexpected status: 0x" + Integer.toHexString(e.getNtStatus()));
+        }
+    }
+
+    @Test
+    @DisplayName("a share the account cannot reach reports a failure")
+    void inaccessibleShareFails() throws Exception {
+        final CIFSContext context = server().context();
+        assertThrows(SmbException.class, () -> {
+            try (SmbFile file = new SmbFile(server().url("testuser2private", "denied.txt"), context)) {
+                file.createNewFile();
+            }
+        }, "testuser1 must not be able to write into testuser2's private share");
+    }
+
+    @Test
+    @DisplayName("a share that does not exist reports a failure")
+    void missingShareFails() throws Exception {
+        final CIFSContext context = server().context();
+        assertThrows(SmbException.class, () -> {
+            try (SmbFile file = new SmbFile(server().url("no-such-share-" + UUID.randomUUID()), context)) {
+                file.listFiles();
+            }
+        });
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/it/ResolveIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/ResolveIT.java
@@ -1,0 +1,92 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.impl.SmbFile;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Resolving a child against a parent, with and without a trailing separator.
+ *
+ * <p>
+ * A parent given without a trailing slash used to glue the child name onto the
+ * last path segment, and the URL, the canonical path and the UNC path each broke
+ * differently (#83). These tests hold all three to the same answer against a
+ * live server.
+ * </p>
+ */
+class ResolveIT extends AbstractSmbIT {
+
+    private SmbFile workDir;
+
+    @AfterEach
+    void removeWorkDir() throws Exception {
+        if (this.workDir != null) {
+            try (SmbFile child = new SmbFile(this.workDir, "child.txt")) {
+                deleteQuietly(child);
+            }
+            deleteQuietly(this.workDir);
+        }
+    }
+
+    @Test
+    @DisplayName("a child resolves under a parent given without a trailing separator")
+    void childResolvesUnderParentWithoutTrailingSeparator() throws Exception {
+        final CIFSContext context = server().context();
+        final String dirName = "resolve-" + UUID.randomUUID();
+
+        this.workDir = new SmbFile(server().url(server().share(), dirName + "/"), context);
+        this.workDir.mkdirs();
+        writeFile(this.workDir, "child.txt", "child contents");
+
+        try (SmbFile parentWithoutSlash = new SmbFile(server().url(server().share(), dirName), context);
+                SmbFile child = new SmbFile(parentWithoutSlash, "child.txt")) {
+            assertTrue(child.exists(), "child resolved to " + child.getPath() + ", which does not exist");
+            assertTrue(child.getPath().endsWith("/" + dirName + "/child.txt"), "unexpected URL path: " + child.getPath());
+            assertTrue(child.getUncPath().endsWith("\\" + dirName + "\\child.txt"), "unexpected UNC path: " + child.getUncPath());
+            assertTrue(child.getCanonicalPath().endsWith("/" + dirName + "/child.txt"),
+                    "unexpected canonical path: " + child.getCanonicalPath());
+        }
+    }
+
+    @Test
+    @DisplayName("a trailing separator on the parent makes no difference")
+    void trailingSeparatorOnParentMakesNoDifference() throws Exception {
+        final CIFSContext context = server().context();
+        final String dirName = "resolve-" + UUID.randomUUID();
+
+        this.workDir = new SmbFile(server().url(server().share(), dirName + "/"), context);
+        this.workDir.mkdirs();
+        writeFile(this.workDir, "child.txt", "child contents");
+
+        try (SmbFile withSlash = new SmbFile(server().url(server().share(), dirName + "/"), context);
+                SmbFile withoutSlash = new SmbFile(server().url(server().share(), dirName), context);
+                SmbFile fromWithSlash = new SmbFile(withSlash, "child.txt");
+                SmbFile fromWithoutSlash = new SmbFile(withoutSlash, "child.txt")) {
+            assertTrue(fromWithSlash.exists());
+            assertTrue(fromWithoutSlash.exists());
+            assertTrue(fromWithSlash.getUncPath().equals(fromWithoutSlash.getUncPath()),
+                    "UNC paths diverged: " + fromWithSlash.getUncPath() + " vs " + fromWithoutSlash.getUncPath());
+        }
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/it/SigningIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/SigningIT.java
@@ -1,0 +1,93 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.impl.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbNegotiationProbe;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Message signing against a real server.
+ *
+ * <p>
+ * Both backends are configured to require signing - Windows Server 2025 does so
+ * by default and the Samba fixture is set to {@code server signing = mandatory}
+ * to match - so every connection here is signed and the tests are the same on
+ * both.
+ * </p>
+ *
+ * <p>
+ * Note what {@code isSigningNegotiated()} actually reports: it reads the
+ * SIGNING_REQUIRED bit out of the server's negotiate response. It says the server
+ * demanded signing, not that the client signed anything - {@code SmbTreeHandle}
+ * exposes no stronger observation.
+ * </p>
+ */
+class SigningIT extends AbstractSmbIT {
+
+    private SmbFile workDir;
+
+    @AfterEach
+    void removeWorkDir() {
+        deleteQuietly(this.workDir);
+    }
+
+    @Test
+    @DisplayName("the server advertises that signing is required")
+    void serverRequiresSigning() throws Exception {
+        try (SmbFile file = new SmbFile(server().url(server().share()), server().context())) {
+            assertTrue(SmbNegotiationProbe.signingNegotiated(file), "the test server should be configured to require signing");
+        }
+    }
+
+    @Test
+    @DisplayName("file contents survive a signed session")
+    void payloadRoundTripsAgainstASigningServer() throws Exception {
+        final CIFSContext context = server().context();
+        this.workDir = createWorkDir(context, server().share());
+        final String contents = "signed round trip";
+        final SmbFile file = writeFile(this.workDir, "signed.txt", contents);
+
+        try (InputStream in = file.getInputStream()) {
+            assertArrayEquals(contents.getBytes(StandardCharsets.UTF_8), in.readAllBytes());
+        }
+    }
+
+    @Test
+    @DisplayName("a client that enforces signing can still talk to a server that requires it")
+    void clientEnforcedSigningWorks() throws Exception {
+        final Properties props = new Properties();
+        props.setProperty("jcifs.client.signingEnforced", "true");
+        final CIFSContext context = server().context(props);
+        this.workDir = createWorkDir(context, server().share());
+        final String contents = "client enforced signing";
+        final SmbFile file = writeFile(this.workDir, "enforced.txt", contents);
+
+        try (InputStream in = file.getInputStream()) {
+            assertArrayEquals(contents.getBytes(StandardCharsets.UTF_8), in.readAllBytes());
+        }
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/it/SmbFileIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/SmbFileIT.java
@@ -13,7 +13,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-package org.codelibs.jcifs.smb;
+package org.codelibs.jcifs.smb.it;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -28,70 +28,35 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
-import org.codelibs.jcifs.smb.context.BaseContext;
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.CIFSException;
+import org.codelibs.jcifs.smb.SmbResource;
+import org.codelibs.jcifs.smb.impl.NtlmPasswordAuthenticator;
 import org.codelibs.jcifs.smb.impl.SmbFile;
 import org.codelibs.jcifs.smb.impl.SmbRandomAccessFile;
+import org.codelibs.jcifs.smb.it.env.RequiresBackend;
+import org.codelibs.jcifs.smb.it.env.SmbBackend;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
 /**
- * Integration tests for SmbFile using a real Samba server via Testcontainers.
- * These tests verify SMB2/3 protocol support and basic file operations.
+ * File operations against a real SMB server.
+ *
+ * <p>
+ * These tests predate the harness and used to start their own Samba container.
+ * They now go through {@link AbstractSmbIT}, so the same bodies run against
+ * either backend.
+ * </p>
  */
-@Testcontainers
-public class SmbFileIntegrationTest {
+class SmbFileIT extends AbstractSmbIT {
 
-    private static final Logger log = LoggerFactory.getLogger(SmbFileIntegrationTest.class);
+    private static final Logger log = LoggerFactory.getLogger(SmbFileIT.class);
 
-    private static final String SAMBA_IMAGE = "dperson/samba:latest";
     private static final String TESTUSER1 = "testuser1";
     private static final String TESTUSER2 = "testuser2";
-    private static final String PASSWORD = "test123";
-
-    @Container
-    private static final GenericContainer<?> sambaContainer =
-            new GenericContainer<>(DockerImageName.parse(SAMBA_IMAGE)).withExposedPorts(139, 445)
-                    .withCommand("-u", TESTUSER1 + ";" + PASSWORD, "-u", TESTUSER2 + ";" + PASSWORD, "-s",
-                            "public;/share/public;yes;no;yes", "-s", "users;/share/users;yes;no;no;" + TESTUSER1 + "," + TESTUSER2, "-s",
-                            "testuser1private;/share/testuser1private;yes;no;no;" + TESTUSER1, "-s",
-                            "testuser2private;/share/testuser2private;yes;no;no;" + TESTUSER2, "-p")
-                    .waitingFor(Wait.forListeningPorts(139, 445).withStartupTimeout(java.time.Duration.ofSeconds(60)))
-                    .withLogConsumer(new Slf4jLogConsumer(log).withPrefix("SAMBA"));
-
-    private static String sambaHost;
-    private static int sambaPort;
-
-    @BeforeAll
-    static void setupContainer() throws Exception {
-        sambaHost = sambaContainer.getHost();
-        sambaPort = sambaContainer.getMappedPort(445);
-        log.info("Samba container started at {}:{}", sambaHost, sambaPort);
-
-        // Wait a bit for Samba to fully initialize after ports are open
-        Thread.sleep(5000);
-
-        // Verify Samba is accessible
-        try {
-            final CIFSContext testContext = createContext(TESTUSER1, PASSWORD);
-            final String testUrl = String.format("smb://%s:%d/%s/", sambaHost, sambaPort, "users");
-            final SmbFile testFile = new SmbFile(testUrl, testContext);
-            testFile.exists();
-            log.info("Samba server is accessible and ready for tests");
-        } catch (final Exception e) {
-            log.error("Failed to verify Samba accessibility", e);
-            throw e;
-        }
-    }
 
     /**
      * Creates a CIFSContext for the specified user.
@@ -101,17 +66,8 @@ public class SmbFileIntegrationTest {
      * @return a configured CIFSContext
      */
     private static CIFSContext createContext(final String username, final String password) {
-        final Properties props = new Properties();
-        props.setProperty("jcifs.smb.client.minVersion", "SMB202");
-        props.setProperty("jcifs.smb.client.maxVersion", "SMB311");
-        props.setProperty("jcifs.smb.client.port", String.valueOf(sambaPort));
-
         try {
-            final BaseContext context = new BaseContext(new org.codelibs.jcifs.smb.config.PropertyConfiguration(props));
-            if (username != null && password != null) {
-                return context.withCredentials(new org.codelibs.jcifs.smb.impl.NtlmPasswordAuthenticator(username, password));
-            }
-            return context;
+            return server().context(username, password);
         } catch (final CIFSException e) {
             throw new RuntimeException("Failed to create CIFS context", e);
         }
@@ -125,24 +81,27 @@ public class SmbFileIntegrationTest {
      * @return the SMB URL
      */
     private String createSmbUrl(final String share, final String path) {
-        return String.format("smb://%s:%d/%s/%s", sambaHost, sambaPort, share, path);
+        return server().url(share, path);
     }
 
     @AfterEach
     void cleanup() throws Exception {
         // Clean up test files after each test
-        final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+        final CIFSContext context = createContext(TESTUSER1, password());
         cleanupShare(context, "users");
         cleanupShare(context, "testuser1private");
 
-        final CIFSContext context2 = createContext(TESTUSER2, PASSWORD);
+        final CIFSContext context2 = createContext(TESTUSER2, password());
         cleanupShare(context2, "testuser2private");
+    }
+
+    private static String password() {
+        return server().password();
     }
 
     private void cleanupShare(final CIFSContext context, final String share) {
         try {
-            final String shareUrl = String.format("smb://%s:%d/%s/", sambaHost, sambaPort, share);
-            final SmbFile shareRoot = new SmbFile(shareUrl, context);
+            final SmbFile shareRoot = new SmbFile(server().url(share), context);
             if (shareRoot.exists()) {
                 deleteRecursively(shareRoot);
             }
@@ -173,7 +132,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testConnectWithValidCredentials() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final String url = createSmbUrl("users", "");
             final SmbFile file = new SmbFile(url, context);
 
@@ -181,6 +140,9 @@ public class SmbFileIntegrationTest {
         }
 
         @Test
+        @RequiresBackend(SmbBackend.SAMBA)
+        // Windows Server 2025 and Windows 11 24H2 refuse insecure guest access by
+        // default, and the Windows fixture does not re-enable it.
         void testConnectToPublicShare() throws Exception {
             final CIFSContext context = createContext(null, null);
             final String url = createSmbUrl("public", "");
@@ -190,8 +152,12 @@ public class SmbFileIntegrationTest {
         }
 
         @Test
+        @RequiresBackend(SmbBackend.SAMBA)
+        // Samba refuses the tree connect, and exists() rethrows anything that is
+        // not a "not found" status. Windows answers differently - see
+        // AuthenticationIT.inaccessibleShareIsNotReportedAsExisting.
         void testAccessDeniedToPrivateShare() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final String url = createSmbUrl("testuser2private", "");
 
             // testuser1 should not be able to access testuser2's private share
@@ -203,7 +169,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testConnectToOwnPrivateShare() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final String url = createSmbUrl("testuser1private", "");
             final SmbFile file = new SmbFile(url, context);
 
@@ -219,7 +185,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testCreateAndDeleteTextFile() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final String url = createSmbUrl("users", "test.txt");
             final SmbFile file = new SmbFile(url, context);
 
@@ -234,7 +200,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testWriteAndReadTextFile() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final String url = createSmbUrl("users", "test.txt");
             final SmbFile file = new SmbFile(url, context);
 
@@ -256,7 +222,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testWriteAndReadBinaryFile() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final String url = createSmbUrl("users", "binary.dat");
             final SmbFile file = new SmbFile(url, context);
 
@@ -281,7 +247,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testOverwriteFile() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final String url = createSmbUrl("users", "overwrite.txt");
             final SmbFile file = new SmbFile(url, context);
 
@@ -309,7 +275,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testFileExists() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final String url = createSmbUrl("users", "exists.txt");
             final SmbFile file = new SmbFile(url, context);
 
@@ -324,7 +290,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testDeleteNonExistentFile() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final String url = createSmbUrl("users", "nonexistent.txt");
             final SmbFile file = new SmbFile(url, context);
 
@@ -350,7 +316,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testCreateAndDeleteDirectory() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final String url = createSmbUrl("users", "testdir/");
             final SmbFile dir = new SmbFile(url, context);
 
@@ -366,7 +332,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testCreateNestedDirectories() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final String url = createSmbUrl("users", "parent/child/grandchild/");
             final SmbFile dir = new SmbFile(url, context);
 
@@ -378,7 +344,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testListDirectory() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final String dirUrl = createSmbUrl("users", "listtest/");
             final SmbFile dir = new SmbFile(dirUrl, context);
             dir.mkdir();
@@ -396,7 +362,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testDeleteNonEmptyDirectory() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final String dirUrl = createSmbUrl("users", "nonempty/");
             final SmbFile dir = new SmbFile(dirUrl, context);
             dir.mkdir();
@@ -426,7 +392,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testGetFileSize() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final String url = createSmbUrl("users", "sized.txt");
             final SmbFile file = new SmbFile(url, context);
 
@@ -440,7 +406,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testGetLastModified() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final String url = createSmbUrl("users", "timestamped.txt");
             final SmbFile file = new SmbFile(url, context);
 
@@ -455,7 +421,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testIsFileAndIsDirectory() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
 
             final SmbFile file = new SmbFile(createSmbUrl("users", "testfile.txt"), context);
             file.createNewFile();
@@ -477,7 +443,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testRenameFileInSameDirectory() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile oldFile = new SmbFile(createSmbUrl("users", "oldname.txt"), context);
             final SmbFile newFile = new SmbFile(createSmbUrl("users", "newname.txt"), context);
 
@@ -491,7 +457,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testMoveFileToSubdirectory() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile sourceFile = new SmbFile(createSmbUrl("users", "source.txt"), context);
             final SmbFile targetDir = new SmbFile(createSmbUrl("users", "targetdir/"), context);
             final SmbFile targetFile = new SmbFile(createSmbUrl("users", "targetdir/source.txt"), context);
@@ -513,7 +479,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testInputStreamRead() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile file = new SmbFile(createSmbUrl("users", "stream.txt"), context);
 
             final String content = "Test stream content";
@@ -533,7 +499,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testRandomAccessFile() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile file = new SmbFile(createSmbUrl("users", "random.txt"), context);
 
             try (SmbRandomAccessFile raf = new SmbRandomAccessFile(file, "rw")) {
@@ -554,7 +520,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testUserCannotAccessOtherPrivateShare() throws Exception {
-            final CIFSContext context1 = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context1 = createContext(TESTUSER1, password());
             final String url = createSmbUrl("testuser2private", "file.txt");
 
             assertThrows(Exception.class, () -> {
@@ -565,7 +531,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testUserCanAccessOwnPrivateShare() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile file = new SmbFile(createSmbUrl("testuser1private", "private.txt"), context);
 
             file.createNewFile();
@@ -574,8 +540,8 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testBothUsersCanAccessUsersShare() throws Exception {
-            final CIFSContext context1 = createContext(TESTUSER1, PASSWORD);
-            final CIFSContext context2 = createContext(TESTUSER2, PASSWORD);
+            final CIFSContext context1 = createContext(TESTUSER1, password());
+            final CIFSContext context2 = createContext(TESTUSER2, password());
 
             final SmbFile file1 = new SmbFile(createSmbUrl("users", "user1file.txt"), context1);
             final SmbFile file2 = new SmbFile(createSmbUrl("users", "user2file.txt"), context2);
@@ -600,7 +566,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testFileNotFoundException() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile file = new SmbFile(createSmbUrl("users", "nonexistent.txt"), context);
 
             assertThrows(IOException.class, () -> {
@@ -610,7 +576,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testInvalidPath() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
 
             // Creating an SmbFile with invalid host doesn't throw immediately,
             // but accessing it should
@@ -629,7 +595,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testLargeFileWriteAndRead() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile file = new SmbFile(createSmbUrl("users", "large.dat"), context);
 
             final int size = 10 * 1024 * 1024; // 10MB
@@ -667,7 +633,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testCanReadAndCanWrite() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile file = new SmbFile(createSmbUrl("users", "rwtest.txt"), context);
 
             file.createNewFile();
@@ -679,7 +645,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testSetReadOnlyAndReadWrite() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile file = new SmbFile(createSmbUrl("users", "readonly.txt"), context);
 
             file.createNewFile();
@@ -696,7 +662,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testGetAndSetAttributes() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile file = new SmbFile(createSmbUrl("users", "attrtest.txt"), context);
 
             file.createNewFile();
@@ -716,7 +682,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testCreateTimeAndLastAccessTime() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile file = new SmbFile(createSmbUrl("users", "timestest.txt"), context);
 
             final long beforeCreate = System.currentTimeMillis();
@@ -736,7 +702,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testSetLastModified() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile file = new SmbFile(createSmbUrl("users", "modtest.txt"), context);
 
             file.createNewFile();
@@ -752,7 +718,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testSetFileTimes() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile file = new SmbFile(createSmbUrl("users", "filetimes.txt"), context);
 
             file.createNewFile();
@@ -770,7 +736,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testSetCreateTimeAndLastAccessTime() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile file = new SmbFile(createSmbUrl("users", "settimes.txt"), context);
 
             file.createNewFile();
@@ -790,7 +756,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testIsHidden() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile file = new SmbFile(createSmbUrl("users", "visiblefile.txt"), context);
 
             file.createNewFile();
@@ -808,7 +774,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testCopyFileInSameDirectory() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile source = new SmbFile(createSmbUrl("users", "source.txt"), context);
             final SmbFile dest = new SmbFile(createSmbUrl("users", "copy.txt"), context);
 
@@ -835,7 +801,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testCopyFileToDifferentDirectory() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile source = new SmbFile(createSmbUrl("users", "original.txt"), context);
             final SmbFile destDir = new SmbFile(createSmbUrl("users", "copydir/"), context);
             final SmbFile dest = new SmbFile(createSmbUrl("users", "copydir/original.txt"), context);
@@ -856,7 +822,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testCopyLargeFile() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile source = new SmbFile(createSmbUrl("users", "largesource.dat"), context);
             final SmbFile dest = new SmbFile(createSmbUrl("users", "largedest.dat"), context);
 
@@ -878,7 +844,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testCopyPreservesTimestampsForRegularFile() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile source = new SmbFile(createSmbUrl("users", "timestampsource.txt"), context);
             final SmbFile dest = new SmbFile(createSmbUrl("users", "timestampdest.txt"), context);
 
@@ -925,7 +891,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testCopyPreservesTimestampsForEmptyFile() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile source = new SmbFile(createSmbUrl("users", "emptysource.txt"), context);
             final SmbFile dest = new SmbFile(createSmbUrl("users", "emptydest.txt"), context);
 
@@ -961,7 +927,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testCopyPreservesTimestampsAcrossDirectories() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile sourceDir = new SmbFile(createSmbUrl("users", "srcdir/"), context);
             final SmbFile destDir = new SmbFile(createSmbUrl("users", "destdir/"), context);
 
@@ -998,7 +964,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testCopyPreservesFileAttributes() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile source = new SmbFile(createSmbUrl("users", "attrsource.txt"), context);
             final SmbFile dest = new SmbFile(createSmbUrl("users", "attrdest.txt"), context);
 
@@ -1036,7 +1002,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testCopyPreservesTimestampsForLargeFile() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile source = new SmbFile(createSmbUrl("users", "largetimestamp.dat"), context);
             final SmbFile dest = new SmbFile(createSmbUrl("users", "largetimestampdest.dat"), context);
 
@@ -1083,7 +1049,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testZeroByteFile() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile file = new SmbFile(createSmbUrl("users", "zerobyte.txt"), context);
 
             // Create empty file
@@ -1103,7 +1069,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testFileWithSpacesInName() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile file = new SmbFile(createSmbUrl("users", "file with spaces.txt"), context);
 
             file.createNewFile();
@@ -1123,7 +1089,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testFileWithSpecialCharacters() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             // Test various special characters that are typically allowed in filenames
             final SmbFile file = new SmbFile(createSmbUrl("users", "file!@#$%^&()_+-=.txt"), context);
 
@@ -1133,7 +1099,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testFileWithJapaneseCharacters() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile file = new SmbFile(createSmbUrl("users", "テストファイル.txt"), context);
 
             file.createNewFile();
@@ -1153,7 +1119,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testDeepDirectoryHierarchy() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final String deepPath = "level1/level2/level3/level4/level5/level6/level7/level8/level9/level10/";
             final SmbFile deepDir = new SmbFile(createSmbUrl("users", deepPath), context);
 
@@ -1170,7 +1136,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testManyFilesInDirectory() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile dir = new SmbFile(createSmbUrl("users", "manyfiles/"), context);
             dir.mkdir();
 
@@ -1189,7 +1155,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testEmptyDirectory() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile dir = new SmbFile(createSmbUrl("users", "emptydir/"), context);
             dir.mkdir();
 
@@ -1200,7 +1166,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testLongFileName() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             // Create a filename with 200 characters (within typical limits)
             final String longName = "a".repeat(200) + ".txt";
             final SmbFile file = new SmbFile(createSmbUrl("users", longName), context);
@@ -1211,7 +1177,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testMultipleConsecutiveOperations() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile file = new SmbFile(createSmbUrl("users", "multiop.txt"), context);
 
             // Create, write, read, modify, read again
@@ -1246,7 +1212,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testGetName() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile file = new SmbFile(createSmbUrl("users", "testfile.txt"), context);
 
             file.createNewFile();
@@ -1256,7 +1222,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testGetParent() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile file = new SmbFile(createSmbUrl("users", "subdir/file.txt"), context);
 
             final String parent = file.getParent();
@@ -1266,7 +1232,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testGetPath() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile file = new SmbFile(createSmbUrl("users", "testpath.txt"), context);
 
             file.createNewFile();
@@ -1278,7 +1244,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testGetUncPath() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile file = new SmbFile(createSmbUrl("users", "unctest.txt"), context);
 
             final String uncPath = file.getUncPath();
@@ -1290,7 +1256,7 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testGetShare() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile file = new SmbFile(createSmbUrl("users", "sharefile.txt"), context);
 
             final String share = file.getShare();
@@ -1300,17 +1266,17 @@ public class SmbFileIntegrationTest {
 
         @Test
         void testGetServer() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile file = new SmbFile(createSmbUrl("users", "servertest.txt"), context);
 
             final String server = file.getServer();
             assertNotNull(server, "Server should not be null");
-            assertEquals(sambaHost, server, "Server should match container host");
+            assertEquals(server().host(), server, "Server should match the configured host");
         }
 
         @Test
         void testGetCanonicalPath() throws Exception {
-            final CIFSContext context = createContext(TESTUSER1, PASSWORD);
+            final CIFSContext context = createContext(TESTUSER1, password());
             final SmbFile file = new SmbFile(createSmbUrl("users", "canonical.txt"), context);
 
             file.createNewFile();

--- a/src/test/java/org/codelibs/jcifs/smb/it/SpecialNamesIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/SpecialNamesIT.java
@@ -1,0 +1,97 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.SmbResource;
+import org.codelibs.jcifs.smb.impl.SmbFile;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * File names that are legal on SMB but awkward in a URL.
+ */
+class SpecialNamesIT extends AbstractSmbIT {
+
+    private SmbFile workDir;
+
+    @AfterEach
+    void removeWorkDir() throws Exception {
+        if (this.workDir != null) {
+            try {
+                final SmbResource[] children = this.workDir.listFiles();
+                if (children != null) {
+                    for (final SmbResource child : children) {
+                        deleteQuietly((SmbFile) child);
+                    }
+                }
+            } catch (final Exception e) {
+                // fall through to removing the directory itself
+            }
+            deleteQuietly(this.workDir);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "日本語ファイル.txt", "with space.txt", "with+plus.txt", "with&amp.txt", "with~tilde.txt", "with'apostrophe.txt",
+            "UPPER and lower.TXT" })
+    @DisplayName("a file with an awkward name round trips")
+    void awkwardNameRoundTrips(final String name) throws Exception {
+        final CIFSContext context = server().context();
+        this.workDir = createWorkDir(context, server().share());
+
+        final String contents = "contents of " + name;
+        final SmbFile file = writeFile(this.workDir, name, contents);
+
+        assertTrue(file.exists(), name + " was written but does not exist");
+        try (InputStream in = file.getInputStream()) {
+            assertArrayEquals(contents.getBytes(StandardCharsets.UTF_8), in.readAllBytes());
+        }
+    }
+
+    @Test
+    @DisplayName("an awkward name survives a directory listing")
+    void awkwardNameSurvivesListing() throws Exception {
+        final CIFSContext context = server().context();
+        this.workDir = createWorkDir(context, server().share());
+        final String name = "日本語 and space.txt";
+        writeFile(this.workDir, name, "listed");
+
+        final SmbResource[] children = this.workDir.listFiles();
+        assertTrue(Arrays.stream(children).anyMatch(child -> name.equals(child.getName())),
+                "listing did not contain " + name + ", it had " + Arrays.stream(children).map(SmbResource::getName).toList());
+    }
+
+    @Test
+    @DisplayName("a long name is accepted up to the SMB limit")
+    void longNameIsAccepted() throws Exception {
+        final CIFSContext context = server().context();
+        this.workDir = createWorkDir(context, server().share());
+        final String name = "l".repeat(200) + ".txt";
+        final SmbFile file = writeFile(this.workDir, name, "long");
+        assertTrue(file.exists());
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/it/SymlinkIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/SymlinkIT.java
@@ -1,0 +1,130 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.codelibs.jcifs.smb.impl.SmbFile;
+import org.codelibs.jcifs.smb.it.env.RequiresBackend;
+import org.codelibs.jcifs.smb.it.env.SmbBackend;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Symlinks inside and across a share boundary.
+ *
+ * <p>
+ * The two backends behave differently here and both are correct. Samba resolves
+ * a symlink on the server, so the client sees an ordinary file. Windows hands
+ * the reparse point back and expects the client to resolve it. That is why the
+ * tests are split by backend instead of branching.
+ * </p>
+ */
+class SymlinkIT extends AbstractSmbIT {
+
+    private static final String TARGET_CONTENTS = "target file contents\n";
+    private static final String OUTSIDE_CONTENTS = "outside the share\n";
+
+    private SmbFile shared(final String name) throws Exception {
+        return new SmbFile(server().url(server().share(), name), server().context());
+    }
+
+    private static String read(final SmbFile file) throws Exception {
+        try (InputStream in = file.getInputStream()) {
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    // ------------------------------------------------------------- Samba --
+
+    @Test
+    @RequiresBackend(SmbBackend.SAMBA)
+    @DisplayName("Samba resolves a link inside the share before the client sees it")
+    void sambaResolvesLinkInsideShare() throws Exception {
+        try (SmbFile link = shared("link-to-file")) {
+            assertTrue(link.exists(), "the link should look like an ordinary file");
+            assertEquals(TARGET_CONTENTS, read(link));
+        }
+    }
+
+    @Test
+    @RequiresBackend(SmbBackend.SAMBA)
+    @DisplayName("Samba resolves a relative link the same way")
+    void sambaResolvesRelativeLink() throws Exception {
+        try (SmbFile link = shared("link-relative")) {
+            assertEquals(TARGET_CONTENTS, read(link));
+        }
+    }
+
+    @Test
+    @RequiresBackend(SmbBackend.SAMBA)
+    @DisplayName("Samba resolves a link to a directory")
+    void sambaResolvesLinkToDirectory() throws Exception {
+        try (SmbFile link = new SmbFile(server().url(server().share(), "link-to-dir/"), server().context())) {
+            assertTrue(link.isDirectory());
+            try (SmbFile inside = new SmbFile(link, "inside.txt")) {
+                assertTrue(inside.exists());
+            }
+        }
+    }
+
+    @Test
+    @RequiresBackend(SmbBackend.SAMBA)
+    @DisplayName("Samba follows a link that points outside the share when wide links are on")
+    void sambaFollowsLinkOutsideShare() throws Exception {
+        try (SmbFile link = shared("link-outside")) {
+            assertEquals(OUTSIDE_CONTENTS, read(link));
+        }
+    }
+
+    @Test
+    @RequiresBackend(SmbBackend.SAMBA)
+    @DisplayName("a link with no target is not visible over Samba")
+    void sambaHidesBrokenLink() throws Exception {
+        try (SmbFile link = shared("link-broken")) {
+            assertFalse(link.exists());
+        }
+    }
+
+    // ----------------------------------------------------------- Windows --
+
+    @Test
+    @RequiresBackend(SmbBackend.WINDOWS)
+    @Disabled("#75: the client does not resolve reparse points. Windows returns STATUS_STOPPED_ON_SYMLINK "
+            + "with the target in the error data; enable once jcifs follows it.")
+    @DisplayName("reading through a link inside the share returns the target's contents")
+    void windowsResolvesLinkInsideShare() throws Exception {
+        try (SmbFile link = shared("link-to-file")) {
+            assertEquals(TARGET_CONTENTS, read(link));
+        }
+    }
+
+    @Test
+    @RequiresBackend(SmbBackend.WINDOWS)
+    @Disabled("#75: the client does not resolve reparse points. See windowsResolvesLinkInsideShare.")
+    @DisplayName("a link to a directory can be listed through")
+    void windowsResolvesLinkToDirectory() throws Exception {
+        try (SmbFile link = new SmbFile(server().url(server().share(), "link-to-dir/"), server().context())) {
+            assertTrue(link.isDirectory());
+        }
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/it/env/RequiresBackend.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/env/RequiresBackend.java
@@ -1,0 +1,45 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it.env;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Restricts a test or test class to a single {@link SmbBackend}.
+ *
+ * <p>
+ * Use this when the two backends have genuinely different - and both correct -
+ * behaviour. Write one test per backend rather than branching inside a single
+ * test: a branch can leave both paths unexercised while still reporting green.
+ * </p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@ExtendWith(RequiresBackendCondition.class)
+public @interface RequiresBackend {
+
+    /**
+     * The backend this test needs.
+     *
+     * @return the required backend
+     */
+    SmbBackend value();
+}

--- a/src/test/java/org/codelibs/jcifs/smb/it/env/RequiresBackendCondition.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/env/RequiresBackendCondition.java
@@ -1,0 +1,43 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it.env;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.support.AnnotationSupport;
+
+/**
+ * Evaluates {@link RequiresBackend} against the backend the harness resolved.
+ */
+public class RequiresBackendCondition implements ExecutionCondition {
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(final ExtensionContext context) {
+        final Optional<RequiresBackend> annotation = AnnotationSupport.findAnnotation(context.getElement(), RequiresBackend.class);
+        if (annotation.isEmpty()) {
+            return ConditionEvaluationResult.enabled("no backend requirement");
+        }
+        final SmbBackend required = annotation.get().value();
+        final SmbBackend actual = SmbServerResolver.resolve().backend();
+        if (required == actual) {
+            return ConditionEvaluationResult.enabled("running against " + actual);
+        }
+        return ConditionEvaluationResult.disabled("requires the " + required + " backend, running against " + actual);
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/it/env/RequiresDfs.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/env/RequiresDfs.java
@@ -1,0 +1,56 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it.env;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Restricts a test to a server that can serve DFS referrals.
+ *
+ * <p>
+ * A referral names a host but no port, so only a server reachable on 445
+ * qualifies. CI hosts have 445 free; a developer machine that is sharing files
+ * does not, and there these tests skip. When {@code JCIFS_IT_REQUIRED=true} the
+ * preflight refuses to start at all rather than let them skip unnoticed.
+ * </p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@ExtendWith(RequiresDfs.Condition.class)
+public @interface RequiresDfs {
+
+    /** Skips when the resolved server cannot serve referrals. */
+    class Condition implements ExecutionCondition {
+
+        @Override
+        public ConditionEvaluationResult evaluateExecutionCondition(final ExtensionContext context) {
+            final SmbServerFixture fixture = SmbServerResolver.resolve();
+            if (fixture.dfsAvailable()) {
+                return ConditionEvaluationResult.enabled("server is reachable on the default SMB port");
+            }
+            return ConditionEvaluationResult
+                    .disabled("DFS referrals cannot be followed: the server answers on port " + fixture.port() + " rather than 445");
+        }
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/it/env/SmbBackend.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/env/SmbBackend.java
@@ -1,0 +1,36 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it.env;
+
+/**
+ * The SMB server implementation the integration tests are running against.
+ *
+ * <p>
+ * Several behaviours are correct but different on each backend - Samba resolves
+ * symlinks inside a share on the server, Windows hands the reparse point back to
+ * the client - so tests that observe such a difference are written once per
+ * backend and selected with {@link RequiresBackend} rather than branching
+ * internally.
+ * </p>
+ */
+public enum SmbBackend {
+
+    /** Samba, either the container started by the harness or an external server. */
+    SAMBA,
+
+    /** A real Windows SMB server. */
+    WINDOWS
+}

--- a/src/test/java/org/codelibs/jcifs/smb/it/env/SmbItPreflight.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/env/SmbItPreflight.java
@@ -1,0 +1,167 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it.env;
+
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import java.util.UUID;
+
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.DialectVersion;
+import org.codelibs.jcifs.smb.impl.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbNegotiationProbe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Checks that the server really is configured the way the tests assume, before
+ * a single test runs.
+ *
+ * <p>
+ * Every check here exists because its absence produces a green run that proves
+ * nothing: an encryption test that silently ran against a plain share, or a
+ * dialect test whose configuration property was never read.
+ * </p>
+ */
+final class SmbItPreflight {
+
+    private static final Logger log = LoggerFactory.getLogger(SmbItPreflight.class);
+
+    private static final int CONNECT_TIMEOUT_MILLIS = 5000;
+    private static final int REACHABILITY_ATTEMPTS = 60;
+    private static final long REACHABILITY_INTERVAL_MILLIS = 500;
+
+    private SmbItPreflight() {
+    }
+
+    static void check(final SmbServerFixture fixture) throws Exception {
+        awaitReachable(fixture);
+        checkPlainShareIsWritable(fixture);
+        checkEncryptedShareRejectsUnencryptedClients(fixture);
+        checkDialectSettingIsHonoured(fixture);
+        checkDfsAvailability(fixture);
+        logNegotiatedState(fixture);
+    }
+
+    /**
+     * Polls until the port accepts connections. This replaces a fixed sleep: the
+     * server is ready when it answers, not after an arbitrary number of seconds.
+     */
+    private static void awaitReachable(final SmbServerFixture fixture) throws Exception {
+        Exception last = null;
+        for (int attempt = 0; attempt < REACHABILITY_ATTEMPTS; attempt++) {
+            try (Socket socket = new Socket()) {
+                socket.connect(new InetSocketAddress(fixture.host(), fixture.port()), CONNECT_TIMEOUT_MILLIS);
+                return;
+            } catch (final Exception e) {
+                last = e;
+                Thread.sleep(REACHABILITY_INTERVAL_MILLIS);
+            }
+        }
+        throw new IllegalStateException("SMB server at " + fixture.host() + ":" + fixture.port() + " never became reachable", last);
+    }
+
+    private static void checkPlainShareIsWritable(final SmbServerFixture fixture) throws Exception {
+        final String name = "preflight-" + UUID.randomUUID() + ".txt";
+        final CIFSContext context = fixture.context();
+        try (SmbFile file = new SmbFile(fixture.url(fixture.share(), name), context)) {
+            try (OutputStream out = file.getOutputStream()) {
+                out.write("preflight".getBytes(StandardCharsets.UTF_8));
+            }
+            if (!file.exists()) {
+                throw new IllegalStateException("Wrote to " + file.getPath() + " but the file does not exist");
+            }
+            file.delete();
+        }
+    }
+
+    /**
+     * The encrypted share must actually mandate encryption. An SMB 2.0.2 client
+     * cannot encrypt at all, so it is the cleanest probe: it must be refused
+     * there and accepted on the plain share.
+     */
+    private static void checkEncryptedShareRejectsUnencryptedClients(final SmbServerFixture fixture) throws Exception {
+        final Properties noEncryption = new Properties();
+        noEncryption.setProperty("jcifs.client.maxVersion", "SMB202");
+        final CIFSContext context = fixture.context(noEncryption);
+
+        try (SmbFile control = new SmbFile(fixture.url(fixture.share()), context)) {
+            if (!control.exists()) {
+                throw new IllegalStateException("An SMB 2.0.2 client cannot reach the plain share " + fixture.share()
+                        + "; the encryption probe below would be meaningless");
+            }
+        }
+
+        boolean refused = false;
+        try (SmbFile encrypted = new SmbFile(fixture.url(fixture.encryptedShare()), context)) {
+            encrypted.exists();
+        } catch (final Exception e) {
+            refused = true;
+            log.debug("Encrypted share correctly refused an unencrypted client", e);
+        }
+        if (!refused) {
+            throw new IllegalStateException("Share " + fixture.encryptedShare() + " accepted a client that cannot encrypt. "
+                    + "It is not configured to require encryption, so the encryption tests would prove nothing.");
+        }
+    }
+
+    /**
+     * Self-test of the harness. The {@code jcifs.smb.client.} prefix was renamed
+     * in 3.0.0 and the old names are read back as defaults, so a test can pin a
+     * dialect, be silently ignored and still pass. Pin one and check the wire.
+     */
+    private static void checkDialectSettingIsHonoured(final SmbServerFixture fixture) throws Exception {
+        final Properties pinned = new Properties();
+        pinned.setProperty("jcifs.client.maxVersion", "SMB210");
+        try (SmbFile file = new SmbFile(fixture.url(fixture.share()), fixture.context(pinned))) {
+            final DialectVersion negotiated = SmbNegotiationProbe.negotiatedDialect(file);
+            if (negotiated != DialectVersion.SMB210) {
+                throw new IllegalStateException("Pinned jcifs.client.maxVersion=SMB210 but negotiated " + negotiated
+                        + ". The configuration property is not being honoured, so no dialect-dependent test can be trusted.");
+            }
+        }
+    }
+
+    /**
+     * When CI demands that the tests actually run, a server that cannot serve DFS
+     * is a misconfiguration rather than a reason to skip the DFS tests.
+     */
+    private static void checkDfsAvailability(final SmbServerFixture fixture) throws Exception {
+        if (!fixture.dfsAvailable()) {
+            if (SmbServerResolver.required()) {
+                throw new IllegalStateException("SMB integration tests are required but the server answers on port " + fixture.port()
+                        + " rather than 445, so DFS referrals cannot be followed and the DFS tests would silently skip.");
+            }
+            log.info("Server is on port {}, DFS tests will skip", fixture.port());
+            return;
+        }
+        try (SmbFile root = new SmbFile(fixture.url(fixture.dfsRoot()), fixture.context())) {
+            if (!root.exists()) {
+                throw new IllegalStateException("DFS root " + fixture.dfsRoot() + " is not reachable");
+            }
+        }
+    }
+
+    private static void logNegotiatedState(final SmbServerFixture fixture) throws Exception {
+        try (SmbFile file = new SmbFile(fixture.url(fixture.share()), fixture.context())) {
+            log.info("Negotiated dialect={} signing={} against {}", SmbNegotiationProbe.negotiatedDialect(file),
+                    SmbNegotiationProbe.signingNegotiated(file), fixture);
+        }
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/it/env/SmbServerExtension.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/env/SmbServerExtension.java
@@ -1,0 +1,59 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it.env;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Resolves the SMB server once per JVM and runs the preflight checks before any
+ * integration test executes.
+ */
+public class SmbServerExtension implements BeforeAllCallback {
+
+    private static volatile boolean checked;
+    private static volatile RuntimeException failure;
+
+    @Override
+    public void beforeAll(final ExtensionContext context) throws Exception {
+        final SmbServerFixture fixture = SmbServerResolver.resolve();
+        if (checked) {
+            if (failure != null) {
+                throw failure;
+            }
+            return;
+        }
+        synchronized (SmbServerExtension.class) {
+            if (checked) {
+                if (failure != null) {
+                    throw failure;
+                }
+                return;
+            }
+            try {
+                SmbItPreflight.check(fixture);
+            } catch (final RuntimeException e) {
+                failure = e;
+                throw e;
+            } catch (final Exception e) {
+                failure = new IllegalStateException("SMB integration test preflight failed", e);
+                throw failure;
+            } finally {
+                checked = true;
+            }
+        }
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/it/env/SmbServerFixture.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/env/SmbServerFixture.java
@@ -1,0 +1,237 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it.env;
+
+import java.util.Properties;
+
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.CIFSException;
+import org.codelibs.jcifs.smb.config.PropertyConfiguration;
+import org.codelibs.jcifs.smb.context.BaseContext;
+import org.codelibs.jcifs.smb.impl.NtlmPasswordAuthenticator;
+
+/**
+ * Everything a test needs to reach the SMB server the harness resolved.
+ *
+ * <p>
+ * Tests refer to shares by role - the plain share, the encrypted share, the DFS
+ * root - never by a literal name, because the two backends are configured with
+ * the same vocabulary but the names are settable per environment.
+ * </p>
+ */
+public final class SmbServerFixture {
+
+    /** The default SMB port; a URL only carries the port when it differs from this. */
+    private static final int DEFAULT_SMB_PORT = 445;
+
+    private final SmbBackend backend;
+    private final String host;
+    private final int port;
+    private final String domain;
+    private final String user;
+    private final String password;
+    private final String share;
+    private final String encryptedShare;
+    private final String dfsRoot;
+
+    SmbServerFixture(final SmbBackend backend, final String host, final int port, final String domain, final String user,
+            final String password, final String share, final String encryptedShare, final String dfsRoot) {
+        this.backend = backend;
+        this.host = host;
+        this.port = port;
+        this.domain = domain;
+        this.user = user;
+        this.password = password;
+        this.share = share;
+        this.encryptedShare = encryptedShare;
+        this.dfsRoot = dfsRoot;
+    }
+
+    /**
+     * @return the backend under test
+     */
+    public SmbBackend backend() {
+        return this.backend;
+    }
+
+    /**
+     * @return the host the server is reachable at
+     */
+    public String host() {
+        return this.host;
+    }
+
+    /**
+     * @return the port the server is reachable at
+     */
+    public int port() {
+        return this.port;
+    }
+
+    /**
+     * @return the primary test account
+     */
+    public String user() {
+        return this.user;
+    }
+
+    /**
+     * @return the password of the primary test account
+     */
+    public String password() {
+        return this.password;
+    }
+
+    /**
+     * @return the domain of the test accounts, may be null
+     */
+    public String domain() {
+        return this.domain;
+    }
+
+    /**
+     * @return the name of the plain, unencrypted share
+     */
+    public String share() {
+        return this.share;
+    }
+
+    /**
+     * @return the name of the share that mandates SMB3 encryption
+     */
+    public String encryptedShare() {
+        return this.encryptedShare;
+    }
+
+    /**
+     * @return the name of the DFS namespace root
+     */
+    public String dfsRoot() {
+        return this.dfsRoot;
+    }
+
+    /**
+     * Whether DFS referrals can be followed against this server.
+     *
+     * <p>
+     * A referral names a host but never a port, so the client can only reconnect
+     * by following one when the server answers on the default SMB port. A Samba
+     * container published on a mapped port therefore cannot serve DFS.
+     * </p>
+     *
+     * @return true when the DFS tests can run
+     */
+    public boolean dfsAvailable() {
+        return this.port == DEFAULT_SMB_PORT;
+    }
+
+    /**
+     * Builds an SMB URL for a path inside a share.
+     *
+     * @param shareName the share to address
+     * @param path      the path inside the share, may be empty
+     * @return the SMB URL
+     */
+    public String url(final String shareName, final String path) {
+        final StringBuilder sb = new StringBuilder("smb://").append(this.host);
+        if (this.port != DEFAULT_SMB_PORT) {
+            sb.append(':').append(this.port);
+        }
+        sb.append('/').append(shareName).append('/');
+        if (path != null && !path.isEmpty()) {
+            sb.append(path);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Builds an SMB URL for the root of a share.
+     *
+     * @param shareName the share to address
+     * @return the SMB URL
+     */
+    public String url(final String shareName) {
+        return url(shareName, "");
+    }
+
+    /**
+     * @return a context for the primary test account with default settings
+     * @throws CIFSException if the configuration is rejected
+     */
+    public CIFSContext context() throws CIFSException {
+        return context(new Properties());
+    }
+
+    /**
+     * @param overrides configuration properties layered on top of the defaults
+     * @return a context for the primary test account
+     * @throws CIFSException if the configuration is rejected
+     */
+    public CIFSContext context(final Properties overrides) throws CIFSException {
+        return context(this.user, this.password, overrides);
+    }
+
+    /**
+     * @param userName the account to authenticate as
+     * @param userPassword the password of that account
+     * @return a context for the given account
+     * @throws CIFSException if the configuration is rejected
+     */
+    public CIFSContext context(final String userName, final String userPassword) throws CIFSException {
+        return context(userName, userPassword, new Properties());
+    }
+
+    /**
+     * @param userName     the account to authenticate as
+     * @param userPassword the password of that account
+     * @param overrides    configuration properties layered on top of the defaults
+     * @return a context for the given account
+     * @throws CIFSException if the configuration is rejected
+     */
+    public CIFSContext context(final String userName, final String userPassword, final Properties overrides) throws CIFSException {
+        final Properties props = defaultProperties();
+        props.putAll(overrides);
+        final BaseContext context = new BaseContext(new PropertyConfiguration(props));
+        if (userName == null) {
+            return context;
+        }
+        return context.withCredentials(new NtlmPasswordAuthenticator(this.domain, userName, userPassword));
+    }
+
+    /**
+     * The baseline client configuration for every integration test.
+     *
+     * <p>
+     * Note the {@code jcifs.client.} prefix: the {@code jcifs.smb.client.} names
+     * were renamed in 3.0.0 and are read back as their defaults, so a test using
+     * the old names pins nothing at all.
+     * </p>
+     *
+     * @return a mutable copy of the default properties
+     */
+    public Properties defaultProperties() {
+        final Properties props = new Properties();
+        props.setProperty("jcifs.client.minVersion", "SMB202");
+        props.setProperty("jcifs.client.maxVersion", "SMB311");
+        return props;
+    }
+
+    @Override
+    public String toString() {
+        return "SmbServerFixture[" + this.backend + " " + this.host + ":" + this.port + " user=" + this.user + " share=" + this.share
+                + " encrypted=" + this.encryptedShare + " dfs=" + this.dfsRoot + "]";
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/it/env/SmbServerResolver.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/env/SmbServerResolver.java
@@ -1,0 +1,223 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it.env;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Locale;
+
+import org.opentest4j.TestAbortedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+
+/**
+ * Decides which SMB server the integration tests talk to, and starts one if the
+ * environment did not supply it.
+ *
+ * <p>
+ * Three shapes are supported by a single rule:
+ * </p>
+ * <ul>
+ * <li>nothing configured - a Samba container is started by the harness</li>
+ * <li>{@code JCIFS_IT_BACKEND=windows} plus a host - a real Windows server</li>
+ * <li>{@code JCIFS_IT_BACKEND=samba} plus a host - an external Samba</li>
+ * </ul>
+ *
+ * <p>
+ * When {@code JCIFS_IT_REQUIRED=true} a missing or unusable environment is a
+ * failure rather than a skip. CI sets it, so a job cannot pass by quietly
+ * skipping every integration test.
+ * </p>
+ */
+public final class SmbServerResolver {
+
+    private static final Logger log = LoggerFactory.getLogger(SmbServerResolver.class);
+
+    /** Directory holding the Dockerfile and fixtures for the Samba backend. */
+    private static final Path SAMBA_CONTEXT = Path.of("build_helpers", "samba");
+
+    /** Kept stable so repeated local runs reuse the built image instead of rebuilding. */
+    private static final String SAMBA_IMAGE_NAME = "jcifs-it-samba:test";
+
+    private static final String DEFAULT_USER = "testuser1";
+    private static final String SECONDARY_USER = "testuser2";
+    /**
+     * Password of the accounts the fixture scripts create. It is not a secret:
+     * the account only exists on the container or CI runner that the setup
+     * script just built, and is thrown away with it.
+     */
+    private static final String DEFAULT_PASSWORD = "Public-Fixture-Not-A-Secret-1!";
+    private static final String DEFAULT_SHARE = "share";
+    private static final String DEFAULT_ENCRYPTED_SHARE = "share-encrypted";
+    private static final String DEFAULT_DFS_ROOT = "dfs";
+
+    private static SmbServerFixture fixture;
+    private static TestAbortedException skipped;
+    private static GenericContainer<?> container;
+
+    private SmbServerResolver() {
+    }
+
+    /**
+     * @return the account the fixture does not authenticate as by default, used
+     *         by the authorization tests
+     */
+    public static String secondaryUser() {
+        return SECONDARY_USER;
+    }
+
+    /**
+     * @return true when the environment forbids skipping integration tests
+     */
+    public static boolean required() {
+        return Boolean.parseBoolean(setting("REQUIRED", "false"));
+    }
+
+    /**
+     * Resolves - and on the first call possibly starts - the SMB server.
+     *
+     * @return the fixture describing how to reach it
+     */
+    public static synchronized SmbServerFixture resolve() {
+        if (fixture != null) {
+            return fixture;
+        }
+        if (skipped != null) {
+            throw skipped;
+        }
+        try {
+            fixture = build();
+            log.info("SMB integration tests are running against {}", fixture);
+            return fixture;
+        } catch (final TestAbortedException e) {
+            skipped = e;
+            throw e;
+        }
+    }
+
+    private static SmbServerFixture build() {
+        final String backendSetting = setting("BACKEND", null);
+        final String host = setting("HOST", null);
+
+        if (backendSetting != null || host != null) {
+            return externalServer(backendSetting, host);
+        }
+        return containerServer();
+    }
+
+    private static SmbServerFixture externalServer(final String backendSetting, final String host) {
+        final SmbBackend backend = parseBackend(backendSetting);
+        if (host == null) {
+            throw unusable("JCIFS_IT_BACKEND is set to " + backend + " but JCIFS_IT_HOST is not set");
+        }
+        return new SmbServerFixture(backend, host, Integer.parseInt(setting("PORT", "445")), setting("DOMAIN", null),
+                setting("USER", DEFAULT_USER), setting("PASSWORD", DEFAULT_PASSWORD), setting("SHARE", DEFAULT_SHARE),
+                setting("SHARE_ENCRYPTED", DEFAULT_ENCRYPTED_SHARE), setting("DFS_ROOT", DEFAULT_DFS_ROOT));
+    }
+
+    private static SmbBackend parseBackend(final String value) {
+        if (value == null) {
+            return SmbBackend.SAMBA;
+        }
+        try {
+            return SmbBackend.valueOf(value.trim().toUpperCase(Locale.ROOT));
+        } catch (final IllegalArgumentException e) {
+            throw new IllegalStateException("JCIFS_IT_BACKEND must be 'samba' or 'windows', was: " + value, e);
+        }
+    }
+
+    private static SmbServerFixture containerServer() {
+        if (!Files.isDirectory(SAMBA_CONTEXT)) {
+            throw new IllegalStateException("Samba build context not found at " + SAMBA_CONTEXT.toAbsolutePath()
+                    + ". Integration tests must be run from the project root.");
+        }
+        if (!DockerClientFactory.instance().isDockerAvailable()) {
+            throw unusable("no Docker daemon is available to start the Samba backend");
+        }
+
+        // Try the default port first. DFS referrals name a host but never a port,
+        // so a client can only follow them when the server answers on 445. CI
+        // hosts have 445 free; a developer machine sharing files usually does not,
+        // and then the DFS tests skip instead of failing.
+        container = startSamba(true);
+        if (container == null) {
+            log.info("Port 445 is not available on this host; the Samba backend will use a mapped port and DFS tests will skip");
+            container = startSamba(false);
+        }
+
+        return new SmbServerFixture(SmbBackend.SAMBA, container.getHost(), container.getMappedPort(445), null, DEFAULT_USER,
+                DEFAULT_PASSWORD, DEFAULT_SHARE, DEFAULT_ENCRYPTED_SHARE, DEFAULT_DFS_ROOT);
+    }
+
+    private static GenericContainer<?> startSamba(final boolean bindDefaultPort) {
+        final GenericContainer<?> candidate =
+                new GenericContainer<>(new ImageFromDockerfile(SAMBA_IMAGE_NAME, false).withFileFromPath(".", SAMBA_CONTEXT))
+                        .withExposedPorts(445)
+                        .waitingFor(Wait.forListeningPort().withStartupTimeout(Duration.ofMinutes(3)))
+                        .withLogConsumer(new Slf4jLogConsumer(log).withPrefix("samba"));
+        if (bindDefaultPort) {
+            candidate.setPortBindings(List.of("445:445"));
+        }
+        try {
+            candidate.start();
+            return candidate;
+        } catch (final RuntimeException e) {
+            if (!bindDefaultPort) {
+                throw e;
+            }
+            log.debug("Could not publish the Samba container on port 445", e);
+            try {
+                candidate.stop();
+            } catch (final RuntimeException stopFailure) {
+                log.debug("Ignoring failure while discarding the container", stopFailure);
+            }
+            return null;
+        }
+    }
+
+    /**
+     * A missing environment skips by default and fails when CI demands the tests
+     * actually run.
+     */
+    private static RuntimeException unusable(final String reason) {
+        if (required()) {
+            return new IllegalStateException("SMB integration tests are required but " + reason);
+        }
+        return new TestAbortedException("Skipping SMB integration tests: " + reason);
+    }
+
+    /**
+     * Reads a setting from {@code JCIFS_IT_<NAME>} or {@code jcifs.it.<name>}.
+     */
+    private static String setting(final String name, final String fallback) {
+        final String fromEnv = System.getenv("JCIFS_IT_" + name);
+        if (fromEnv != null && !fromEnv.isBlank()) {
+            return fromEnv;
+        }
+        final String fromProperty = System.getProperty("jcifs.it." + name.toLowerCase(Locale.ROOT).replace('_', '.'));
+        if (fromProperty != null && !fromProperty.isBlank()) {
+            return fromProperty;
+        }
+        return fallback;
+    }
+}


### PR DESCRIPTION
## Why

The integration tests started their own Samba container, so they could only ever
observe Samba's behaviour. Several open issues cannot be settled that way:

- **#70 / #71** SMB3 transform encryption — needs a share that mandates encryption
- **#75** reparse points — Samba resolves symlinks server side, so the client-side
  path never runs
- **#86 / #88** DFS referral handling — needs a real namespace

A `windows-latest` runner is a Windows Server 2025 host with the rights to create
shares, mandate encryption and install the DFS Namespaces role, so a real Windows
server is available without any virtual machine.

## What this does

One suite, two backends, selected by environment:

| `JCIFS_IT_BACKEND` | `JCIFS_IT_HOST` | server |
|---|---|---|
| unset | unset | Samba container started by the harness |
| `windows` | set | a real Windows server |
| `samba` | set | an external Samba |

Both backends are configured with the same share vocabulary — `share`,
`share-encrypted`, `dfs`, `public`, `users`, `testuser1private`,
`testuser2private` — so tests only ever refer to a share by role.

- `build_helpers/samba/` — Samba fixture. Replaces `dperson/samba:latest`, which
  could not express per-share encryption, `msdfs root` or wide links, with a
  pinned Alpine base and an explicit `smb.conf`. Signing is mandatory, matching
  the Windows Server 2025 default.
- `build_helpers/win-setup.ps1` — the same layout on Windows, including symlinks
  and a standalone DFS namespace. Skips the DFS section on a client SKU.
- `src/test/java/org/codelibs/jcifs/smb/it/` — `SmbFileIntegrationTest` moved to
  `SmbFileIT` on the new abstraction, plus suites for dialect negotiation,
  signing, encryption, authentication, DFS, symlinks, child resolution, awkward
  file names and error mapping.

Behaviour that legitimately differs between the two servers is written as one
test per backend with `@RequiresBackend`, never as a branch inside a single test.

## Guards against a green run that proves nothing

Two problems surfaced while building this, and both are now checked:

- **Failsafe was auto-detecting the JUnit 4 provider**, discovering none of the
  JUnit 5 tests and still reporting success. `surefire-junit-platform` is now
  pinned, and `build_helpers/check-it-reports.py` fails a build in which no
  integration test executed.
- **The old tests set `jcifs.smb.client.minVersion` and `maxVersion`.** Those
  names have been read as `jcifs.client.*` since 3.0.0, so they pinned nothing —
  the suite claimed to verify SMB2/3 support while negotiating whatever the
  default was. The preflight now pins a dialect and checks the wire, so the same
  class of mistake fails immediately.

The preflight also refuses to start unless the encrypted share really does reject
a client that cannot encrypt, which stops the encryption tests from silently
running against a plain share.

`JCIFS_IT_REQUIRED=true` turns a missing or unusable environment into a failure
rather than a skip. CI sets it.

Also replaces the fixed `Thread.sleep(5000)` after startup with polling.

## CI

Both backends run on every pull request. `windows-latest` is a standard
GitHub-hosted runner and free on public repositories, and a workflow reachable
only by schedule or dispatch cannot be exercised until it is already on the
default branch. The Windows job also stays on a nightly schedule so drift in the
runner image surfaces when no pull request is open.

Port 445 is free on both runners, so the DFS tests run in CI on both.

## Running it locally

```bash
mvn verify                          # Samba, nothing to install
./build_helpers/run-it-with-dfs.sh  # also runs the DFS tests
```

A DFS referral names a host but no port, so the DFS tests only run when the
server answers on 445. The second script puts Samba and the test JVM on a Docker
network so they run even on a machine whose own 445 is taken.

For a real Windows server, run `build_helpers/win-setup.ps1` there and point the
tests at it with `JCIFS_IT_BACKEND=windows` and `JCIFS_IT_HOST`.

## Verification

Both jobs are green on this pull request:

| | negotiated | result |
|---|---|---|
| `ubuntu-latest`, Samba | SMB 3.1.1, signed | 8535 unit + 104 integration, 99 executed, 5 skipped |
| `windows-latest`, Windows Server 2025 | SMB 3.1.1, signed | 8535 unit + 104 integration, 92 executed, 12 skipped |

`DfsIT` runs in full on both, including the `link` / `link-extra` pair that keeps
a permanent trap for the unbounded prefix matching behind #86 and #88.

Two encryption tests are `@Disabled` against #70/#71. On `main` the server accepts
the tree connect and then never answers `SMB2_CREATE`, so they hang. **Applied on
top of #92 they pass**, including a 3 MB payload through the encrypted share,
which makes them a usable acceptance check for that fix.

### One difference the Windows run turned up

`SmbFile.exists()` on a share root only checks that the tree connect succeeded.
Against Samba, an account that is not on the share ACL is refused there and
`exists()` rethrows, as its own contract says it should for anything that is not
a "not found" status. **Against Windows Server 2025 it returns `true`** for a
share whose ACL grants only the other account, while `listFiles()` and
`createNewFile()` on that same share are still refused — so access control holds,
but an unreachable share is reported as existing.

The two behaviours are recorded as a pair: the Samba side asserts the refusal,
and `AuthenticationIT.inaccessibleShareIsNotReportedAsExisting` states what should
hold on Windows and is `@Disabled` pending an issue. Neither test was weakened to
get the build green, and the security-relevant assertions pass on both backends.

Disabled tests always state the behaviour that should hold, never the current
behaviour, and each carries its reason. `check-it-reports.py` lists them in the
job summary so they stay visible.
