### PR TITLE
fix(smb2): keep written bytes when an output stream reopens the file

### DIFF
--- a/docs/SMB3_SUPPORT.md
+++ b/docs/SMB3_SUPPORT.md
@@ -195,6 +195,18 @@ additional TCP connections to the same host once a connection reaches
 sessions across more connections; `ssnLimit=1` gives one connection per session.
 These are independent connections, not bound channels of one session.
 
+### Reconnecting after a dropped connection
+
+There are no durable handles, so a dropped connection invalidates every open
+handle. A stream notices on its next operation, reopens the file by path, and
+carries on writing or reading at the position it had reached.
+
+A write stream keeps what it has already written. Before 3.0.4 the reopen used
+the create flags the stream was constructed with, so on SMB2 it came back with
+`FILE_OVERWRITE_IF`: the file was truncated and the stream wrote on at its old
+offset, leaving everything before that offset as a hole. Nothing reported it —
+the write returned normally and `close()` succeeded.
+
 ## Other features
 
 | Feature | Status | Notes |

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbFileOutputStream.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbFileOutputStream.java
@@ -146,13 +146,20 @@ public class SmbFileOutputStream extends OutputStream {
      */
     protected final void init(final SmbTreeHandleImpl th) throws CIFSException {
         final int sendBufferSize = th.getSendBufferSize();
+
+        /*
+         * A file stream is already open by the time this runs, so a reopen after a dropped connection must neither
+         * create nor truncate the file again: the stream carries on writing at the position it had reached, and
+         * truncating would leave everything before that position as a hole.
+         */
+        this.openFlags &= ~(SmbConstants.O_CREAT | SmbConstants.O_TRUNC);
+
         if (this.smb2) {
             this.writeSize = sendBufferSize;
             this.writeSizeFile = sendBufferSize;
             return;
         }
 
-        this.openFlags &= ~(SmbConstants.O_CREAT | SmbConstants.O_TRUNC); /* in case we close and reopen */
         this.writeSize = sendBufferSize - 70;
 
         this.useNTSmbs = th.hasCapability(SmbConstants.CAP_NT_SMBS);

--- a/src/test/java/org/codelibs/jcifs/smb/it/OutputStreamReconnectIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/OutputStreamReconnectIT.java
@@ -1,0 +1,137 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.impl.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbFileOutputStream;
+import org.codelibs.jcifs.smb.it.env.TcpRelay;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * What a write does when the connection under it goes away.
+ *
+ * <p>
+ * A stream whose connection drops reopens the file by path on the next write.
+ * The reopen has to keep what the stream already wrote, because the stream
+ * carries on at the position it had reached: reopening with a create
+ * disposition that truncates leaves that part of the file as a hole, and
+ * nothing reports it.
+ * </p>
+ */
+class OutputStreamReconnectIT extends AbstractSmbIT {
+
+    private static final int CHUNK_BYTES = 128 * 1024;
+
+    private static final long DROP_TIMEOUT_SECONDS = 30;
+
+    private String workDirName;
+
+    @AfterEach
+    void removeWorkDir() throws Exception {
+        if (this.workDirName != null) {
+            deleteQuietly(new SmbFile(server().url(server().share(), this.workDirName + "/"), server().context()));
+        }
+    }
+
+    @Test
+    @DisplayName("a write that outlives a dropped connection keeps the bytes written before the drop")
+    void writeSurvivesDroppedConnection() throws Exception {
+        final CIFSContext context = server().context();
+        this.workDirName = "it-" + UUID.randomUUID();
+        final byte[] beforeDrop = randomBytes(1);
+        final byte[] afterDrop = randomBytes(2);
+
+        try (TcpRelay relay = TcpRelay.to(server().host(), server().port())) {
+            final String base = "smb://" + relay.host() + ":" + relay.port() + "/" + server().share() + "/" + this.workDirName + "/";
+            try (SmbFile dir = new SmbFile(base, context)) {
+                dir.mkdirs();
+            }
+
+            try (SmbFile file = new SmbFile(base + "reconnect.bin", context); SmbFileOutputStream out = file.openOutputStream()) {
+                out.write(beforeDrop);
+                relay.dropConnections();
+                awaitDropped(out);
+                out.write(afterDrop);
+            }
+        }
+
+        // Read it back over a connection straight to the server, so only what reached the disk counts
+        final byte[] expected = new byte[beforeDrop.length + afterDrop.length];
+        System.arraycopy(beforeDrop, 0, expected, 0, beforeDrop.length);
+        System.arraycopy(afterDrop, 0, expected, beforeDrop.length, afterDrop.length);
+        try (SmbFile written = new SmbFile(server().url(server().share(), this.workDirName + "/reconnect.bin"), context);
+                InputStream in = written.getInputStream()) {
+            final byte[] actual = in.readAllBytes();
+            assertArrayEquals(expected, actual, describe(expected, actual));
+        }
+    }
+
+    /**
+     * Waits until the client has noticed the closed socket.
+     *
+     * <p>
+     * Without this the test could pass for the wrong reason: if the connection
+     * were never really dropped, the stream would never reopen the file, and
+     * the contents would be correct whether or not the reopen truncates.
+     * </p>
+     */
+    private static void awaitDropped(final SmbFileOutputStream out) throws Exception {
+        final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(DROP_TIMEOUT_SECONDS);
+        while (out.isOpen() && System.nanoTime() < deadline) {
+            Thread.sleep(10);
+        }
+        assertFalse(out.isOpen(), "the connection was never dropped, so the reopen this test is about never happened");
+    }
+
+    private static byte[] randomBytes(final long seed) {
+        final byte[] bytes = new byte[CHUNK_BYTES];
+        new Random(seed).nextBytes(bytes);
+        return bytes;
+    }
+
+    /**
+     * Names what went wrong, since comparing two 256 KB arrays otherwise prints
+     * only the first differing index.
+     */
+    private static String describe(final byte[] expected, final byte[] actual) {
+        if (expected.length != actual.length) {
+            return "the file is " + actual.length + " bytes, expected " + expected.length;
+        }
+        int zeroed = 0;
+        for (int i = 0; i < expected.length; i++) {
+            if (expected[i] != actual[i] && actual[i] == 0) {
+                zeroed++;
+            }
+        }
+        if (zeroed > 0) {
+            return "the file has " + zeroed + " zero bytes where data was written, from offset " + Arrays.mismatch(expected, actual)
+                    + "; the reopen after the drop truncated it";
+        }
+        return "the file came back different from what was written";
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/it/env/TcpRelay.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/env/TcpRelay.java
@@ -1,0 +1,199 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it.env;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A TCP relay the tests can put in front of the SMB server so a connection can
+ * be dropped on demand.
+ *
+ * <p>
+ * Connecting a client through the relay and calling {@link #dropConnections()}
+ * reproduces what an idle firewall or a restarted server does to a live SMB
+ * connection: both ends go away without a protocol-level goodbye. Nothing else
+ * in the harness can produce that, because the server itself has to stay up for
+ * the client to reconnect to.
+ * </p>
+ *
+ * <p>
+ * It listens on the loopback interface only, on a port the operating system
+ * picks, so it never collides with the SMB port the backends use.
+ * </p>
+ */
+public final class TcpRelay implements AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(TcpRelay.class);
+
+    private static final int BUFFER_BYTES = 8192;
+
+    private final ServerSocket listener;
+    private final String targetHost;
+    private final int targetPort;
+
+    /**
+     * Every socket of every connection relayed so far. Sockets that close on their own are left in the list, which
+     * costs nothing for a relay that lives for one test and keeps {@link #dropConnections()} free of bookkeeping.
+     */
+    private final List<Socket> relayed = Collections.synchronizedList(new ArrayList<>());
+
+    private volatile boolean closed;
+
+    private TcpRelay(final String targetHost, final int targetPort) throws IOException {
+        this.targetHost = targetHost;
+        this.targetPort = targetPort;
+        this.listener = new ServerSocket(0, 0, InetAddress.getLoopbackAddress());
+    }
+
+    /**
+     * Starts a relay forwarding to the given server.
+     *
+     * @param host the server to forward to
+     * @param port the port to forward to
+     * @return the running relay, which the caller closes
+     * @throws IOException if the listening socket cannot be opened
+     */
+    public static TcpRelay to(final String host, final int port) throws IOException {
+        final TcpRelay relay = new TcpRelay(host, port);
+        final Thread accepting = new Thread(relay::acceptLoop, "smb-it-relay-accept");
+        accepting.setDaemon(true);
+        accepting.start();
+        return relay;
+    }
+
+    /**
+     * The loopback address clients connect to, ready to put in a URL.
+     *
+     * <p>
+     * Taken from the socket rather than written out as a literal, because a JVM
+     * that prefers IPv6 binds {@code ::1} where another binds {@code 127.0.0.1}.
+     * </p>
+     *
+     * @return the address, bracketed if it is an IPv6 one
+     */
+    public String host() {
+        final String address = this.listener.getInetAddress().getHostAddress();
+        return address.indexOf(':') >= 0 ? "[" + address + "]" : address;
+    }
+
+    /**
+     * @return the loopback port clients connect to
+     */
+    public int port() {
+        return this.listener.getLocalPort();
+    }
+
+    /**
+     * Closes every connection currently relayed, in both directions.
+     *
+     * <p>
+     * The relay keeps listening, so a client that reconnects is served again.
+     * </p>
+     */
+    public void dropConnections() {
+        final List<Socket> live;
+        synchronized (this.relayed) {
+            live = new ArrayList<>(this.relayed);
+            this.relayed.clear();
+        }
+        live.forEach(TcpRelay::closeQuietly);
+    }
+
+    @Override
+    public void close() {
+        this.closed = true;
+        closeQuietly(this.listener);
+        dropConnections();
+    }
+
+    private void acceptLoop() {
+        while (!this.closed) {
+            Socket client = null;
+            Socket server = null;
+            try {
+                client = this.listener.accept();
+                server = new Socket(this.targetHost, this.targetPort);
+                this.relayed.add(client);
+                this.relayed.add(server);
+                pump(client, server);
+                pump(server, client);
+            } catch (final IOException e) {
+                closeQuietly(client);
+                closeQuietly(server);
+                if (this.closed) {
+                    return;
+                }
+                // Failing to reach the server is transient. Giving up here would leave the listener accepting
+                // connections that are never forwarded, and the client would then wait out its response timeout
+                // instead of failing, turning a blip into a test that hangs.
+                log.debug("Relay could not establish a connection", e);
+            }
+        }
+    }
+
+    private void pump(final Socket from, final Socket to) {
+        final Thread pumping = new Thread(() -> {
+            final byte[] buffer = new byte[BUFFER_BYTES];
+            try {
+                final InputStream in = from.getInputStream();
+                final OutputStream out = to.getOutputStream();
+                int read;
+                while ((read = in.read(buffer)) != -1) {
+                    out.write(buffer, 0, read);
+                    out.flush();
+                }
+            } catch (final IOException e) {
+                log.trace("Relayed connection ended", e);
+            } finally {
+                closeQuietly(from);
+                closeQuietly(to);
+            }
+        }, "smb-it-relay-pump-" + port());
+        pumping.setDaemon(true);
+        pumping.start();
+    }
+
+    private static void closeQuietly(final ServerSocket socket) {
+        if (socket != null) {
+            try {
+                socket.close();
+            } catch (final IOException e) {
+                log.trace("Failed to close the relay listener", e);
+            }
+        }
+    }
+
+    private static void closeQuietly(final Socket socket) {
+        if (socket != null) {
+            try {
+                socket.close();
+            } catch (final IOException e) {
+                log.trace("Failed to close a relayed socket", e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Stacked on #99 — please merge that first. The base of this PR is `fix/smb2-create-context-encoding`, so the diff shown here is only this change. They are stacked because both update `docs/SMB3_SUPPORT.md`.

A write whose connection drops loses everything written before the drop, silently. This fixes that and adds the harness needed to test it.

## The problem

`SmbFileOutputStream` reopens the file by path when its handle is no longer valid, and carries on writing at the position it had reached. On SMB2 the reopen used the flags the stream was constructed with, and the usual constructors pass `O_CREAT | O_TRUNC`, so `SmbFile.openUnshared` chose `FILE_OVERWRITE_IF`. The file was truncated and the stream then wrote at its old offset, leaving a hole where the earlier bytes had been.

Nothing reported it. The write returned normally, `close()` succeeded, and the file was left the right length with its first part zeroed.

`init()` clears `O_CREAT` and `O_TRUNC` for exactly this reason — "in case we close and reopen" — but the SMB2 branch returned before reaching that line, so only SMB1 was protected.

## What this changes

`init()` clears the two flags for both dialects, before the SMB2 branch returns.

That is safe because:
- The file is already open by the time `init()` runs; both constructors open the handle first, so the flags never affect the initial open.
- SMB2 does not truncate through the create disposition at all. The constructor truncates with a separate SET_INFO request carrying `FileEndOfFileInformation(0)`.
- It is what the SMB1 path has always done.
- Named pipe streams are unaffected: `SmbPipeOutputStream` passes flags of 0 and overrides `ensureOpen()` to use the pipe handle, so it never reads this field.

`docs/SMB3_SUPPORT.md` gains a short section on what a dropped connection does to an open stream. It described the reconnect behaviour nowhere before, which is part of why this went unnoticed.

## Tests

- **`OutputStreamReconnectIT`** writes 128 KB, drops the connection under the stream, writes another 128 KB, closes, and reads the file back over a connection straight to the server. Without the fix the first 128 KB come back as zeros; the failure message reports how many bytes were zeroed and from which offset, since comparing two 256 KB arrays otherwise says only "differ at index 0".
  - It waits for the stream to notice the drop and fails if it never does. Otherwise a drop that silently missed would leave the file correct for the wrong reason, and the test would pass with the bug present.
- **`TcpRelay`** (test-only) forwards TCP to the server so a test can drop a live connection while the server stays up — the one thing the harness could not do before, and the reason this bug went unnoticed. It listens on loopback on an ephemeral port, so it needs no Docker, does not touch port 445, and runs against the Windows backend too.

## Verification

With only `SmbFileOutputStream` reverted to its state on `main`, and both test files as they are here, `OutputStreamReconnectIT` fails with:

```
the file has 130518 zero bytes where data was written, from offset 0; the reopen after the drop truncated it
```

Each run below is on this branch and compared with the same run on its base, `fix/smb2-create-context-encoding` (#99). There are no failures anywhere.

| Run | Base branch (#99) | This branch |
|---|---|---|
| `mvn verify` against the Samba container | 8576 unit, 106 integration (7 skipped) | 8576 unit, 107 integration (7 skipped) |
| `build_helpers/run-it-with-dfs.sh` (Samba on port 445, DFS tests enabled) | 8576 unit, 106 integration (3 skipped) | 8576 unit, 107 integration (3 skipped) |
| `windows-smb` workflow (Windows Server 2025) | 8576 unit, 106 integration (9 skipped) | 8576 unit, 107 integration (9 skipped) |

The unit test count is unchanged because the new test is an integration test; the skipped tests are the same ones as on the base branch (DFS where port 445 is unavailable, and the backend-specific or #75 cases). The new test passes against both Samba and Windows.

`mvn apache-rat:check` passes, and `mvn formatter:format` has been applied.
