### PR TITLE
test(it): pin how each server answers exists() on a share it refuses

### DIFF
--- a/build_helpers/win-setup.ps1
+++ b/build_helpers/win-setup.ps1
@@ -42,10 +42,21 @@ foreach ($name in $shareNames) {
 }
 New-Item -Path $OutsideRoot -ItemType Directory -Force | Out-Null
 
-# Share level permissions are what restrict the private shares; NTFS stays open
-# so the accounts can write everywhere they are allowed to connect.
-icacls $Root /grant 'testuser1:(OI)(CI)F' 'testuser2:(OI)(CI)F' /T /Q | Out-Null
+# Both accounts share the common directories.
+foreach ($name in @('share', 'share-encrypted', 'dfs', 'public', 'users')) {
+    icacls (Join-Path $Root $name) /grant 'testuser1:(OI)(CI)F' 'testuser2:(OI)(CI)F' /T /Q | Out-Null
+}
 icacls $OutsideRoot /grant 'testuser1:(OI)(CI)F' 'testuser2:(OI)(CI)F' /T /Q | Out-Null
+
+# The private directories are private at the NTFS layer as well as the share
+# layer, the way a real deployment would restrict them. Inheritance is turned off
+# first: a grant applied with /T leaves an explicit ACE that /inheritance:r would
+# not remove.
+foreach ($user in $testUsers) {
+    $privatePath = Join-Path $Root "${user}private"
+    icacls $privatePath /inheritance:r /Q | Out-Null
+    icacls $privatePath /grant 'BUILTIN\Administrators:(OI)(CI)F' 'NT AUTHORITY\SYSTEM:(OI)(CI)F' "${user}:(OI)(CI)F" /T /Q | Out-Null
+}
 
 Write-Host 'Creating SMB shares'
 $sharedByBoth = @('share', 'dfs', 'public', 'users')
@@ -136,6 +147,11 @@ Set-NetFirewallRule -Name FPS-SMB-In-TCP -Enabled True
 Set-Service -Name LanmanServer -StartupType Automatic -Status Running
 
 Write-Host ''
+Write-Host 'NTFS permissions on the private shares:'
+foreach ($user in $testUsers) {
+    icacls (Join-Path $Root "${user}private") | Out-String | Write-Host
+}
+
 Write-Host 'Share permissions as configured:'
 Get-SmbShare | Where-Object { $_.Name -ne 'IPC$' } | Get-SmbShareAccess |
     Format-Table -AutoSize ScaleOut, Name, AccountName, AccessControlType, AccessRight | Out-String | Write-Host

