### PR TITLE
fix(smb3): validate transform headers and drop redundant copies

### DIFF
--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbSessionImpl.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbSessionImpl.java
@@ -1322,32 +1322,4 @@ final class SmbSessionImpl implements SmbSessionInternal {
         return this.encryptionContext;
     }
 
-    /**
-     * Encrypt a message using the session's encryption context
-     *
-     * @param message the message to encrypt
-     * @return encrypted message with transform header
-     * @throws CIFSException if encryption fails or is not enabled
-     */
-    public byte[] encryptMessage(byte[] message) throws CIFSException {
-        if (this.encryptionContext == null) {
-            throw new CIFSException("Encryption not enabled for this session");
-        }
-        return this.encryptionContext.encryptMessage(message, this.sessionId);
-    }
-
-    /**
-     * Decrypt a message using the session's encryption context
-     *
-     * @param encryptedMessage the encrypted message with transform header
-     * @return decrypted message
-     * @throws CIFSException if decryption fails or encryption is not enabled
-     */
-    public byte[] decryptMessage(byte[] encryptedMessage) throws CIFSException {
-        if (this.encryptionContext == null) {
-            throw new CIFSException("Encryption not enabled for this session");
-        }
-        return this.encryptionContext.decryptMessage(encryptedMessage);
-    }
-
 }

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbTransportImpl.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbTransportImpl.java
@@ -921,22 +921,20 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
             throw new IOException("Encryption is required but session 0x" + Long.toHexString(sessionId) + " has no encryption context");
         }
 
-        final byte[] plaintext = new byte[n];
-        System.arraycopy(buffer, 4, plaintext, 0, n);
+        // Encrypt straight into the frame so that the session header and the wrapped message reach the socket in
+        // a single write, as they do on the unencrypted path.
+        final int wireLength = Smb2TransformHeader.TRANSFORM_HEADER_SIZE + n;
+        final byte[] framed = new byte[4 + wireLength];
+        framed[0] = 0;
+        framed[1] = (byte) (wireLength >> 16);
+        framed[2] = (byte) (wireLength >> 8);
+        framed[3] = (byte) wireLength;
 
-        final byte[] wire;
         try {
-            wire = encryptionContext.encryptMessage(plaintext, sessionId);
+            encryptionContext.encryptMessage(buffer, 4, n, sessionId, framed, 4);
         } catch (final CIFSException e) {
             throw new IOException("Failed to encrypt message", e);
         }
