### PR TITLE
feat(smb2): report the symbolic link target on STATUS_STOPPED_ON_SYMLINK

### DIFF
--- a/src/main/java/org/codelibs/jcifs/smb/impl/NtStatus.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/NtStatus.java
@@ -176,6 +176,8 @@ public interface NtStatus {
     int NT_STATUS_IO_REPARSE_TAG_NOT_HANDLED = 0xC0000279;
     /** No more files were found matching the file specification */
     int NT_STATUS_NO_MORE_FILES = 0x80000006;
+    /** The create operation stopped after reaching a symbolic link */
+    int NT_STATUS_STOPPED_ON_SYMLINK = 0x8000002D;
 
     /** Array of all NT status codes defined in this interface */
     int[] NT_STATUS_CODES = { NT_STATUS_SUCCESS, NT_STATUS_PENDING, NT_STATUS_NOTIFY_ENUM_DIR, NT_STATUS_BUFFER_OVERFLOW,
@@ -195,7 +197,7 @@ public interface NtStatus {
             NT_STATUS_LOGON_TYPE_NOT_GRANTED, NT_STATUS_NO_TRUST_SAM_ACCOUNT, NT_STATUS_TRUSTED_DOMAIN_FAILURE,
             NT_STATUS_TRUSTED_RELATIONSHIP_FAILURE, NT_STATUS_NOLOGON_WORKSTATION_TRUST_ACCOUNT, NT_STATUS_PASSWORD_MUST_CHANGE,
             NT_STATUS_NOT_FOUND, NT_STATUS_ACCOUNT_LOCKED_OUT, NT_STATUS_CONNECTION_REFUSED, NT_STATUS_PATH_NOT_COVERED,
-            NT_STATUS_IO_REPARSE_TAG_NOT_HANDLED, NT_STATUS_NO_MORE_FILES, };
+            NT_STATUS_IO_REPARSE_TAG_NOT_HANDLED, NT_STATUS_NO_MORE_FILES, NT_STATUS_STOPPED_ON_SYMLINK, };
 
     /** Array of human-readable messages corresponding to NT_STATUS_CODES */
     String[] NT_STATUS_MESSAGES = { "The operation completed successfully.", "Request is pending",
@@ -233,5 +235,6 @@ public interface NtStatus {
             "The referenced account is currently locked out and may not be logged on to.", "Connection refused",
             "The remote system is not reachable by the transport.",
             "The layered file system driver for this I/O tag did not handle it when needed.",
-            "No more files were found that match the file specification.", };
+            "No more files were found that match the file specification.",
+            "The create operation stopped after reaching a symbolic link.", };
 }

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbSymlinkException.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbSymlinkException.java
@@ -1,0 +1,122 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.impl;
+
+import org.codelibs.jcifs.smb.internal.smb2.Smb2SymlinkErrorResponse;
+
+/**
+ * Thrown when a server answers STATUS_STOPPED_ON_SYMLINK, meaning the path traverses a symbolic link
+ * that the server will not follow on the client's behalf.
+ *
+ * <p>
+ * jCIFS does not resolve symbolic links, so the operation fails. This exception carries the link
+ * target the server disclosed, letting callers report or follow it themselves. Being an
+ * {@link SmbException}, it is still caught by existing handlers, and {@link #getNtStatus()} still
+ * returns STATUS_STOPPED_ON_SYMLINK.
+ * </p>
+ *
+ * <p>
+ * Beware that the target is the server's own view of the link. A relative target
+ * ({@link #isRelative()}) is relative to the directory holding the link; an absolute one is
+ * expressed in the server's namespace and need not be reachable through this share at all.
+ * </p>
+ */
+public class SmbSymlinkException extends SmbException {
+
+    private static final long serialVersionUID = 1L;
+
+    /** The path that was requested when the server stopped on the link, or null if unknown. */
+    private final String path;
+
+    /** The link target as the server stores it. */
+    private final String substituteName;
+
+    /** The link target in display form. */
+    private final String printName;
+
+    /** Whether the target is relative to the directory holding the link. */
+    private final boolean relative;
+
+    /** UTF-16 byte count of the requested path the server had not consumed. */
+    private final int unparsedPathLength;
+
+    SmbSymlinkException(final String path, final Smb2SymlinkErrorResponse symlink) {
+        super(NtStatus.NT_STATUS_STOPPED_ON_SYMLINK, null);
+        this.path = path;
+        this.substituteName = symlink.getSubstituteName();
+        this.printName = symlink.getPrintName();
+        this.relative = symlink.isRelative();
+        this.unparsedPathLength = symlink.getUnparsedPathLength();
+    }
+
+    @Override
+    public String getMessage() {
+        return super.getMessage() + " " + (this.path != null ? this.path : "The path") + " points to "
+                + (this.relative ? "the relative target " : "the absolute target ") + '"' + this.substituteName + '"'
+                + ", which jCIFS does not resolve.";
+    }
+
+    /**
+     * Returns the path that was requested when the server stopped on the link, if known.
+     *
+     * @return the requested path, or null
+     */
+    public String getPath() {
+        return this.path;
+    }
+
+    /**
+     * Returns the link target as the server stores it. This is the name to resolve against, and is
+     * interpreted according to {@link #isRelative()}.
+     *
+     * @return the substitute name
+     */
+    public String getSubstituteName() {
+        return this.substituteName;
+    }
+
+    /**
+     * Returns the link target in a form meant for display, which may differ from the substitute name
+     * and is not suitable for resolution.
+     *
+     * @return the print name
+     */
+    public String getPrintName() {
+        return this.printName;
+    }
+
+    /**
+     * Whether the target is relative to the directory containing the link. An absolute target is
+     * expressed in the server's own namespace, in forms such as {@code \??\C:\...} on Windows, and
+     * is not necessarily reachable through this share.
+     *
+     * @return true if the target is relative
+     */
+    public boolean isRelative() {
+        return this.relative;
+    }
+
+    /**
+     * Returns how many bytes at the end of the requested path the server had not consumed when it
+     * hit the link, as a UTF-16 byte count. Resolving the link means substituting the target for
+     * everything ahead of that tail.
+     *
+     * @return the unparsed path length in bytes
+     */
+    public int getUnparsedPathLength() {
+        return this.unparsedPathLength;
+    }
+}

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbTransportImpl.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbTransportImpl.java
@@ -75,6 +75,7 @@ import org.codelibs.jcifs.smb.internal.smb2.ServerMessageBlock2Request;
 import org.codelibs.jcifs.smb.internal.smb2.ServerMessageBlock2Response;
 import org.codelibs.jcifs.smb.internal.smb2.Smb2Constants;
 import org.codelibs.jcifs.smb.internal.smb2.Smb2EncryptionContext;
