### PR TITLE
fix(smb2): lay out SMB2 CREATE create contexts as MS-SMB2 requires

### DIFF
--- a/docs/SMB3_SUPPORT.md
+++ b/docs/SMB3_SUPPORT.md
@@ -164,11 +164,12 @@ None of this works. It is the area most likely to be mistaken for working code.
 | SMB3 leases | Not implemented | Two unused constants. A real lease-break frame would fail the notification decode (structure size 44 vs the expected 24) and tear down the transport. |
 | Directory leasing | Not implemented | Unused capability constant; depends on leases. |
 | Durable / persistent handles | Not implemented | No DHnQ/DH2Q/DHnC/DH2C contexts, no app instance id, no handle reconnect path. |
-| Create contexts (the framework itself) | Not functional | Encoder and decoder are both present and correct, but `Smb2CreateRequest.createContexts` is private with **no setter**, and `Smb2CreateResponse.createContext()` is `return null`. No context can be sent, and none can be recognised. |
+| Create contexts (the framework itself) | Not functional | The request side encodes correctly: `Smb2CreateRequest.setCreateContexts()` lays contexts out as MS-SMB2 2.2.13.2 requires, and `CreateContextIT` checks that a real server answers each one. But nothing outside the tests calls it, and `Smb2CreateResponse.createContext()` is `return null`, so a context in a response is skipped. Before 3.0.4 no context could be sent at all — `size()` left out each context's header and name, so the request failed before it was sent — and the encoder also zeroed every `Next` and undercounted `CreateContextsLength`. |
 
 The last row is the blocker for the three above it: leases, durable handles and
-persistent handles all ride on create contexts, so they cannot be implemented
-without first opening those two dead ends.
+persistent handles all ride on create contexts. Contexts can now be sent, but a
+lease or durable handle response still cannot be recognised, so none of the three
+can be implemented without first decoding those response contexts.
 
 ## Throughput and credits
 

--- a/docs/proposals/smb3/01-smb3-lease-design.md
+++ b/docs/proposals/smb3/01-smb3-lease-design.md
@@ -10,10 +10,10 @@
 > What does exist is unused protocol scaffolding: the constants
 > `SMB2_OPLOCK_LEVEL_LEASE` (`Smb2CreateRequest`) and `SMB2_GLOBAL_CAP_LEASING`
 > (`Smb2Constants`), neither of which is referenced anywhere, plus the create
-> context framework described below. That framework encodes and decodes contexts
-> generically, but `Smb2CreateRequest` exposes no way to set one and
-> `Smb2CreateResponse.createContext()` returns `null` for every context name, so no
-> lease context can be sent or recognised.
+> context framework described below. `Smb2CreateRequest.setCreateContexts()` can
+> send contexts, but no lease context exists to send, and
+> `Smb2CreateResponse.createContext()` returns `null` for every context name, so a
+> lease response could not be recognised.
 >
 > For what jcifs actually supports today, see
 > [SMB3_SUPPORT.md](../../SMB3_SUPPORT.md). For the other unstarted proposals,

--- a/docs/proposals/smb3/02-persistent-handles-design.md
+++ b/docs/proposals/smb3/02-persistent-handles-design.md
@@ -9,10 +9,10 @@
 >
 > What does exist is unused protocol scaffolding: the
 > `SMB2_GLOBAL_CAP_PERSISTENT_HANDLES` constant (`Smb2Constants`), which is not