--- a/src/main/java/org/codelibs/jcifs/smb/SmbResource.java
+++ b/src/main/java/org/codelibs/jcifs/smb/SmbResource.java
@@ -82,6 +82,15 @@ public interface SmbResource extends AutoCloseable {
      * this <code>SmbResource</code> is a traditional file or directory, it will
      * be queried for on the specified server as expected.
      *
+     * <p>
+     * For a share root this reflects whether the tree connect succeeded, which is
+     * all the protocol offers at that level, and servers answer it differently:
+     * Windows accepts the tree connect for an account the share's ACL excludes and
+     * refuses at open, while Samba refuses the tree connect itself. A
+     * <code>true</code> here therefore says the share is present, not that it can
+     * be read.
+     * </p>
+     *
      * @return <code>true</code> if the resource exists or is alive or
      *         <code>false</code> otherwise
      * @throws CIFSException if an error occurs accessing the resource

--- a/src/test/java/org/codelibs/jcifs/smb/it/AuthenticationIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/AuthenticationIT.java
@@ -27,7 +27,6 @@ import org.codelibs.jcifs.smb.impl.SmbFile;
 import org.codelibs.jcifs.smb.it.env.RequiresBackend;
 import org.codelibs.jcifs.smb.it.env.SmbBackend;
 import org.codelibs.jcifs.smb.it.env.SmbServerResolver;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -79,17 +78,20 @@ class AuthenticationIT extends AbstractSmbIT {
 
     @Test
     @RequiresBackend(SmbBackend.WINDOWS)
-    @Disabled("Measured on Windows Server 2025: exists() returns true for a share the account cannot connect to. "
-            + "The share ACL grants only the other account, listFiles() on the same share is still refused, and "
-            + "Samba rethrows the tree connect denial as exists() is documented to. Needs an issue before enabling.")
-    @DisplayName("a share the account cannot connect to is not reported as existing")
-    void inaccessibleShareIsNotReportedAsExisting() throws Exception {
+    @DisplayName("a share the account cannot read still reports that it exists")
+    void inaccessibleShareStillReportsThatItExists() throws Exception {
+        // Measured against Windows Server 2025 with the share ACL and the NTFS ACL
+        // both granting only the other account. Windows accepts the tree connect
+        // anyway and refuses at open. exists() on a share root can only report
+        // whether the tree connect succeeded, so it answers true - and the share
+        // does exist. The Samba counterpart is
+        // SmbFileIT.ConnectionAndAuthenticationTests.testAccessDeniedToPrivateShare,
+        // where the tree connect itself is refused.
         final CIFSContext context = server().context();
-        assertThrows(SmbException.class, () -> {
-            try (SmbFile share = new SmbFile(server().url("testuser2private"), context)) {
-                share.exists();
-            }
-        }, "an unreachable share must not be reported as existing");
+        try (SmbFile share = new SmbFile(server().url("testuser2private"), context)) {
+            assertTrue(share.exists(), "the share is present on the server");
+            assertThrows(SmbException.class, share::listFiles, "but testuser1 must not be able to read it");
+        }
     }
 
     @Test

--- a/src/test/java/org/codelibs/jcifs/smb/it/SmbFileIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/SmbFileIT.java
@@ -154,8 +154,9 @@ class SmbFileIT extends AbstractSmbIT {
         @Test
         @RequiresBackend(SmbBackend.SAMBA)
         // Samba refuses the tree connect, and exists() rethrows anything that is
-        // not a "not found" status. Windows answers differently - see
-        // AuthenticationIT.inaccessibleShareIsNotReportedAsExisting.
+        // not a "not found" status. Windows accepts the tree connect and refuses at
+        // open instead - see
+        // AuthenticationIT.inaccessibleShareStillReportsThatItExists.
         void testAccessDeniedToPrivateShare() throws Exception {
             final CIFSContext context = createContext(TESTUSER1, password());
             final String url = createSmbUrl("testuser2private", "");


### PR DESCRIPTION
Stacked on #93. Merge that first.

## What this settles

#93's first run against a real Windows server turned up a disagreement:
`SmbFile.exists()` returns `true` on Windows Server 2025 for a share the account
cannot read, while Samba refuses and `exists()` rethrows. That was left
`@Disabled` there pending an explanation. This is the explanation.

Measured on the Windows runner, with `testuser2private` granted to `testuser2`
only in **both** the share ACL and the NTFS ACL:

```
PROBE[denied] exists()   -> true
PROBE[denied] tree        connectedShare=TESTUSER2PRIVATE connected=true
PROBE[denied] listFiles() -> SmbAuthException ntStatus=0xc0000022
```

against Samba, same fixture, same account:

```
PROBE[denied] exists()   -> SmbAuthException: Access is denied.
PROBE[denied] tree       -> SmbAuthException: Access is denied.
PROBE[denied] listFiles() -> SmbAuthException ntStatus=0xc0000022
```

**Windows accepts the tree connect whatever the ACLs say and refuses at open;
Samba refuses the tree connect itself.** `exists()` on a share root can only
report whether the tree connect succeeded — that is all the protocol offers at
that level — so it answers `true` on one and rethrows on the other.

Both answers are faithful, and on Windows `true` is also the correct answer to the
question asked: the share is present. **This is not a client defect and nothing in
the client changes here.**

## What changes

- `AuthenticationIT.inaccessibleShareStillReportsThatItExists` asserts the Windows
  contract, and asserts in the same test that reading is still refused, so the
  pair cannot quietly drift into access being open.
- `SmbFileIT.testAccessDeniedToPrivateShare` keeps the Samba contract and names
  its counterpart.
- No test is left `@Disabled` for this.
- `SmbResource.exists()` now says what it means for a share root, since the answer
  is server dependent and nothing else said so.

## Fixture fix found on the way

The Windows fixture's private shares were restricted at the share layer but not at
NTFS: the earlier blanket `icacls ... /T` leaves an **explicit** ACE, which
`/inheritance:r` does not remove, so both accounts kept full control on disk. The
private directories now clear inheritance first and grant one account each. The
finding above was re-measured after that and is unchanged.

The setup script also prints the resulting share and NTFS permissions, so a future
failure here can be read off the run log instead of guessed at.