+import org.codelibs.jcifs.smb.internal.smb2.Smb2SymlinkErrorResponse;
 import org.codelibs.jcifs.smb.internal.smb2.Smb3KeyDerivation;
 import org.codelibs.jcifs.smb.internal.smb2.io.Smb2ReadResponse;
 import org.codelibs.jcifs.smb.internal.smb2.ioctl.Smb2IoctlRequest;
@@ -1386,6 +1387,8 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
             checkReferral(resp, path, (RequestWithPath) req);
             // checkReferral always throws and exception but put break here for clarity
             break;
+        case NtStatus.NT_STATUS_STOPPED_ON_SYMLINK:
+            throw createSymlinkException(req, resp);
         case NtStatus.NT_STATUS_BUFFER_OVERFLOW:
             if (resp instanceof Smb2ReadResponse) {
                 break;
@@ -1407,6 +1410,29 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
             throw new SMBSignatureValidationException("Signature verification failed.");
         }
         return cont;
+    }
+
+    /**
+     * Builds the exception for a STATUS_STOPPED_ON_SYMLINK response, carrying the link target the
+     * server disclosed. Falls back to a plain {@link SmbException} if that data cannot be decoded,
+     * so a malformed response never turns into something worse than the status itself.
+     *
+     * @param req the request that hit the link
+     * @param resp its response
+     * @return the exception to throw
+     */
+    private static SmbException createSymlinkException(final ServerMessageBlock2 req, final Response resp) {
+        if (resp instanceof ServerMessageBlock2) {
+            final ServerMessageBlock2 r = (ServerMessageBlock2) resp;
+            try {
+                final Smb2SymlinkErrorResponse symlink = Smb2SymlinkErrorResponse.decode(r.getErrorData(), r.getErrorContextCount());
+                final String path = req instanceof RequestWithPath ? ((RequestWithPath) req).getFullUNCPath() : null;
+                return new SmbSymlinkException(path, symlink);
+            } catch (final SMBProtocolDecodingException e) {
+                log.debug("Failed to decode symlink error data", e);
+            }
+        }
+        return new SmbException(NtStatus.NT_STATUS_STOPPED_ON_SYMLINK, null);
     }
 
     /**

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbTransportImpl.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbTransportImpl.java
@@ -1429,7 +1429,7 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
                 final String path = req instanceof RequestWithPath ? ((RequestWithPath) req).getFullUNCPath() : null;
                 return new SmbSymlinkException(path, symlink);
             } catch (final SMBProtocolDecodingException e) {
-                log.debug("Failed to decode symlink error data", e);
+                log.warn("Could not decode the symlink error data, reporting the status alone", e);
             }
         }
         return new SmbException(NtStatus.NT_STATUS_STOPPED_ON_SYMLINK, null);

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/Smb2SymlinkErrorResponse.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/Smb2SymlinkErrorResponse.java
@@ -1,0 +1,200 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.internal.smb2;
+
+import org.codelibs.jcifs.smb.internal.SMBProtocolDecodingException;
+import org.codelibs.jcifs.smb.internal.util.SMBUtil;
+import org.codelibs.jcifs.smb.util.Strings;
+
+/**
+ * The SMB2_SYMLINK_ERROR_RESPONSE a server returns alongside STATUS_STOPPED_ON_SYMLINK, telling the
+ * client where the link it refused to follow actually points.
+ *
+ * <p>
+ * See MS-SMB2 2.2.2.2.1. Over SMB 3.1.1 the payload is wrapped in an SMB2 ERROR Context (MS-SMB2
+ * 2.2.2.1); earlier dialects place the same structure directly in ErrorData. The response's
+ * ErrorContextCount says which form arrived, so both are accepted here.
+ * </p>
+ */
+public final class Smb2SymlinkErrorResponse {
+
+    /** Marks the error data as a symbolic link error response ("SYML" in little endian). */
+    public static final int SYMLINK_ERROR_TAG = 0x4C4D5953;
+
+    /** The reparse point tag identifying a symbolic link (MS-FSCC 2.1.2.4). */
+    public static final int IO_REPARSE_TAG_SYMLINK = 0xA000000C;
+
+    /** SYMLINK_FLAG_RELATIVE: the substitute name is relative to the link's own directory. */
+    private static final int SYMLINK_FLAG_RELATIVE = 0x1;
+
+    /** Size of the SMB2 ERROR Context header that SMB 3.1.1 prepends. */
+    private static final int ERROR_CONTEXT_HEADER_SIZE = 8;
+
+    /** Size of the fixed part of SMB2_SYMLINK_ERROR_RESPONSE, up to but excluding PathBuffer. */
+    private static final int FIXED_SIZE = 28;
+
+    /**
+     * Number of bytes ReparseDataLength covers before PathBuffer: the four name offset/length
+     * fields plus Flags.
+     */
+    private static final int REPARSE_DATA_HEADER_SIZE = 12;
+
+    private final int unparsedPathLength;
+    private final boolean relative;
+    private final String substituteName;
+    private final String printName;
+
+    private Smb2SymlinkErrorResponse(final int unparsedPathLength, final boolean relative, final String substituteName,
+            final String printName) {
+        this.unparsedPathLength = unparsedPathLength;
+        this.relative = relative;
+        this.substituteName = substituteName;
+        this.printName = printName;
+    }
+
+    /**
+     * Decodes the symbolic link error data carried by a STATUS_STOPPED_ON_SYMLINK response.
+     *
+     * @param errorData the raw ErrorData of the SMB2 error response
+     * @param errorContextCount the response's ErrorContextCount; non-zero means the payload is
+     *            wrapped in an SMB2 ERROR Context, as SMB 3.1.1 does
+     * @return the decoded symbolic link error response
+     * @throws SMBProtocolDecodingException if the data is absent, truncated, or not a symbolic link
+     *             error response
+     */
+    public static Smb2SymlinkErrorResponse decode(final byte[] errorData, final int errorContextCount) throws SMBProtocolDecodingException {
+        if (errorData == null) {
+            throw new SMBProtocolDecodingException("Symlink error response carries no error data");
+        }
+
+        int bufferIndex = 0;
+        if (errorContextCount > 0) {
+            if (errorData.length < ERROR_CONTEXT_HEADER_SIZE) {
+                throw new SMBProtocolDecodingException("Truncated SMB2 error context header: " + errorData.length + " bytes");
+            }
+            final int contextDataLength = SMBUtil.readInt4(errorData, 0);
+            bufferIndex = ERROR_CONTEXT_HEADER_SIZE;
+            if (contextDataLength < 0 || contextDataLength > errorData.length - bufferIndex) {
+                throw new SMBProtocolDecodingException("SMB2 error context claims " + contextDataLength + " bytes but only "
+                        + (errorData.length - bufferIndex) + " are present");
+            }
+        }
+
+        final int available = errorData.length - bufferIndex;
+        if (available < FIXED_SIZE) {
+            throw new SMBProtocolDecodingException("Truncated symlink error response: " + available + " bytes");
+        }
+
+        final int symLinkLength = SMBUtil.readInt4(errorData, bufferIndex);
+        final int symLinkErrorTag = SMBUtil.readInt4(errorData, bufferIndex + 4);
+        final int reparseTag = SMBUtil.readInt4(errorData, bufferIndex + 8);
+
+        if (symLinkErrorTag != SYMLINK_ERROR_TAG) {
+            throw new SMBProtocolDecodingException(
+                    "Not a symlink error response, SymLinkErrorTag is 0x" + Integer.toHexString(symLinkErrorTag));
+        }
+        if (reparseTag != IO_REPARSE_TAG_SYMLINK) {
+            throw new SMBProtocolDecodingException("Unsupported reparse tag 0x" + Integer.toHexString(reparseTag));
+        }
+        // SymLinkLength covers everything from SymLinkErrorTag onwards
+        if (symLinkLength < FIXED_SIZE - 4 || symLinkLength > available - 4) {
+            throw new SMBProtocolDecodingException("Invalid SymLinkLength " + symLinkLength + " for " + available + " bytes");
+        }
+
+        final int reparseDataLength = SMBUtil.readInt2(errorData, bufferIndex + 12);
+        final int unparsedPathLength = SMBUtil.readInt2(errorData, bufferIndex + 14);
+        final int substituteNameOffset = SMBUtil.readInt2(errorData, bufferIndex + 16);
+        final int substituteNameLength = SMBUtil.readInt2(errorData, bufferIndex + 18);
+        final int printNameOffset = SMBUtil.readInt2(errorData, bufferIndex + 20);
+        final int printNameLength = SMBUtil.readInt2(errorData, bufferIndex + 22);
+        final int flags = SMBUtil.readInt4(errorData, bufferIndex + 24);
+
+        // ReparseDataLength covers the name offset/length fields, Flags, and PathBuffer
+        if (reparseDataLength < REPARSE_DATA_HEADER_SIZE) {
+            throw new SMBProtocolDecodingException("Invalid ReparseDataLength " + reparseDataLength);
+        }
+        final int pathBufferIndex = bufferIndex + FIXED_SIZE;
+        final int pathBufferLength = reparseDataLength - REPARSE_DATA_HEADER_SIZE;
+        if (pathBufferLength > errorData.length - pathBufferIndex) {
+            throw new SMBProtocolDecodingException("ReparseDataLength " + reparseDataLength + " overruns the error data");
+        }
+        if (unparsedPathLength % 2 != 0) {
+            throw new SMBProtocolDecodingException("UnparsedPathLength " + unparsedPathLength + " is not a UTF-16 length");
+        }
+
+        checkName("SubstituteName", substituteNameOffset, substituteNameLength, pathBufferLength);
+        checkName("PrintName", printNameOffset, printNameLength, pathBufferLength);
+
+        return new Smb2SymlinkErrorResponse(unparsedPathLength, (flags & SYMLINK_FLAG_RELATIVE) == SYMLINK_FLAG_RELATIVE,
+                Strings.fromUNIBytes(errorData, pathBufferIndex + substituteNameOffset, substituteNameLength),
+                Strings.fromUNIBytes(errorData, pathBufferIndex + printNameOffset, printNameLength));
+    }
+
+    private static void checkName(final String what, final int offset, final int length, final int pathBufferLength)
+            throws SMBProtocolDecodingException {
+        if (offset < 0 || length < 0 || length % 2 != 0 || offset > pathBufferLength || length > pathBufferLength - offset) {
+            throw new SMBProtocolDecodingException(
+                    what + " at " + offset + " length " + length + " does not fit a " + pathBufferLength + " byte path buffer");
+        }
+    }
+
+    /**
+     * Returns the number of bytes at the end of the requested path that the server did not consume
+     * before it hit the link, as a UTF-16 byte count. Resolving the link means replacing everything
+     * before this tail.
+     *
+     * @return the unparsed path length in bytes
+     */
+    public int getUnparsedPathLength() {
+        return this.unparsedPathLength;
+    }
+
+    /**
+     * Whether the substitute name is relative to the directory containing the link. An absolute
+     * target is expressed in the server's own namespace (a Windows server sends forms such as
+     * {@code \??\C:\...}), which is not necessarily reachable through this share.
+     *
+     * @return true if SYMLINK_FLAG_RELATIVE is set
+     */
+    public boolean isRelative() {
+        return this.relative;
+    }
+
+    /**
+     * Returns the link target as the server stores it. This is the name to resolve against.
+     *
+     * @return the substitute name
+     */
+    public String getSubstituteName() {
+        return this.substituteName;
+    }
+
+    /**
+     * Returns the link target in a form meant for display, which may differ from the substitute
+     * name and is not suitable for resolution.
+     *
+     * @return the print name
+     */
+    public String getPrintName() {
+        return this.printName;
+    }
+
+    @Override
+    public String toString() {
+        return "Smb2SymlinkErrorResponse[substituteName=" + this.substituteName + ",printName=" + this.printName + ",relative="
+                + this.relative + ",unparsedPathLength=" + this.unparsedPathLength + "]";
+    }
+}

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/Smb2SymlinkErrorResponse.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/Smb2SymlinkErrorResponse.java
@@ -68,39 +68,75 @@ public final class Smb2SymlinkErrorResponse {
     /**
      * Decodes the symbolic link error data carried by a STATUS_STOPPED_ON_SYMLINK response.
      *
+     * <p>
+     * When the response carries error contexts, each is tried in turn: MS-SMB2 2.2.2 permits more
+     * than one, and does not promise the symbolic link context comes first. A context is accepted
+     * only if its payload carries the SYML tag, which identifies it more precisely than ErrorId
+     * would.
+     * </p>
+     *
      * @param errorData the raw ErrorData of the SMB2 error response
      * @param errorContextCount the response's ErrorContextCount; non-zero means the payload is
-     *            wrapped in an SMB2 ERROR Context, as SMB 3.1.1 does
+     *            wrapped in one or more SMB2 ERROR Contexts, as SMB 3.1.1 does
      * @return the decoded symbolic link error response
-     * @throws SMBProtocolDecodingException if the data is absent, truncated, or not a symbolic link
-     *             error response
+     * @throws SMBProtocolDecodingException if the data is absent, truncated, or carries no symbolic
+     *             link error response
      */
     public static Smb2SymlinkErrorResponse decode(final byte[] errorData, final int errorContextCount) throws SMBProtocolDecodingException {
         if (errorData == null) {
             throw new SMBProtocolDecodingException("Symlink error response carries no error data");
         }
+        if (errorContextCount <= 0) {
+            return decodeSymlinkResponse(errorData, 0, errorData.length);
+        }
 
+        SMBProtocolDecodingException failure = null;
         int bufferIndex = 0;
-        if (errorContextCount > 0) {
-            if (errorData.length < ERROR_CONTEXT_HEADER_SIZE) {
-                throw new SMBProtocolDecodingException("Truncated SMB2 error context header: " + errorData.length + " bytes");
+        for (int i = 0; i < errorContextCount; i++) {
+            if (bufferIndex > errorData.length - ERROR_CONTEXT_HEADER_SIZE) {
+                break;
             }
-            final int contextDataLength = SMBUtil.readInt4(errorData, 0);
-            bufferIndex = ERROR_CONTEXT_HEADER_SIZE;
-            if (contextDataLength < 0 || contextDataLength > errorData.length - bufferIndex) {
+            final int contextDataLength = SMBUtil.readInt4(errorData, bufferIndex);
+            final int contextDataIndex = bufferIndex + ERROR_CONTEXT_HEADER_SIZE;
+            if (contextDataLength < 0 || contextDataLength > errorData.length - contextDataIndex) {
                 throw new SMBProtocolDecodingException("SMB2 error context claims " + contextDataLength + " bytes but only "
-                        + (errorData.length - bufferIndex) + " are present");
+                        + (errorData.length - contextDataIndex) + " are present");
             }
+            try {
+                return decodeSymlinkResponse(errorData, contextDataIndex, contextDataLength);
+            } catch (final SMBProtocolDecodingException e) {
+                // not the symbolic link context, or a malformed one: keep looking
+                failure = e;
+            }
+            // each context starts on an 8 byte boundary relative to the start of the error response,
+            // which is where this buffer begins
+            bufferIndex = contextDataIndex + contextDataLength;
+            bufferIndex += (8 - bufferIndex % 8) % 8;
+        }
+        if (failure != null) {
+            throw failure;
+        }
+        throw new SMBProtocolDecodingException("No symbolic link error context in " + errorContextCount + " contexts");
+    }
+
+    /**
+     * Decodes one SMB2_SYMLINK_ERROR_RESPONSE. Every read is bounded by the declared lengths rather
+     * than by the size of the enclosing buffer, so a structure that overstates its own extent cannot
+     * reach whatever happens to follow it.
+     *
+     * @param errorData the buffer to read from
+     * @param start where the structure begins
+     * @param length how many bytes the enclosing context declares
+     */
+    private static Smb2SymlinkErrorResponse decodeSymlinkResponse(final byte[] errorData, final int start, final int length)
+            throws SMBProtocolDecodingException {
+        if (length < FIXED_SIZE) {
+            throw new SMBProtocolDecodingException("Truncated symlink error response: " + length + " bytes");
         }
 
-        final int available = errorData.length - bufferIndex;
-        if (available < FIXED_SIZE) {
-            throw new SMBProtocolDecodingException("Truncated symlink error response: " + available + " bytes");
-        }
-
-        final int symLinkLength = SMBUtil.readInt4(errorData, bufferIndex);
-        final int symLinkErrorTag = SMBUtil.readInt4(errorData, bufferIndex + 4);
-        final int reparseTag = SMBUtil.readInt4(errorData, bufferIndex + 8);
+        final int symLinkLength = SMBUtil.readInt4(errorData, start);
+        final int symLinkErrorTag = SMBUtil.readInt4(errorData, start + 4);
+        final int reparseTag = SMBUtil.readInt4(errorData, start + 8);
 
         if (symLinkErrorTag != SYMLINK_ERROR_TAG) {
             throw new SMBProtocolDecodingException(
@@ -109,27 +145,27 @@ public final class Smb2SymlinkErrorResponse {
         if (reparseTag != IO_REPARSE_TAG_SYMLINK) {
             throw new SMBProtocolDecodingException("Unsupported reparse tag 0x" + Integer.toHexString(reparseTag));
         }
-        // SymLinkLength covers everything from SymLinkErrorTag onwards
-        if (symLinkLength < FIXED_SIZE - 4 || symLinkLength > available - 4) {
-            throw new SMBProtocolDecodingException("Invalid SymLinkLength " + symLinkLength + " for " + available + " bytes");
+        // SymLinkLength covers everything from SymLinkErrorTag onwards, and bounds the rest of the read
+        if (symLinkLength < FIXED_SIZE - 4 || symLinkLength > length - 4) {
+            throw new SMBProtocolDecodingException("Invalid SymLinkLength " + symLinkLength + " for " + length + " bytes");
         }
 
-        final int reparseDataLength = SMBUtil.readInt2(errorData, bufferIndex + 12);
-        final int unparsedPathLength = SMBUtil.readInt2(errorData, bufferIndex + 14);
-        final int substituteNameOffset = SMBUtil.readInt2(errorData, bufferIndex + 16);
-        final int substituteNameLength = SMBUtil.readInt2(errorData, bufferIndex + 18);
-        final int printNameOffset = SMBUtil.readInt2(errorData, bufferIndex + 20);
-        final int printNameLength = SMBUtil.readInt2(errorData, bufferIndex + 22);
-        final int flags = SMBUtil.readInt4(errorData, bufferIndex + 24);
+        final int reparseDataLength = SMBUtil.readInt2(errorData, start + 12);
+        final int unparsedPathLength = SMBUtil.readInt2(errorData, start + 14);
+        final int substituteNameOffset = SMBUtil.readInt2(errorData, start + 16);
+        final int substituteNameLength = SMBUtil.readInt2(errorData, start + 18);
+        final int printNameOffset = SMBUtil.readInt2(errorData, start + 20);
+        final int printNameLength = SMBUtil.readInt2(errorData, start + 22);
+        final int flags = SMBUtil.readInt4(errorData, start + 24);
 
         // ReparseDataLength covers the name offset/length fields, Flags, and PathBuffer
         if (reparseDataLength < REPARSE_DATA_HEADER_SIZE) {
             throw new SMBProtocolDecodingException("Invalid ReparseDataLength " + reparseDataLength);
         }
-        final int pathBufferIndex = bufferIndex + FIXED_SIZE;
+        final int pathBufferIndex = start + FIXED_SIZE;
         final int pathBufferLength = reparseDataLength - REPARSE_DATA_HEADER_SIZE;
-        if (pathBufferLength > errorData.length - pathBufferIndex) {
-            throw new SMBProtocolDecodingException("ReparseDataLength " + reparseDataLength + " overruns the error data");
+        if (pathBufferLength > 4 + symLinkLength - FIXED_SIZE) {
+            throw new SMBProtocolDecodingException("ReparseDataLength " + reparseDataLength + " overruns the symlink error response");
         }
         if (unparsedPathLength % 2 != 0) {
             throw new SMBProtocolDecodingException("UnparsedPathLength " + unparsedPathLength + " is not a UTF-16 length");

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbSymlinkExceptionTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbSymlinkExceptionTest.java
@@ -1,0 +1,96 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HexFormat;
+
+import org.codelibs.jcifs.smb.internal.smb2.Smb2SymlinkErrorResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link SmbSymlinkException} and the STATUS_STOPPED_ON_SYMLINK entry it depends on.
+ */
+class SmbSymlinkExceptionTest {
+
+    /** {@code link-rel.txt -> target.txt} as captured from Samba over SMB 3.1.1. */
+    private static final String REL_311 =
+            "44000000000000004000000053594d4c0c0000a0340000000000140014001400010000007400610072006700650074002e007400780074007400610072006700650074002e00740078007400";
+
+    /** {@code link-outside.txt -> /etc/hostname}: an absolute target. */
+    private static final String ABSOLUTE_311 =
+            "50000000000000004c00000053594d4c0c0000a04000000000001a001a001a00000000002f006500740063002f0068006f00730074006e0061006d0065002f006500740063002f0068006f00730074006e0061006d006500";
+
+    private static Smb2SymlinkErrorResponse decode(final String hex, final int contexts) throws Exception {
+        return Smb2SymlinkErrorResponse.decode(HexFormat.of().parseHex(hex), contexts);
+    }
+
+    @Test
+    @DisplayName("Records the code and message for STATUS_STOPPED_ON_SYMLINK")
+    void testStatusIsKnown() {
+        assertEquals(0x8000002D, NtStatus.NT_STATUS_STOPPED_ON_SYMLINK);
+        final String message = SmbException.getMessageByCode(NtStatus.NT_STATUS_STOPPED_ON_SYMLINK);
+        assertTrue(message.toLowerCase().contains("symbolic link"), "should describe the status, was: " + message);
+        assertFalse(message.startsWith("0x"), "should no longer fall back to the raw code, was: " + message);
+    }
+
+    @Test
+    @DisplayName("Keeps the NT status so existing handling still sees STATUS_STOPPED_ON_SYMLINK")
+    void testPreservesNtStatus() throws Exception {
+        final SmbSymlinkException e = new SmbSymlinkException("\\srv\\share\\link.txt", decode(REL_311, 1));
+        assertEquals(NtStatus.NT_STATUS_STOPPED_ON_SYMLINK, e.getNtStatus());
+        assertInstanceOf(SmbException.class, e, "callers catching SmbException must keep working");
+    }
+
+    @Test
+    @DisplayName("Exposes a relative target and names it in the message")
+    void testRelativeTarget() throws Exception {
+        final SmbSymlinkException e = new SmbSymlinkException("\\srv\\share\\link-rel.txt", decode(REL_311, 1));
+        assertEquals("target.txt", e.getSubstituteName());
+        assertEquals("target.txt", e.getPrintName());
+        assertTrue(e.isRelative());
+        assertEquals(0, e.getUnparsedPathLength());
+        assertEquals("\\srv\\share\\link-rel.txt", e.getPath());
+
+        final String message = e.getMessage();
+        assertTrue(message.contains("target.txt"), message);
+        assertTrue(message.contains("\\srv\\share\\link-rel.txt"), message);
+        assertTrue(message.contains("relative"), message);
+    }
+
+    @Test
+    @DisplayName("Exposes an absolute target and says so in the message")
+    void testAbsoluteTarget() throws Exception {
+        final SmbSymlinkException e = new SmbSymlinkException("\\srv\\share\\link-outside.txt", decode(ABSOLUTE_311, 1));
+        assertEquals("/etc/hostname", e.getSubstituteName());
+        assertFalse(e.isRelative());
+        assertTrue(e.getMessage().contains("absolute"), e.getMessage());
+        assertTrue(e.getMessage().contains("/etc/hostname"), e.getMessage());
+    }
+
+    @Test
+    @DisplayName("Tolerates an unknown request path")
+    void testWithoutPath() throws Exception {
+        final SmbSymlinkException e = new SmbSymlinkException(null, decode(REL_311, 1));
+        assertEquals(null, e.getPath());
+        assertTrue(e.getMessage().contains("target.txt"), e.getMessage());
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbTransportSymlinkStatusTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbTransportSymlinkStatusTest.java
@@ -1,0 +1,138 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HexFormat;
+import java.util.Properties;
+
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.config.PropertyConfiguration;
+import org.codelibs.jcifs.smb.context.BaseContext;
+import org.codelibs.jcifs.smb.internal.smb2.Smb2Constants;
+import org.codelibs.jcifs.smb.internal.smb2.create.Smb2CreateRequest;
+import org.codelibs.jcifs.smb.internal.smb2.create.Smb2CreateResponse;
+import org.codelibs.jcifs.smb.internal.util.SMBUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins how {@code SmbTransportImpl.checkStatus2} dispatches STATUS_STOPPED_ON_SYMLINK.
+ *
+ * The response is decoded from a real wire buffer rather than stubbed, so this also covers
+ * {@code ServerMessageBlock2.readErrorResponse} populating the error data the dispatch relies on. A
+ * response type that stopped treating this status as an error would fail here.
+ */
+class SmbTransportSymlinkStatusTest {
+
+    /** A symbolic link error response for {@code link.txt -> target.txt}, as captured from Samba. */
+    private static final String SYMLINK_ERROR_DATA =
+            "44000000000000004000000053594d4c0c0000a0340000000000140014001400010000007400610072006700650074002e007400780074007400610072006700650074002e00740078007400";
+
+    /** SMB2 CREATE, which ServerMessageBlock2 keeps protected. */
+    private static final short SMB2_CREATE = 0x0005;
+
+    private CIFSContext context;
+    private SmbTransportImpl transport;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        this.context = new BaseContext(new PropertyConfiguration(new Properties()));
+        this.transport = new SmbTransportImpl(this.context, null, 445, null, 0, false);
+    }
+
+    /**
+     * Builds an SMB2 error response on the wire and decodes it, the way the transport would.
+     *
+     * @param status the NT status to report
+     * @param errorContextCount the ErrorContextCount to report
+     * @param errorData the ErrorData to carry, or null for none
+     */
+    private Smb2CreateResponse decodeErrorResponse(final int status, final int errorContextCount, final byte[] errorData) throws Exception {
+        final int dataLength = errorData != null ? errorData.length : 0;
+        final byte[] buffer = new byte[Smb2Constants.SMB2_HEADER_LENGTH + 8 + dataLength];
+
+        System.arraycopy(SMBUtil.SMB2_HEADER, 0, buffer, 0, SMBUtil.SMB2_HEADER.length);
+        SMBUtil.writeInt4(status, buffer, 8);
+        SMBUtil.writeInt2(SMB2_CREATE, buffer, 12);
+
+        int index = Smb2Constants.SMB2_HEADER_LENGTH;
+        SMBUtil.writeInt2(9, buffer, index); // StructureSize
+        buffer[index + 2] = (byte) errorContextCount;
+        SMBUtil.writeInt4(dataLength, buffer, index + 4);
+        index += 8;
+        if (errorData != null) {
+            System.arraycopy(errorData, 0, buffer, index, dataLength);
+        }
+
+        final Smb2CreateResponse response = new Smb2CreateResponse(this.context.getConfig(), "link.txt");
+        response.setCommand(SMB2_CREATE);
+        response.decode(buffer, 0);
+        return response;
+    }
+
+    private Smb2CreateRequest request() {
+        final Smb2CreateRequest request = new Smb2CreateRequest(this.context.getConfig(), "\\link.txt");
+        request.setFullUNCPath(null, null, "\\\\server\\share\\link.txt");
+        return request;
+    }
+
+    @Test
+    @DisplayName("Turns STATUS_STOPPED_ON_SYMLINK into an SmbSymlinkException naming the target")
+    void testDispatchesSymlinkStatus() throws Exception {
+        final Smb2CreateResponse response =
+                decodeErrorResponse(NtStatus.NT_STATUS_STOPPED_ON_SYMLINK, 1, HexFormat.of().parseHex(SYMLINK_ERROR_DATA));
+
+        // the dispatch depends on readErrorResponse having captured the payload
+        assertEquals(1, response.getErrorContextCount());
+        assertEquals(NtStatus.NT_STATUS_STOPPED_ON_SYMLINK, response.getStatus());
+
+        final Smb2CreateRequest request = request();
+        final SmbSymlinkException e = assertThrows(SmbSymlinkException.class, () -> this.transport.checkStatus2(request, response));
+        assertEquals("target.txt", e.getSubstituteName());
+        assertTrue(e.isRelative());
+        assertEquals("\\\\server\\share\\link.txt", e.getPath());
+        assertEquals(NtStatus.NT_STATUS_STOPPED_ON_SYMLINK, e.getNtStatus());
+    }
+
+    @Test
+    @DisplayName("Falls back to a plain SmbException when the error data cannot be decoded")
+    void testFallsBackOnUndecodableErrorData() throws Exception {
+        final Smb2CreateResponse response =
+                decodeErrorResponse(NtStatus.NT_STATUS_STOPPED_ON_SYMLINK, 1, new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });
+
+        final Smb2CreateRequest request = request();
+        final SmbException e = assertThrows(SmbException.class, () -> this.transport.checkStatus2(request, response));
+        assertFalse(e instanceof SmbSymlinkException, "undecodable data must not produce a fabricated target");
+        assertEquals(NtStatus.NT_STATUS_STOPPED_ON_SYMLINK, e.getNtStatus());
+    }
+
+    @Test
+    @DisplayName("Falls back to a plain SmbException when the response carries no error data at all")
+    void testFallsBackOnAbsentErrorData() throws Exception {
+        final Smb2CreateResponse response = decodeErrorResponse(NtStatus.NT_STATUS_STOPPED_ON_SYMLINK, 0, null);
+
+        final Smb2CreateRequest request = request();
+        final SmbException e = assertThrows(SmbException.class, () -> this.transport.checkStatus2(request, response));
+        assertFalse(e instanceof SmbSymlinkException);
+        assertEquals(NtStatus.NT_STATUS_STOPPED_ON_SYMLINK, e.getNtStatus());
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb2SymlinkErrorResponseTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb2SymlinkErrorResponseTest.java
@@ -1,0 +1,158 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.internal.smb2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HexFormat;
+
+import org.codelibs.jcifs.smb.internal.SMBProtocolDecodingException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link Smb2SymlinkErrorResponse}.
+ *
+ * The byte fixtures were captured from a Samba 4.23.8 server configured with
+ * {@code follow symlinks = no} and {@code wide links = no}, which is the configuration that makes a
+ * server answer STATUS_STOPPED_ON_SYMLINK rather than resolving the link itself.
+ */
+class Smb2SymlinkErrorResponseTest {
+
+    /** {@code link-rel.txt -> target.txt}, requested over SMB 3.1.1, so wrapped in an error context. */
+    private static final String REL_311 =
+            "44000000000000004000000053594d4c0c0000a0340000000000140014001400010000007400610072006700650074002e007400780074007400610072006700650074002e00740078007400";
+
+    /** The very same link requested over SMB 2.1, where the error context wrapper is absent. */
+    private static final String REL_210 =
+            "4000000053594d4c0c0000a0340000000000140014001400010000007400610072006700650074002e007400780074007400610072006700650074002e00740078007400";
+
+    /** {@code linkdir/sub.txt} where {@code linkdir -> realdir}: the {@code \sub.txt} tail is unparsed. */
+    private static final String UNPARSED_311 =
+            "38000000000000003400000053594d4c0c0000a02800100000000e000e000e00010000007200650061006c006400690072007200650061006c00640069007200";
+
+    /** {@code link-outside.txt -> /etc/hostname}: an absolute, non-UNC target. */
+    private static final String ABSOLUTE_311 =
+            "50000000000000004c00000053594d4c0c0000a04000000000001a001a001a00000000002f006500740063002f0068006f00730074006e0061006d0065002f006500740063002f0068006f00730074006e0061006d006500";
+
+    private static byte[] hex(final String s) {
+        return HexFormat.of().parseHex(s.replace(" ", ""));
+    }
+
+    @Test
+    @DisplayName("Decodes a relative link captured over SMB 3.1.1")
+    void testRelativeWithErrorContext() throws Exception {
+        final Smb2SymlinkErrorResponse r = Smb2SymlinkErrorResponse.decode(hex(REL_311), 1);
+        assertEquals("target.txt", r.getSubstituteName());
+        assertEquals("target.txt", r.getPrintName());
+        assertTrue(r.isRelative());
+        assertEquals(0, r.getUnparsedPathLength());
+    }
+
+    @Test
+    @DisplayName("Decodes the same link captured over SMB 2.1, where no error context wraps it")
+    void testRelativeWithoutErrorContext() throws Exception {
+        final Smb2SymlinkErrorResponse r = Smb2SymlinkErrorResponse.decode(hex(REL_210), 0);
+        assertEquals("target.txt", r.getSubstituteName());
+        assertTrue(r.isRelative());
+        assertEquals(0, r.getUnparsedPathLength());
+    }
+
+    @Test
+    @DisplayName("SMB 2.1 and SMB 3.1.1 carry the same payload, so both decode alike")
+    void testDialectsAgree() throws Exception {
+        final Smb2SymlinkErrorResponse a = Smb2SymlinkErrorResponse.decode(hex(REL_311), 1);
+        final Smb2SymlinkErrorResponse b = Smb2SymlinkErrorResponse.decode(hex(REL_210), 0);
+        assertEquals(a.getSubstituteName(), b.getSubstituteName());
+        assertEquals(a.isRelative(), b.isRelative());
+        assertEquals(a.getUnparsedPathLength(), b.getUnparsedPathLength());
+    }
+
+    @Test
+    @DisplayName("Reports the unparsed tail length when the link is a path component")
+    void testUnparsedPathLength() throws Exception {
+        final Smb2SymlinkErrorResponse r = Smb2SymlinkErrorResponse.decode(hex(UNPARSED_311), 1);
+        assertEquals("realdir", r.getSubstituteName());
+        assertTrue(r.isRelative());
+        // "\sub.txt" is 8 UTF-16 characters that the server did not consume
+        assertEquals(16, r.getUnparsedPathLength());
+    }
+
+    @Test
+    @DisplayName("Decodes an absolute target and reports it as non-relative")
+    void testAbsoluteTarget() throws Exception {
+        final Smb2SymlinkErrorResponse r = Smb2SymlinkErrorResponse.decode(hex(ABSOLUTE_311), 1);
+        assertEquals("/etc/hostname", r.getSubstituteName());
+        assertFalse(r.isRelative());
+    }
+
+    @Test
+    @DisplayName("Rejects a payload whose SymLinkErrorTag is not SYML")
+    void testRejectsWrongErrorTag() {
+        final byte[] b = hex(REL_311);
+        b[8 + 4] ^= 0xFF; // corrupt the first byte of SymLinkErrorTag
+        assertThrows(SMBProtocolDecodingException.class, () -> Smb2SymlinkErrorResponse.decode(b, 1));
+    }
+
+    @Test
+    @DisplayName("Rejects a reparse tag other than IO_REPARSE_TAG_SYMLINK")
+    void testRejectsWrongReparseTag() {
+        final byte[] b = hex(REL_311);
+        b[8 + 8] ^= 0xFF; // corrupt the first byte of ReparseTag
+        assertThrows(SMBProtocolDecodingException.class, () -> Smb2SymlinkErrorResponse.decode(b, 1));
+    }
+
+    @Test
+    @DisplayName("Rejects a truncated payload instead of reading out of bounds")
+    void testRejectsTruncated() {
+        final byte[] full = hex(REL_311);
+        for (final int len : new int[] { 0, 4, 8, 16, 24, 36, full.length - 2 }) {
+            final byte[] b = new byte[len];
+            System.arraycopy(full, 0, b, 0, len);
+            assertThrows(SMBProtocolDecodingException.class, () -> Smb2SymlinkErrorResponse.decode(b, 1),
+                    "should have rejected a " + len + " byte payload");
+        }
+    }
+
+    @Test
+    @DisplayName("Rejects absent error data")
+    void testRejectsNull() {
+        assertThrows(SMBProtocolDecodingException.class, () -> Smb2SymlinkErrorResponse.decode(null, 1));
+    }
+
+    @Test
+    @DisplayName("Rejects a name that claims to extend past the path buffer")
+    void testRejectsNameOutOfBounds() {
+        final byte[] b = hex(REL_311);
+        // SubstituteNameLength sits 8 (context) + 18 bytes into the payload
+        b[8 + 18] = (byte) 0xFF;
+        b[8 + 19] = (byte) 0x7F;
+        assertThrows(SMBProtocolDecodingException.class, () -> Smb2SymlinkErrorResponse.decode(b, 1));
+    }
+
+    @Test
+    @DisplayName("Rejects a ReparseDataLength inconsistent with the payload")
+    void testRejectsInconsistentReparseDataLength() {
+        final byte[] b = hex(REL_311);
+        // ReparseDataLength sits 8 (context) + 12 bytes into the payload
+        b[8 + 12] = (byte) 0x08;
+        b[8 + 13] = (byte) 0x00;
+        assertThrows(SMBProtocolDecodingException.class, () -> Smb2SymlinkErrorResponse.decode(b, 1));
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb2SymlinkErrorResponseTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb2SymlinkErrorResponseTest.java
@@ -51,6 +51,20 @@ class Smb2SymlinkErrorResponseTest {
     private static final String ABSOLUTE_311 =
             "50000000000000004c00000053594d4c0c0000a04000000000001a001a001a00000000002f006500740063002f0068006f00730074006e0061006d0065002f006500740063002f0068006f00730074006e0061006d006500";
 
+    /**
+     * A response whose first error context honestly declares 68 bytes, but whose symbolic link
+     * structure inflates SymLinkLength and ReparseDataLength and points SubstituteName past its own
+     * path buffer, into the bytes that follow the context.
+     */
+    private static final String FORGED_TRAILING =
+            "44000000000000005000000053594d4c0c0000a04400000028000800140014000100000074006100720067006500740"
+                    + "02e007400780074007400610072006700650074002e007400780074004500560049004c000000000000000000";
+
+    /** Two error contexts, where the symbolic link one is second: a SHARE_REDIRECT context precedes it. */
+    private static final String SECOND_CONTEXT =
+            "0400000053526472010203040000000038000000000000003400000053594d4c0c0000a02800000000000e000e000e00"
+                    + "010000007200650061006c006400690072007200650061006c00640069007200";
+
     private static byte[] hex(final String s) {
         return HexFormat.of().parseHex(s.replace(" ", ""));
     }
@@ -154,5 +168,20 @@ class Smb2SymlinkErrorResponseTest {
         b[8 + 12] = (byte) 0x08;
         b[8 + 13] = (byte) 0x00;
         assertThrows(SMBProtocolDecodingException.class, () -> Smb2SymlinkErrorResponse.decode(b, 1));
+    }
+
+    @Test
+    @DisplayName("Bounds the payload by the declared lengths, not by whatever follows in the buffer")
+    void testRejectsNameReachingPastTheDeclaredContext() {
+        assertThrows(SMBProtocolDecodingException.class, () -> Smb2SymlinkErrorResponse.decode(hex(FORGED_TRAILING), 1),
+                "a name pointing past the declared context must not be decoded from trailing bytes");
+    }
+
+    @Test
+    @DisplayName("Finds the symbolic link context when it is not the first one")
+    void testSymlinkContextNotFirst() throws Exception {
+        final Smb2SymlinkErrorResponse r = Smb2SymlinkErrorResponse.decode(hex(SECOND_CONTEXT), 2);
+        assertEquals("realdir", r.getSubstituteName());
+        assertTrue(r.isRelative());
     }
 }


### PR DESCRIPTION
Refs #75.

## The problem

A server that will not follow a symbolic link on the client's behalf answers `STATUS_STOPPED_ON_SYMLINK` (0x8000002D), and the error response carries an `SMB2_SYMLINK_ERROR_RESPONSE` naming the link target.

jCIFS had no name for that status. `SmbTransportImpl.checkStatus2()` fell through to its default branch and threw an `SmbException` whose entire message was the string `0x8000002D`. `SmbFile.exists()` does not swallow that status either, so `exists()`, `isFile()`, `isDirectory()` and `length()` all threw with nothing to explain why. The target the server had just disclosed was already sitting in `ServerMessageBlock2.getErrorData()`, unread.

## What this changes

Symbolic links are still **not resolved**. This only makes the refusal explain itself.

- **`NtStatus`** — add `NT_STATUS_STOPPED_ON_SYMLINK` and its message. The value and text come from MS-ERREF. The lookup is a `HashMap`, so ordering does not matter, but both tables stay parallel. `smb1`'s own table, which `smb1.SmbException` binary-searches, is untouched.
- **`Smb2SymlinkErrorResponse`** (new, `internal.smb2`) — decodes MS-SMB2 2.2.2.2.1, validating the `SYML` tag, the reparse tag, `ReparseDataLength`, and every name offset and length before reading. SMB 3.1.1 wraps the payload in an SMB2 ERROR Context while earlier dialects send it bare, so the response's `ErrorContextCount` selects the form. Every read is bounded by the lengths the server declares rather than by the size of the buffer, and contexts are walked in turn since MS-SMB2 2.2.2 allows more than one and does not promise the symbolic link context comes first.
- **`SmbSymlinkException`** (new) — extends `SmbException`, exposing `getSubstituteName()`, `getPrintName()`, `isRelative()`, `getUnparsedPathLength()` and the requested path.
- **`SmbTransportImpl`** — one `case` in `checkStatus2()`. If the error data cannot be decoded it falls back to the plain `SmbException` with a warning, so a malformed response is never worse than the status alone.

Before:

```
SmbException: 0x8000002D
```

After:

```
SmbSymlinkException: The create operation stopped after reaching a symbolic link.
\server\share\linkdir\sub.txt points to the relative target "realdir",
which jCIFS does not resolve.
```

## Compatibility

`SmbSymlinkException` is a subclass of `SmbException`, so existing `catch` blocks still catch it and `getNtStatus()` still returns `0x8000002D`. Code comparing the exception's exact class would see the difference; nothing in this repository does. `SmbFile.exists()` is deliberately left alone and still rethrows.

## Verification

Against Samba 4.23.8 configured with `follow symlinks = no` and `wide links = no`, which is the configuration that makes a server return this status instead of resolving the link itself. Exercised over **both SMB 2.1 (no error context) and SMB 3.1.1 (error context)** for a relative link, an absolute link, a linked directory, and a path below a linked directory. The unit test fixtures are those captured responses.

- 21 new tests; on top of current `main` (`abb3eb9`) `mvn verify` runs 8615 unit tests and 104 integration tests against the Samba backend, 0 failures
- The dispatch test decodes a real error response off the wire and drives `checkStatus2`, so it covers `readErrorResponse` populating the data the dispatch relies on, plus both fallback paths
- `mvn formatter:validate package` and `mvn javadoc:javadoc` both clean

## Relationship to `SymlinkIT`

`SymlinkIT` already documents that Windows hands the reparse point back and expects the client to resolve it, and keeps two Windows tests `@Disabled` against this issue. **This change does not enable them** — they are waiting for resolution, not for reporting. It does give them something precise to fail against in the meantime, and supplies the decoder that resolution would build on.

## Not in this change

Transparent resolution — following the link and reissuing the request. That changes behaviour rather than just reporting, and needs an opt-in setting, a depth limit carried as a parameter, and a check that the target stays on the same share. Worth doing separately, on top of this.