-> referenced anywhere, plus the create context framework. That framework encodes
-> and decodes contexts generically, but `Smb2CreateRequest` exposes no way to set
-> one and `Smb2CreateResponse.createContext()` returns `null` for every context
-> name, so no durable or persistent handle context can be sent or recognised.
+> referenced anywhere, plus the create context framework.
+> `Smb2CreateRequest.setCreateContexts()` can send contexts, but no durable or
+> persistent handle context exists to send, and `Smb2CreateResponse.createContext()`
+> returns `null` for every context name, so no such response could be recognised.
 >
 > For what jcifs actually supports today, see
 > [SMB3_SUPPORT.md](../../SMB3_SUPPORT.md). For the other unstarted proposals,

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/create/Smb2CreateRequest.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/create/Smb2CreateRequest.java
@@ -405,6 +405,14 @@ public class Smb2CreateRequest extends ServerMessageBlock2Request<Smb2CreateResp
     }
 
     /**
+     * Set the create contexts to send with the request
+     * @param createContexts the create contexts, in the order they are sent
+     */
+    public void setCreateContexts(final CreateContextRequest... createContexts) {
+        this.createContexts = createContexts;
+    }
+
+    /**
      * {@inheritDoc}
      *
      * @see org.codelibs.jcifs.smb.internal.CommonServerMessageBlockRequest#size()
@@ -419,9 +427,16 @@ public class Smb2CreateRequest extends ServerMessageBlock2Request<Smb2CreateResp
 
         size += size8(nameLen);
         if (this.createContexts != null) {
+            int createContextsLength = 0;
             for (final CreateContextRequest ccr : this.createContexts) {
-                size += size8(ccr.size());
+                // every context after the first starts on an 8-byte boundary
+                createContextsLength = size8(createContextsLength);
+                // 16 byte header, then the name, then the data on an 8-byte boundary
+                final int nameEnd = 16 + ccr.getName().length;
+                final int dataLength = ccr.size();
+                createContextsLength += dataLength == 0 ? nameEnd : size8(nameEnd) + dataLength;
             }
+            size += createContextsLength;
         }
         return size8(size);
     }
@@ -484,51 +499,45 @@ public class Smb2CreateRequest extends ServerMessageBlock2Request<Smb2CreateResp
 
         dstIndex += pad8(dstIndex);
 
+        final int createContextsStart = dstIndex;
         if (this.createContexts == null || this.createContexts.length == 0) {
             SMBUtil.writeInt4(0, dst, createContextOffsetOffset);
         } else {
-            SMBUtil.writeInt4(dstIndex - getHeaderStart(), dst, createContextOffsetOffset);
-        }
-        int totalCreateContextLength = 0;
-        if (this.createContexts != null) {
+            SMBUtil.writeInt4(createContextsStart - getHeaderStart(), dst, createContextOffsetOffset);
             int lastStart = -1;
             for (final CreateContextRequest createContext : this.createContexts) {
-                final int structStart = dstIndex;
-
-                SMBUtil.writeInt4(0, dst, structStart); // Next
-                if (lastStart > 0) {
-                    // set next pointer of previous CREATE_CONTEXT
-                    SMBUtil.writeInt4(structStart - dstIndex, dst, lastStart);
+                if (lastStart >= 0) {
+                    // set next pointer of previous CREATE_CONTEXT to this one, on an 8-byte boundary
+                    dstIndex += pad8(dstIndex);
+                    SMBUtil.writeInt4(dstIndex - lastStart, dst, lastStart);
                 }
-
-                dstIndex += 4;
+                final int structStart = dstIndex;
                 final byte[] cnBytes = createContext.getName();
-                final int cnOffsetOffset = dstIndex;
-                SMBUtil.writeInt2(cnBytes.length, dst, dstIndex + 2);
-                dstIndex += 4;
 
-                final int dataOffsetOffset = dstIndex + 2;
-                dstIndex += 4;
-                final int dataLengthOffset = dstIndex;
-                dstIndex += 4;
+                SMBUtil.writeInt4(0, dst, structStart); // Next, stays 0 for the last context
+                SMBUtil.writeInt2(16, dst, structStart + 4); // NameOffset, the name follows the header
+                SMBUtil.writeInt2(cnBytes.length, dst, structStart + 6); // NameLength
+                SMBUtil.writeInt2(0, dst, structStart + 8); // Reserved
+                dstIndex += 16;
 
-                SMBUtil.writeInt2(dstIndex - structStart, dst, cnOffsetOffset);
                 System.arraycopy(cnBytes, 0, dst, dstIndex, cnBytes.length);
                 dstIndex += cnBytes.length;
-                dstIndex += pad8(dstIndex);
 
-                SMBUtil.writeInt2(dstIndex - structStart, dst, dataOffsetOffset);
-                final int len = createContext.encode(dst, dstIndex);
-                SMBUtil.writeInt4(len, dst, dataLengthOffset);
-                dstIndex += len;
-
-                final int pad = pad8(dstIndex);
-                totalCreateContextLength += len + pad;
-                dstIndex += pad;
+                // Data goes on the next 8-byte boundary, and DataOffset SHOULD be 0 when there is none (MS-SMB2 2.2.13.2).
+                // Going by what encode() wrote rather than size() lets the size check catch a context that misreports it.
+                final int dataStart = dstIndex + pad8(dstIndex);
+                final int dataLength = createContext.encode(dst, dataStart);
+                int dataOffset = 0;
+                if (dataLength > 0) {
+                    dataOffset = dataStart - structStart;
+                    dstIndex = dataStart + dataLength;
+                }
+                SMBUtil.writeInt2(dataOffset, dst, structStart + 10); // DataOffset
+                SMBUtil.writeInt4(dataLength, dst, structStart + 12); // DataLength
                 lastStart = structStart;
             }
         }
-        SMBUtil.writeInt4(totalCreateContextLength, dst, createContextLengthOffset);
+        SMBUtil.writeInt4(dstIndex - createContextsStart, dst, createContextLengthOffset);
         return dstIndex - start;
     }
 

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbCreateContextProbe.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbCreateContextProbe.java
@@ -1,0 +1,62 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.impl;
+
+import org.codelibs.jcifs.smb.CIFSException;
+import org.codelibs.jcifs.smb.SmbConstants;
+import org.codelibs.jcifs.smb.internal.smb2.create.CreateContextRequest;
+import org.codelibs.jcifs.smb.internal.smb2.create.Smb2CloseRequest;
+import org.codelibs.jcifs.smb.internal.smb2.create.Smb2CreateRequest;
+import org.codelibs.jcifs.smb.internal.smb2.create.Smb2CreateResponse;
+
+/**
+ * Test-only way to put an SMB2 CREATE carrying create contexts on the wire.
+ *
+ * <p>
+ * {@code SmbTreeHandleImpl} is package private, so this class lives in the
+ * implementation package purely so integration tests can see how a real server
+ * answers a hand-built list of create contexts.
+ * </p>
+ */
+public final class SmbCreateContextProbe {
+
+    private SmbCreateContextProbe() {
+    }
+
+    /**
+     * Opens an existing file with the given create contexts and closes it again
+     * in the same compound request.
+     *
+     * @param file     an existing file
+     * @param contexts the create contexts to send, in order
+     * @return the raw SMB2 CREATE response, starting at its SMB2 header
+     * @throws CIFSException if the server refuses the request
+     */
+    public static byte[] openWithContexts(final SmbFile file, final CreateContextRequest... contexts) throws CIFSException {
+        try (SmbTreeHandleImpl th = (SmbTreeHandleImpl) file.getTreeHandle()) {
+            if (!th.isSMB2()) {
+                throw new IllegalStateException("Create contexts need an SMB2 connection");
+            }
+            final Smb2CreateRequest create = new Smb2CreateRequest(th.getConfig(), file.getUncPath());
+            create.setDesiredAccess(SmbConstants.FILE_READ_ATTRIBUTES);
+            create.setShareAccess(SmbConstants.FILE_SHARE_READ | SmbConstants.FILE_SHARE_WRITE);
+            create.setCreateContexts(contexts);
+            create.chain(new Smb2CloseRequest(th.getConfig(), file.getUncPath()));
+            final Smb2CreateResponse response = th.send(create, RequestParam.RETAIN_PAYLOAD);
+            return response.getRawPayload();
+        }
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/create/Smb2CreateRequestTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/create/Smb2CreateRequestTest.java
@@ -1,17 +1,21 @@
 package org.codelibs.jcifs.smb.internal.smb2.create;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 import org.codelibs.jcifs.smb.CIFSContext;
 import org.codelibs.jcifs.smb.Configuration;
 import org.codelibs.jcifs.smb.internal.smb2.Smb2Constants;
+import org.codelibs.jcifs.smb.internal.util.SMBUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -485,5 +489,190 @@ class Smb2CreateRequestTest {
         // But getPath() adds a backslash at the beginning, so \\fourth\path\\ becomes \fourth\path\
         request.setPath("\\\\fourth\\path\\\\");
         assertEquals("\\\\fourth\\path\\", request.getPath());
+    }
+
+    @Test
+    @DisplayName("a create context carries its name at offset 16 and 8-byte aligned data, with no padding after the last one")
+    void testEncodeSingleCreateContext() {
+        request = new Smb2CreateRequest(mockConfig, "a");
+        request.setCreateContexts(new RawCreateContext(ascii("TEST"), new byte[] { 1, 2, 3, 4, 5 }));
+
+        // The 64 byte header, the 56 byte fixed body and the 2 byte name padded to 8 put the context at 128.
+        // It ends at 128 + 16 (header) + 4 (name) + 4 (padding) + 5 (data) = 157.
+        assertEquals(160, request.size());
+        final byte[] buffer = prefilledBuffer();
+        assertEquals(160, request.encode(buffer, 0));
+
+        assertCreateContexts(buffer, 128, 29);
+        assertCreateContext(buffer, 128, 0, ascii("TEST"), 24, new byte[] { 1, 2, 3, 4, 5 });
+    }
+
+    @Test
+    @DisplayName("each create context points at its 8-byte aligned successor")
+    void testEncodeChainedCreateContexts() {
+        request = new Smb2CreateRequest(mockConfig, "a");
+        request.setCreateContexts(new RawCreateContext(ascii("TEST"), new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }),
+                new RawCreateContext(ascii("ABCD"), new byte[] { 9, 10, 11 }));
+
+        // The first context ends on a boundary at 160; the second ends at 160 + 24 + 3 = 187.
+        assertEquals(192, request.size());
+        final byte[] buffer = prefilledBuffer();
+        assertEquals(192, request.encode(buffer, 0));
+
+        assertCreateContexts(buffer, 128, 59);
+        assertCreateContext(buffer, 128, 32, ascii("TEST"), 24, new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });
+        assertCreateContext(buffer, 160, 0, ascii("ABCD"), 24, new byte[] { 9, 10, 11 });
+    }
+
+    @Test
+    @DisplayName("a create context without data sends DataOffset 0 and is padded before its successor")
+    void testEncodeCreateContextWithoutData() {
+        request = new Smb2CreateRequest(mockConfig, "a");
+        request.setCreateContexts(new RawCreateContext(ascii("QFid"), new byte[0]),
+                new RawCreateContext(ascii("TEST"), new byte[] { 1, 2, 3, 4, 5 }));
+
+        // The first context is header and name only, ending at 148 and padded to 152.
+        // The second ends at 152 + 24 + 5 = 181.
+        assertEquals(184, request.size());
+        final byte[] buffer = prefilledBuffer();
+        assertEquals(184, request.encode(buffer, 0));
+
+        assertCreateContexts(buffer, 128, 53);
+        assertCreateContext(buffer, 128, 24, ascii("QFid"), 0, new byte[0]);
+        assertCreateContext(buffer, 152, 0, ascii("TEST"), 24, new byte[] { 1, 2, 3, 4, 5 });
+    }
+
+    @Test
+    @DisplayName("a create context named by a 16 byte GUID has its data directly after the name")
+    void testEncodeCreateContextWithGuidName() {
+        // SMB2_CREATE_APP_INSTANCE_ID is named by a GUID rather than a four character tag
+        final byte[] name = { 0x45, (byte) 0xBC, (byte) 0xA6, 0x6A, (byte) 0xEF, (byte) 0xA7, (byte) 0xF7, 0x4A, (byte) 0x90, 0x08,
+                (byte) 0xFA, 0x46, 0x2E, 0x14, 0x4D, 0x74 };
+        final byte[] data = new byte[20];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) (i + 1);
+        }
+        request = new Smb2CreateRequest(mockConfig, "a");
+        request.setCreateContexts(new RawCreateContext(name, data));
+
+        // Header and name end on a boundary at 160; the data ends at 180.
+        assertEquals(184, request.size());
+        final byte[] buffer = prefilledBuffer();
+        assertEquals(184, request.encode(buffer, 0));
+
+        assertCreateContexts(buffer, 128, 52);
+        assertCreateContext(buffer, 128, 0, name, 32, data);
+    }
+
+    @Test
+    @DisplayName("a request with an empty create context list leaves the create contexts section empty")
+    void testEncodeWithEmptyCreateContexts() {
+        request = new Smb2CreateRequest(mockConfig, "a");
+        request.setCreateContexts();
+
+        final byte[] buffer = prefilledBuffer();
+        assertEquals(128, request.encode(buffer, 0));
+
+        assertCreateContexts(buffer, 0, 0);
+    }
+
+    @Test
+    @DisplayName("create context alignment is measured from the SMB2 header when the message follows a transport header")
+    void testEncodeCreateContextsAfterTransportHeader() {
+        request = new Smb2CreateRequest(mockConfig, "a");
+        request.setCreateContexts(new RawCreateContext(ascii("QFid"), new byte[0]),
+                new RawCreateContext(ascii("TEST"), new byte[] { 1, 2, 3, 4, 5 }));
+
+        // The transport writes a 4 byte header before the message. This is testEncodeCreateContextWithoutData moved by 4;
+        // aligning from the start of the buffer instead of the SMB2 header would shift the padded offsets.
+        final byte[] buffer = prefilledBuffer();
+        assertEquals(184, request.encode(buffer, 4));
+
+        assertCreateContexts(buffer, 4, 128, 53);
+        assertCreateContext(buffer, 4 + 128, 24, ascii("QFid"), 0, new byte[0]);
+        assertCreateContext(buffer, 4 + 152, 0, ascii("TEST"), 24, new byte[] { 1, 2, 3, 4, 5 });
+    }
+
+    @Test
+    @DisplayName("a create context whose size() reports no data but which writes some is refused rather than sent without it")
+    void testEncodeRefusesContextThatUnderstatesItsSize() {
+        request = new Smb2CreateRequest(mockConfig, "a");
+        request.setCreateContexts(new RawCreateContext(ascii("TEST"), new byte[] { 1, 2, 3, 4, 5 }, 0));
+
+        assertThrows(IllegalStateException.class, () -> request.encode(prefilledBuffer(), 0));
+    }
+
+    private static byte[] ascii(final String value) {
+        return value.getBytes(StandardCharsets.US_ASCII);
+    }
+
+    /**
+     * @return a buffer whose stale contents show up in any field the encoder does not write
+     */
+    private static byte[] prefilledBuffer() {
+        final byte[] buffer = new byte[512];
+        Arrays.fill(buffer, (byte) 0xAA);
+        return buffer;
+    }
+
+    private static void assertCreateContexts(final byte[] buffer, final int offset, final int length) {
+        assertCreateContexts(buffer, 0, offset, length);
+    }
+
+    private static void assertCreateContexts(final byte[] buffer, final int headerStart, final int offset, final int length) {
+        // CreateContextsOffset and CreateContextsLength are 48 and 52 bytes into the body following the 64 byte header
+        assertEquals(offset, SMBUtil.readInt4(buffer, headerStart + 64 + 48), "CreateContextsOffset");
+        assertEquals(length, SMBUtil.readInt4(buffer, headerStart + 64 + 52), "CreateContextsLength");
+    }
+
+    private static void assertCreateContext(final byte[] buffer, final int start, final int next, final byte[] name, final int dataOffset,
+            final byte[] data) {
+        assertEquals(next, SMBUtil.readInt4(buffer, start), "Next");
+        assertEquals(16, SMBUtil.readInt2(buffer, start + 4), "NameOffset");
+        assertEquals(name.length, SMBUtil.readInt2(buffer, start + 6), "NameLength");
+        assertEquals(0, SMBUtil.readInt2(buffer, start + 8), "Reserved");
+        assertEquals(dataOffset, SMBUtil.readInt2(buffer, start + 10), "DataOffset");
+        assertEquals(data.length, SMBUtil.readInt4(buffer, start + 12), "DataLength");
+        assertArrayEquals(name, Arrays.copyOfRange(buffer, start + 16, start + 16 + name.length), "Name");
+        assertArrayEquals(data, Arrays.copyOfRange(buffer, start + dataOffset, start + dataOffset + data.length), "Data");
+    }
+
+    /**
+     * A create context that sends fixed name and data bytes.
+     */
+    private static final class RawCreateContext implements CreateContextRequest {
+
+        private final byte[] name;
+        private final byte[] data;
+        private final int reportedSize;
+
+        RawCreateContext(final byte[] name, final byte[] data) {
+            this(name, data, data.length);
+        }
+
+        /**
+         * @param reportedSize what {@link #size()} returns; a well-behaved context reports its data length
+         */
+        RawCreateContext(final byte[] name, final byte[] data, final int reportedSize) {
+            this.name = name;
+            this.data = data;
+            this.reportedSize = reportedSize;
+        }
+
+        @Override
+        public byte[] getName() {
+            return this.name;
+        }
+
+        @Override
+        public int encode(final byte[] dst, final int dstIndex) {
+            System.arraycopy(this.data, 0, dst, dstIndex, this.data.length);
+            return this.data.length;
+        }
+
+        @Override
+        public int size() {
+            return this.reportedSize;
+        }
     }
 }