-
-        final byte[] framed = new byte[4 + wire.length];
-        framed[0] = 0;
-        framed[1] = (byte) (wire.length >> 16);
-        framed[2] = (byte) (wire.length >> 8);
-        framed[3] = (byte) wire.length;
-        System.arraycopy(wire, 0, framed, 4, wire.length);
 
         this.out.write(framed, 0, framed.length);
         this.out.flush();

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/Smb2EncryptionContext.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/Smb2EncryptionContext.java
@@ -137,6 +137,38 @@ public class Smb2EncryptionContext {
      *             if encryption fails
      */
     public byte[] encryptMessage(final byte[] message, final long sessionId) throws CIFSException {
+        final byte[] result = new byte[Smb2TransformHeader.TRANSFORM_HEADER_SIZE + message.length];
+        encryptMessage(message, 0, message.length, sessionId, result, 0);
+        return result;
+    }
+
+    /**
+     * Encrypt an SMB2 message into a caller-supplied buffer.
+     *
+     * <p>
+     * Lets the caller reserve room in front of the transform header, so that the NetBIOS session header and the
+     * wrapped message can be written to the socket as a single buffer.
+     * </p>
+     *
+     * @param src
+     *            buffer holding the plaintext message
+     * @param srcOff
+     *            offset of the plaintext within {@code src}
+     * @param srcLen
+     *            length of the plaintext
+     * @param sessionId
+     *            session identifier
+     * @param dst
+     *            destination buffer, which must hold {@link Smb2TransformHeader#TRANSFORM_HEADER_SIZE} +
+     *            {@code srcLen} bytes from {@code dstOff}
+     * @param dstOff
+     *            offset to write the transform header at
+     * @return the number of bytes written at {@code dstOff}
+     * @throws CIFSException
+     *             if encryption fails
+     */
+    public int encryptMessage(final byte[] src, final int srcOff, final int srcLen, final long sessionId, final byte[] dst,
+            final int dstOff) throws CIFSException {
         try {
             final byte[] nonce = generateNonce();
 
@@ -145,28 +177,26 @@ public class Smb2EncryptionContext {
             final byte[] nonceField = new byte[16];
             System.arraycopy(nonce, 0, nonceField, 0, nonce.length);
 
-            final Smb2TransformHeader transformHeader = new Smb2TransformHeader(nonceField, message.length, getTransformFlags(), sessionId);
-
-            final byte[] result = new byte[Smb2TransformHeader.TRANSFORM_HEADER_SIZE + message.length];
+            final Smb2TransformHeader transformHeader = new Smb2TransformHeader(nonceField, srcLen, getTransformFlags(), sessionId);
 
             // Encode the header first, then authenticate the bytes that actually go on the wire rather than a
             // reconstruction of the parsed fields. The signature lies before the authenticated region, so it can
             // be filled in afterwards.
-            transformHeader.encode(result, 0);
+            transformHeader.encode(dst, dstOff);
             final byte[] associatedData =
-                    Arrays.copyOfRange(result, Smb2TransformHeader.AAD_OFFSET, Smb2TransformHeader.TRANSFORM_HEADER_SIZE);
+                    Arrays.copyOfRange(dst, dstOff + Smb2TransformHeader.AAD_OFFSET, dstOff + Smb2TransformHeader.TRANSFORM_HEADER_SIZE);
 
             final AEADBlockCipher cipher = createCipher(true, nonce, associatedData);
-            final byte[] output = new byte[cipher.getOutputSize(message.length)];
-            int len = cipher.processBytes(message, 0, message.length, output, 0);
+            final byte[] output = new byte[cipher.getOutputSize(srcLen)];
+            int len = cipher.processBytes(src, srcOff, srcLen, output, 0);
             len += cipher.doFinal(output, len);
 
             final int tagLength = getAuthTagLength();
             final int ciphertextLength = len - tagLength;
-            System.arraycopy(output, ciphertextLength, result, Smb2TransformHeader.SIGNATURE_OFFSET, tagLength);
-            System.arraycopy(output, 0, result, Smb2TransformHeader.TRANSFORM_HEADER_SIZE, ciphertextLength);
+            System.arraycopy(output, ciphertextLength, dst, dstOff + Smb2TransformHeader.SIGNATURE_OFFSET, tagLength);
+            System.arraycopy(output, 0, dst, dstOff + Smb2TransformHeader.TRANSFORM_HEADER_SIZE, ciphertextLength);
 
-            return result;
+            return Smb2TransformHeader.TRANSFORM_HEADER_SIZE + ciphertextLength;
         } catch (final Exception e) {
             throw new CIFSException("Failed to encrypt message", e);
         }
@@ -188,6 +218,7 @@ public class Smb2EncryptionContext {
             }
 
             final Smb2TransformHeader transformHeader = Smb2TransformHeader.decode(encryptedMessage, 0);
+            checkTransformFlags(transformHeader.getFlags());
             final byte[] authTag = transformHeader.getSignature();
 
             // Authenticate the bytes exactly as received rather than re-encoding the parsed fields.
@@ -208,11 +239,14 @@ public class Smb2EncryptionContext {
             int len = cipher.processBytes(input, 0, input.length, output, 0);
             len += cipher.doFinal(output, len);
 
-            if (len != output.length) {
-                final byte[] exact = new byte[len];
-                System.arraycopy(output, 0, exact, 0, len);
-                return exact;
+            // MS-SMB2 3.2.5.1.1: the header has to agree with what came out of the cipher. The AEAD tag only
+            // proves the field is authentic, not that the server filled it in consistently.
+            final int originalMessageSize = transformHeader.getOriginalMessageSize();
+            if (originalMessageSize != len) {
+                throw new CIFSException(
+                        "Transform header declares " + originalMessageSize + " plaintext bytes but " + len + " were decrypted");
             }
+
             return output;
         } catch (final CIFSException e) {
             throw e;
@@ -227,6 +261,17 @@ public class Smb2EncryptionContext {
 
     private int getAuthTagLength() {
         return 16; // All SMB3 ciphers use 16-byte authentication tags
+    }
+
+    /**
+     * Rejects a transform header whose Flags/EncryptionAlgorithm field does not describe the message this context
+     * is able to decrypt (MS-SMB2 2.2.41, 3.2.5.1.1).
+     */
+    private void checkTransformFlags(final int flags) throws CIFSException {
+        final int expected = getTransformFlags();
+        if (flags != expected) {
+            throw new CIFSException(String.format("Unexpected transform header flags 0x%04x, expected 0x%04x", flags, expected));
+        }
     }
 
     private int getTransformFlags() {

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/Smb2TransformHeader.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/Smb2TransformHeader.java
@@ -46,13 +46,13 @@ public class Smb2TransformHeader implements Encodable {
      */
     public static final int TRANSFORM_HEADER_SIZE = 52;
 
+    /** Offset of the Signature field within the transform header. */
+    public static final int SIGNATURE_OFFSET = 4;
+
     /**
      * Offset of the Nonce field within the transform header. The additional authenticated data for the AEAD cipher
      * starts here (MS-SMB2 3.1.4.3).
      */
-    /** Offset of the Signature field within the transform header. */
-    public static final int SIGNATURE_OFFSET = 4;
-
     public static final int AAD_OFFSET = 20;
 
     /**

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbSessionImplTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbSessionImplTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -309,33 +308,19 @@ class SmbSessionImplTest {
     }
 
     @Test
-    @DisplayName("encryption: flags, encryption, and decryption delegation")
-    void testEncryptionDelegation() throws Exception {
+    @DisplayName("encryption: context is exposed to the transport once it exists")
+    void testEncryptionContextExposure() throws Exception {
         SmbSessionImpl session = newSession();
 
-        // No encryption context -> throws
-        CIFSException notEnabled = assertThrows(CIFSException.class, () -> session.encryptMessage(new byte[] { 1 }));
-        assertTrue(notEnabled.getMessage().contains("Encryption not enabled"));
-        assertThrows(CIFSException.class, () -> session.decryptMessage(new byte[] { 1 }));
+        // No encryption context -> the transport must not try to encrypt on this session
+        assertFalse(session.isEncryptionEnabled());
+        assertNull(session.getEncryptionContext());
 
-        // Set encryption context and verify delegation
         Smb2EncryptionContext enc = mock(Smb2EncryptionContext.class);
         setField(session, "encryptionContext", enc);
-        setField(session, "sessionId", 99L);
-
-        when(enc.encryptMessage(any(byte[].class), eq(99L))).thenReturn(new byte[] { 9, 9 });
-        when(enc.decryptMessage(any(byte[].class))).thenReturn(new byte[] { 7, 7 });
 
         assertTrue(session.isEncryptionEnabled());
         assertSame(enc, session.getEncryptionContext());
-
-        byte[] encOut = session.encryptMessage(new byte[] { 1, 2, 3 });
-        assertArrayEquals(new byte[] { 9, 9 }, encOut);
-        verify(enc, times(1)).encryptMessage(eq(new byte[] { 1, 2, 3 }), eq(99L));
-
-        byte[] decOut = session.decryptMessage(new byte[] { 5 });
-        assertArrayEquals(new byte[] { 7, 7 }, decOut);
-        verify(enc, times(1)).decryptMessage(eq(new byte[] { 5 }));
     }
 
     @Test

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb3EncryptionInteropTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb3EncryptionInteropTest.java
@@ -19,7 +19,17 @@ package org.codelibs.jcifs.smb.internal.smb2;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
+
+import org.bouncycastle.crypto.engines.AESEngine;
+import org.bouncycastle.crypto.modes.AEADBlockCipher;
+import org.bouncycastle.crypto.modes.GCMBlockCipher;
+import org.bouncycastle.crypto.params.AEADParameters;
+import org.bouncycastle.crypto.params.KeyParameter;
+import org.codelibs.jcifs.smb.CIFSException;
 import org.codelibs.jcifs.smb.DialectVersion;
 import org.codelibs.jcifs.smb.internal.smb2.nego.EncryptionNegotiateContext;
 import org.junit.jupiter.api.DisplayName;
@@ -177,5 +187,86 @@ class Smb3EncryptionInteropTest {
             }
             assertEquals(true, seen.add(sb.toString()), "nonce repeated after " + i + " messages");
         }
+    }
+
+    @Test
+    @DisplayName("encrypts into a caller-supplied buffer without disturbing the surrounding bytes")
+    void encryptsIntoCallerSuppliedBuffer() throws Exception {
+        final byte[] key = hex("000102030405060708090A0B0C0D0E0F");
+        final Smb2EncryptionContext ctx =
+                new Smb2EncryptionContext(EncryptionNegotiateContext.CIPHER_AES128_GCM, DialectVersion.SMB311, key, key);
+
+        final byte[] message = sampleMessage(101);
+        final int dstOff = 4;
+        final byte[] dst = new byte[dstOff + Smb2TransformHeader.TRANSFORM_HEADER_SIZE + message.length + 3];
+        Arrays.fill(dst, (byte) 0x7E);
+
+        final int written = ctx.encryptMessage(message, 0, message.length, 0x1122334455667788L, dst, dstOff);
+
+        assertEquals(Smb2TransformHeader.TRANSFORM_HEADER_SIZE + message.length, written, "wrapped length");
+        for (int i = 0; i < dstOff; i++) {
+            assertEquals((byte) 0x7E, dst[i], "byte " + i + " before the frame must be untouched");
+        }
+        for (int i = dstOff + written; i < dst.length; i++) {
+            assertEquals((byte) 0x7E, dst[i], "byte " + i + " after the frame must be untouched");
+        }
+        assertArrayEquals(message, ctx.decryptMessage(Arrays.copyOfRange(dst, dstOff, dstOff + written)));
+    }
+
+    @Test
+    @DisplayName("rejects a transform header whose flags do not match the negotiated dialect")
+    void rejectsUnexpectedTransformFlags() throws Exception {
+        final byte[] key = hex("000102030405060708090A0B0C0D0E0F");
+
+        // An SMB 3.0 context puts the cipher id in the field; an SMB 3.1.1 context requires SMB2_TRANSFORM_FLAG_ENCRYPTED.
+        final Smb2EncryptionContext smb300 =
+                new Smb2EncryptionContext(EncryptionNegotiateContext.CIPHER_AES128_GCM, DialectVersion.SMB300, key, key);
+        final Smb2EncryptionContext smb311 =
+                new Smb2EncryptionContext(EncryptionNegotiateContext.CIPHER_AES128_GCM, DialectVersion.SMB311, key, key);
+
+        final byte[] wire = smb300.encryptMessage(sampleMessage(32), 1L);
+
+        final CIFSException e = assertThrows(CIFSException.class, () -> smb311.decryptMessage(wire));
+        assertTrue(e.getMessage().contains("transform header flags"), e.getMessage());
+    }
+
+    @Test
+    @DisplayName("rejects an authenticated transform header whose OriginalMessageSize disagrees with the plaintext")
+    void rejectsInconsistentOriginalMessageSize() throws Exception {
+        final byte[] key = hex("000102030405060708090A0B0C0D0E0F");
+        final Smb2EncryptionContext ctx =
+                new Smb2EncryptionContext(EncryptionNegotiateContext.CIPHER_AES128_GCM, DialectVersion.SMB311, key, key);
+
+        final byte[] message = sampleMessage(48);
+        // Authentic: the tag is computed over this very header, so the mismatch cannot be caught by the AEAD tag.
+        final byte[] wire = forgeGcmTransformMessage(key, message, message.length + 1);
+
+        final CIFSException e = assertThrows(CIFSException.class, () -> ctx.decryptMessage(wire));
+        assertTrue(e.getMessage().contains("plaintext bytes"), e.getMessage());
+    }
+
+    /**
+     * Builds a correctly authenticated AES-128-GCM transform message that declares {@code declaredSize} in its
+     * OriginalMessageSize field, which a well-behaved server would never do.
+     */
+    private static byte[] forgeGcmTransformMessage(final byte[] key, final byte[] message, final int declaredSize) throws Exception {
+        final byte[] nonceField = new byte[16];
+        Arrays.fill(nonceField, 0, 12, (byte) 0x5A);
+        final Smb2TransformHeader header =
+                new Smb2TransformHeader(nonceField, declaredSize, Smb2EncryptionContext.TRANSFORM_FLAG_ENCRYPTED, 1L);
+
+        final byte[] wire = new byte[Smb2TransformHeader.TRANSFORM_HEADER_SIZE + message.length];
+        header.encode(wire, 0);
+        final byte[] aad = Arrays.copyOfRange(wire, Smb2TransformHeader.AAD_OFFSET, Smb2TransformHeader.TRANSFORM_HEADER_SIZE);
+
+        final AEADBlockCipher cipher = GCMBlockCipher.newInstance(AESEngine.newInstance());
+        cipher.init(true, new AEADParameters(new KeyParameter(key), 128, Arrays.copyOf(nonceField, 12), aad));
+        final byte[] out = new byte[cipher.getOutputSize(message.length)];
+        int len = cipher.processBytes(message, 0, message.length, out, 0);
+        len += cipher.doFinal(out, len);
+
+        System.arraycopy(out, message.length, wire, Smb2TransformHeader.SIGNATURE_OFFSET, len - message.length);
+        System.arraycopy(out, 0, wire, Smb2TransformHeader.TRANSFORM_HEADER_SIZE, message.length);
+        return wire;
     }
 }


### PR DESCRIPTION
Stacked on #92 — please merge that first. The base of this PR is `fix/issue-70-71-smb3-encryption`, so the diff shown here is only the follow-up.

These are the non-blocking points left over from the review of #92.

## Transform header validation

`decryptMessage` checked neither the `Flags`/`EncryptionAlgorithm` field nor `OriginalMessageSize`. Both are covered by the AEAD tag, so they are authentic — but authenticity is not consistency, and nothing rejected a peer that filled them in with something else. MS-SMB2 3.2.5.1.1 expects the client to check.

Both rejections are pinned by tests that construct an *authentic* transform message the client would otherwise accept, so they fail without the production change:

- `rejectsUnexpectedTransformFlags` — a message produced by an SMB 3.0 context (which puts the cipher id in the field) is refused by an SMB 3.1.1 context (which requires `SMB2_TRANSFORM_FLAG_ENCRYPTED`).
- `rejectsInconsistentOriginalMessageSize` — a correctly tagged AES-128-GCM message whose header declares one byte more than it carries.

## One buffer instead of three

`writeEncrypted` copied the plaintext out of the pooled buffer, then `encryptMessage` built the wrapped message, then `writeEncrypted` copied that again to prepend the NetBIOS session header — about four times the message size allocated per encrypted message, on the path the buffer cache exists to keep allocation-free.

`Smb2EncryptionContext.encryptMessage` now takes source and destination ranges, so the transport encrypts directly into the frame it is going to write. Two buffers remain (the frame and the cipher's own output) and the frame still reaches the socket in a single `write`, as on the unencrypted path. The existing `encryptMessage(byte[], long)` is kept as a wrapper.

## Dead code

`SmbSessionImpl.encryptMessage`/`decryptMessage` had no production callers — the transport resolves the encryption context itself and reports its own errors — and kept a second copy of the null-context check. Removed, and the test that covered them now covers what the transport actually relies on.

## Javadoc

The `AAD_OFFSET` javadoc had ended up above `SIGNATURE_OFFSET`, which has its own comment, leaving a public constant undocumented. Moved back.

## Verification

`mvn test` — 8607 tests, 0 failures. `mvn formatter:validate` clean.

Against Samba (`dperson/samba`, 4.13.7), with `jcifs.client.encryptionEnabled=true`:

| server | result |
|---|---|
| share-level `smb encrypt = required`, global unset | list / write / read-back / compounded enumeration OK, 8 MB round trip SHA-256 match |
| global `smb encrypt = required`, SMB 3.1.1 / AES-128-GCM | same |
| global `smb encrypt = required`, `server max protocol = SMB3_02` / AES-128-CCM | same |
| plaintext share with encryption disabled | unchanged |

The new header checks accept real Samba traffic on both ciphers.

Note that this repository only runs CI for pull requests targeting `main`, so no workflow will run on this PR while it is stacked.