--- a/src/test/java/org/codelibs/jcifs/smb/it/CreateContextIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/CreateContextIT.java
@@ -1,0 +1,168 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.SmbConstants;
+import org.codelibs.jcifs.smb.impl.SmbCreateContextProbe;
+import org.codelibs.jcifs.smb.impl.SmbFile;
+import org.codelibs.jcifs.smb.internal.smb2.create.CreateContextRequest;
+import org.codelibs.jcifs.smb.internal.util.SMBUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Sends SMB2 CREATE requests carrying create contexts to a real server.
+ *
+ * <p>
+ * A server that cannot parse the create context list refuses the request with
+ * STATUS_INVALID_PARAMETER, and one given a broken {@code Next} chain only sees
+ * the first context. Asking for two contexts that every server answers catches
+ * both: each of them has to come back. The two orders cover a context with data
+ * and one without in either position.
+ * </p>
+ */
+class CreateContextIT extends AbstractSmbIT {
+
+    private static final int SMB2_HEADER_LENGTH = 64;
+
+    private SmbFile workDir;
+
+    @AfterEach
+    void removeWorkDir() {
+        deleteQuietly(this.workDir);
+    }
+
+    @Test
+    @DisplayName("every create context is answered when the first one carries data")
+    void contextWithDataFirst() throws Exception {
+        assertAnswered(open(maximalAccess(), queryOnDiskId()));
+    }
+
+    @Test
+    @DisplayName("every create context is answered when the first one carries no data")
+    void contextWithoutDataFirst() throws Exception {
+        assertAnswered(open(queryOnDiskId(), maximalAccess()));
+    }
+
+    private Map<String, byte[]> open(final CreateContextRequest... contexts) throws Exception {
+        final CIFSContext context = server().context();
+        this.workDir = createWorkDir(context, server().share());
+        final SmbFile file = writeFile(this.workDir, "contexts.txt", "create context target");
+        return responseContexts(SmbCreateContextProbe.openWithContexts(file, contexts));
+    }
+
+    private static void assertAnswered(final Map<String, byte[]> answered) {
+        final byte[] maximalAccess = answered.get("MxAc");
+        assertNotNull(maximalAccess, "no maximal access response among " + answered.keySet());
+        assertEquals(8, maximalAccess.length, "SMB2_CREATE_QUERY_MAXIMAL_ACCESS_RESPONSE length");
+        assertEquals(0, SMBUtil.readInt4(maximalAccess, 0), "QueryStatus");
+        assertTrue((SMBUtil.readInt4(maximalAccess, 4) & SmbConstants.FILE_READ_ATTRIBUTES) != 0,
+                "the file's creator should have at least FILE_READ_ATTRIBUTES");
+
+        final byte[] onDiskId = answered.get("QFid");
+        assertNotNull(onDiskId, "no on-disk id response among " + answered.keySet());
+        assertEquals(32, onDiskId.length, "SMB2_CREATE_QUERY_ON_DISK_ID response length");
+    }
+
+    /**
+     * Walks the create contexts of a raw CREATE response independently of the
+     * client's own decoder.
+     */
+    private static Map<String, byte[]> responseContexts(final byte[] response) {
+        // CreateContextsOffset and CreateContextsLength are 80 and 84 bytes into the CREATE response body
+        final long offset = SMBUtil.readInt4(response, SMB2_HEADER_LENGTH + 80) & 0xFFFFFFFFL;
+        final long length = SMBUtil.readInt4(response, SMB2_HEADER_LENGTH + 84) & 0xFFFFFFFFL;
+        final Map<String, byte[]> contexts = new LinkedHashMap<>();
+        if (offset == 0 || length == 0) {
+            return contexts;
+        }
+        // Every read stays inside CreateContextsLength, so a truncated or malformed list fails rather than reading zeros
+        final long end = offset + length;
+        assertTrue(end <= response.length, "the create contexts run past the end of the response");
+        long start = offset;
+        while (true) {
+            assertTrue(start + 16 <= end, "a create context header runs past CreateContextsLength");
+            final int at = (int) start;
+            final long next = SMBUtil.readInt4(response, at) & 0xFFFFFFFFL;
+            final int nameOffset = SMBUtil.readInt2(response, at + 4);
+            final int nameLength = SMBUtil.readInt2(response, at + 6);
+            final int dataOffset = SMBUtil.readInt2(response, at + 10);
+            final long dataLength = SMBUtil.readInt4(response, at + 12) & 0xFFFFFFFFL;
+            assertTrue(start + nameOffset + nameLength <= end && start + dataOffset + dataLength <= end,
+                    "a create context runs past CreateContextsLength");
+            final String name = new String(response, at + nameOffset, nameLength, StandardCharsets.US_ASCII);
+            contexts.put(name, Arrays.copyOfRange(response, at + dataOffset, at + dataOffset + (int) dataLength));
+            if (next == 0) {
+                return contexts;
+            }
+            assertTrue(next >= 16 && next % 8 == 0, "invalid Next " + next);
+            start += next;
+        }
+    }
+
+    /**
+     * @return SMB2_CREATE_QUERY_MAXIMAL_ACCESS_REQUEST with a zero Timestamp, which
+     *         never matches the file's last write time and so is always answered
+     */
+    private static CreateContextRequest maximalAccess() {
+        return new FixedCreateContext("MxAc", new byte[8]);
+    }
+
+    /**
+     * @return SMB2_CREATE_QUERY_ON_DISK_ID, which carries no data
+     */
+    private static CreateContextRequest queryOnDiskId() {
+        return new FixedCreateContext("QFid", new byte[0]);
+    }
+
+    private static final class FixedCreateContext implements CreateContextRequest {
+
+        private final byte[] name;
+        private final byte[] data;
+
+        FixedCreateContext(final String name, final byte[] data) {
+            this.name = name.getBytes(StandardCharsets.US_ASCII);
+            this.data = data;
+        }
+
+        @Override
+        public byte[] getName() {
+            return this.name;
+        }
+
+        @Override
+        public int encode(final byte[] dst, final int dstIndex) {
+            System.arraycopy(this.data, 0, dst, dstIndex, this.data.length);
+            return this.data.length;
+        }
+
+        @Override
+        public int size() {
+            return this.data.length;
+        }
+    }
+}


### PR DESCRIPTION
This is the request half of the create context support that SMB3 leases and durable handles both depend on. Nothing in the client attaches a create context yet, so no request it sends today changes.

## The problem

`Smb2CreateRequest` has an encoder for create contexts, but it could never put one on the wire:

- There was no way to attach one: `createContexts` is private and had no setter.
- `size()` counted only each context's data (`size8(ccr.size())`), leaving out its 16-byte header, its name and the padding. `ServerMessageBlock2Request.encode()` compares `size()` with what was written, so any CREATE carrying a context failed with `IllegalStateException: Wrong size calculation` before it was sent.
- The previous context's `Next` was written as `structStart - dstIndex`, which is always 0 at that point, so a server would only ever see the first context.
- `CreateContextsLength` summed data and padding only, so the declared list was shorter than the bytes that followed it.
- `Reserved`, which the client MUST set to 0, was never written.

`docs/SMB3_SUPPORT.md` described the encoder as present and correct. It was not.

## What this changes

- **`Smb2CreateRequest.setCreateContexts(CreateContextRequest...)`** attaches contexts in the order given.
- **Layout.** Each context is laid out as MS-SMB2 2.2.13.2 and Samba's `smb2_create_blob_parse()` expect: the name at offset 16, data on an 8-byte boundary, `DataOffset` 0 when there is no data (the spec's SHOULD), `Reserved` 0, `Next` pointing at the 8-byte aligned successor, and `CreateContextsLength` ending at the last context with no trailing padding, as Samba's own client does.
- **`size()`** follows the same layout.
- **Whether a context carries data** is decided by what its `encode()` wrote. A context whose `size()` disagrees is caught by the existing size check instead of being sent without its data.

The response side is unchanged. Contexts in a CREATE response are still walked and skipped, because `Smb2CreateResponse.createContext()` recognises none. Lease and durable handle responses belong with the features that need them. `SMB3_SUPPORT.md` therefore keeps create contexts as "Not functional": the request side now works, but nothing outside the tests calls it.

`docs/SMB3_SUPPORT.md` and the banners of the lease and durable handle proposals are updated to match.

## Compatibility

A CREATE without contexts takes the same branch as before and produces the same bytes; every CREATE the client sends today is one of those. `setCreateContexts` is new, on an `internal` class.

## Tests

- **`Smb2CreateRequestTest`** pins the byte layout for one context, a chain of two, a context without data followed by one with data, and a context named by a 16-byte GUID (as `SMB2_CREATE_APP_INSTANCE_ID` is). The expected offsets are worked out by hand in comments.
  - Each test encodes into a buffer pre-filled with non-zero bytes, so a field the encoder forgets to write shows up.
  - One case is encoded after a 4-byte transport header, as the transport does. Alignment measured from the buffer start instead of the SMB2 header fails it without needing a server.
  - A context whose `size()` reports no data but whose `encode()` writes some must be refused.
  - Nine mutations of the encoder each fail at least one test: `Next` never linked, last context padded, `DataOffset` set without data, `Reserved` skipped, no padding between contexts, name padding missing from `size()`, wrong `NameOffset`, alignment measured from the buffer start, data skipped when `size()` reports none.
- **`CreateContextIT`** sends `SMB2_CREATE_QUERY_MAXIMAL_ACCESS_REQUEST` (with an 8-byte timestamp) and `SMB2_CREATE_QUERY_ON_DISK_ID` (no data), in both orders, compounded with a CLOSE. It walks the raw response independently of the client's decoder, never reading past `CreateContextsLength`, and checks that both are answered. A broken `Next` chain would drop one; a bad layout would be refused with `STATUS_INVALID_PARAMETER`.
  - `SmbCreateContextProbe` exists only because `SmbTreeHandleImpl` is package private, the same reason `SmbNegotiationProbe` does.

## Verification

Each run is on this branch and compared with the same run on `main` (`f3af915`). There are no failures anywhere.

| Run | `main` | This branch |
|---|---|---|
| `mvn verify` against the Samba container | 8569 unit, 104 integration (7 skipped) | 8576 unit, 106 integration (7 skipped) |
| `build_helpers/run-it-with-dfs.sh` (Samba on port 445, DFS tests enabled) | not run | 8576 unit, 106 integration (3 skipped) |
| `windows-smb` workflow (Windows Server 2025) | 8569 unit, 104 integration (9 skipped) | 8576 unit, 106 integration (9 skipped) |

The skipped tests are the same ones as on `main`:
- DFS tests where port 445 is not available.
- Backend-specific `AuthenticationIT` and `SymlinkIT` cases.
- The two symbolic link cases disabled for #75.

`CreateContextIT` passes against both servers, with SMB 3.1.1 and signing required. Samba and Windows both accept the layout, including a last context with no trailing padding.

`mvn apache-rat:check` passes, and `mvn formatter:format` has been applied.
