### PR TITLE
fix: report a directory listing that a failure cut short

### DIFF
--- a/docs/SMB3_SUPPORT.md
+++ b/docs/SMB3_SUPPORT.md
@@ -141,7 +141,7 @@ errors.
 | CREATE, CLOSE | Supported | Compound (related) requests are used for open+query+close sequences. |
 | READ, WRITE | Supported | See [Throughput](#throughput-and-credits) for size limits. |
 | QUERY_INFO, SET_INFO | Supported | |
-| QUERY_DIRECTORY | Supported | Streaming enumeration. |
+| QUERY_DIRECTORY | Supported | Streaming enumeration. A listing cut short by a failure reports it rather than ending quietly — see [Reconnecting after a dropped connection](#reconnecting-after-a-dropped-connection). |
 | CHANGE_NOTIFY | Supported | Via `SmbResource.watch(int, boolean)`. Blocking. |
 | IOCTL | Partial | Reachable FSCTLs: DFS_GET_REFERRALS, PIPE_PEEK, PIPE_TRANSCEIVE, SRV_COPYCHUNK(_WRITE), SRV_REQUEST_RESUME_KEY, VALIDATE_NEGOTIATE_INFO. The other defined FSCTL constants are never sent. |
 | Async / `STATUS_PENDING` interim responses | Supported | |
@@ -206,6 +206,13 @@ the create flags the stream was constructed with, so on SMB2 it came back with
 `FILE_OVERWRITE_IF`: the file was truncated and the stream wrote on at its old
 offset, leaving everything before that offset as a hole. Nothing reported it —
 the write returned normally and `close()` succeeded.
+
+A directory listing has nothing to reopen: the open handle *is* the enumeration.
+Since 3.0.4 a listing that cannot be continued reports that. `children()` hands
+out the entries it had already read and then throws `RuntimeCIFSException` from
+the iterator; `list()`, `listFiles()`, `SmbFile.delete()` and `copyTo()` throw
+`SmbException`. Before that the listing simply ended, which a caller cannot tell
+apart from a directory that holds only those entries.
 
 ## Other features
 

--- a/src/main/java/org/codelibs/jcifs/smb/SmbResource.java
+++ b/src/main/java/org/codelibs/jcifs/smb/SmbResource.java
@@ -652,6 +652,12 @@ public interface SmbResource extends AutoCloseable {
     /**
      * Fetch all children
      *
+     * <p>
+     * A listing is fetched a page at a time. If a page cannot be fetched, the returned iterator hands out the entries
+     * it has already read and then throws {@link RuntimeCIFSException} from {@link java.util.Iterator#next()}, rather
+     * than ending as though the directory held only those entries.
+     * </p>
+     *
      * @return an iterator over the child resources
      * @throws CIFSException if an error occurs accessing the resource
      */
@@ -669,6 +675,9 @@ public interface SmbResource extends AutoCloseable {
      * it will match that many characters <i>or less</i>.
      * <p>
      * Wildcard expressions will not filter workgroup names or server names.
+     * <p>
+     * As with {@link #children()}, the returned iterator throws {@link RuntimeCIFSException} from
+     * {@link java.util.Iterator#next()} if the listing cannot be read to its end.
      *
      * @param wildcard the wildcard pattern to match
      * @return an iterator over the child resources
@@ -678,6 +687,11 @@ public interface SmbResource extends AutoCloseable {
 
     /**
      * Fetch children matching the given filter.
+     *
+     * <p>
+     * As with {@link #children()}, the returned iterator throws {@link RuntimeCIFSException} from
+     * {@link java.util.Iterator#next()} if the listing cannot be read to its end.
+     * </p>
      *
      * @param filter
      *            filter acting on file names
@@ -690,6 +704,11 @@ public interface SmbResource extends AutoCloseable {
 
     /**
      * Fetch children matching the given filter.
+     *
+     * <p>
+     * As with {@link #children()}, the returned iterator throws {@link RuntimeCIFSException} from
+     * {@link java.util.Iterator#next()} if the listing cannot be read to its end.
+     * </p>
      *
      * @param filter
      *            filter acting on SmbResource instances

--- a/src/main/java/org/codelibs/jcifs/smb/impl/DirFileEntryEnumIteratorBase.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/DirFileEntryEnumIteratorBase.java
@@ -20,6 +20,7 @@ package org.codelibs.jcifs.smb.impl;
 import org.codelibs.jcifs.smb.CIFSException;
 import org.codelibs.jcifs.smb.CloseableIterator;
 import org.codelibs.jcifs.smb.ResourceNameFilter;
+import org.codelibs.jcifs.smb.RuntimeCIFSException;
 import org.codelibs.jcifs.smb.SmbResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,6 +43,12 @@ public abstract class DirFileEntryEnumIteratorBase implements CloseableIterator<
     private final String wildcard;
     private final int searchAttributes;
     private FileEntry next;
+
+    /**
+     * Set when a page could not be fetched, and reported once every entry that was read has been handed out.
+     */
+    private RuntimeCIFSException failure;
+
     private int ridx;
 
     private boolean closed = false;
@@ -224,34 +231,60 @@ public abstract class DirFileEntryEnumIteratorBase implements CloseableIterator<
      */
     @Override
     public boolean hasNext() {
-        return this.next != null;
+        return this.next != null || this.failure != null;
     }
 
     /**
      * {@inheritDoc}
      *
+     * @throws RuntimeCIFSException if the listing could not be read to its end, so that one cut short by a failure is
+     *             not mistaken for the end of the directory. Every entry that was read is returned before it is thrown.
      * @see java.util.Iterator#next()
      */
     @Override
     public FileEntry next() {
+        if (this.next == null) {
+            // Nothing left to hand out. Report the failure that ended the listing, once, and stay exhausted: asking
+            // for another page here would go back to a server over a connection that is already gone.
+            final RuntimeCIFSException pending = this.failure;
+            if (pending != null) {
+                this.failure = null;
+                throw pending;
+            }
+            return null;
+        }
         final FileEntry n = this.next;
         try {
             final FileEntry ne = advance(false);
             if (ne == null) {
-                doClose();
+                closeAtEndOfListing();
                 return n;
             }
             this.next = ne;
         } catch (final CIFSException e) {
-            log.warn("Enumeration failed", e);
+            // Ending the listing here would look exactly like a directory holding only the entries read so far. The
+            // failure waits until this entry, which was read before it happened, has been handed out.
             this.next = null;
+            this.failure = new RuntimeCIFSException("Enumeration failed", e);
             try {
                 doClose();
             } catch (final CIFSException e1) {
-                log.debug("Failed to close enum", e);
+                this.failure.addSuppressed(e1);
             }
         }
         return n;
+    }
+
+    /**
+     * Closes at the natural end of a listing, where failing to close costs the caller nothing: every entry has been
+     * read, so there is no incomplete result to report.
+     */
+    private void closeAtEndOfListing() {
+        try {
+            doClose();
+        } catch (final CIFSException e) {
+            log.debug("Failed to close enum", e);
+        }
     }
 
     /**

--- a/src/main/java/org/codelibs/jcifs/smb/impl/FileEntryAdapterIterator.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/FileEntryAdapterIterator.java
@@ -22,6 +22,7 @@ import java.net.MalformedURLException;
 import org.codelibs.jcifs.smb.CIFSException;
 import org.codelibs.jcifs.smb.CloseableIterator;
 import org.codelibs.jcifs.smb.ResourceFilter;
+import org.codelibs.jcifs.smb.RuntimeCIFSException;
 import org.codelibs.jcifs.smb.SmbResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +35,13 @@ abstract class FileEntryAdapterIterator implements CloseableIterator<SmbResource
     private final ResourceFilter filter;
     private final SmbResource parent;
     private SmbResource next;
+
+    /**
+     * Set when the delegate reports that the listing failed, and thrown once the entry read before it has been
+     * handed out. Every public listing API comes through this class, so deferring here is what makes that guarantee
+     * visible to callers.
+     */
+    private RuntimeCIFSException failure;
 
     /**
      * @param parent
@@ -95,18 +103,36 @@ abstract class FileEntryAdapterIterator implements CloseableIterator<SmbResource
      */
     @Override
     public boolean hasNext() {
-        return this.next != null;
+        return this.next != null || this.failure != null;
     }
 
     /**
      * {@inheritDoc}
      *
+     * @throws RuntimeCIFSException if the listing could not be read to its end, thrown after every entry that was
+     *             read has been returned
      * @see java.util.Iterator#next()
      */
     @Override
     public SmbResource next() {
+        if (this.next == null) {
+            // Nothing left to hand out: report the failure that ended the listing, once, and stay exhausted
+            final RuntimeCIFSException pending = this.failure;
+            if (pending != null) {
+                this.failure = null;
+                throw pending;
+            }
+            return null;
+        }
         final SmbResource n = this.next;
-        this.next = advance();
+        try {
+            this.next = advance();
+        } catch (final RuntimeCIFSException e) {
+            // The delegate had already read this entry when the listing failed, so hand it out and report the
+            // failure on the next call rather than losing it
+            this.next = null;
+            this.failure = e;
+        }
         return n;
     }
 

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbCopyUtil.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbCopyUtil.java
@@ -22,6 +22,7 @@ import java.net.MalformedURLException;
 
 import org.codelibs.jcifs.smb.CIFSException;
 import org.codelibs.jcifs.smb.CloseableIterator;
+import org.codelibs.jcifs.smb.RuntimeCIFSException;
 import org.codelibs.jcifs.smb.SmbConstants;
 import org.codelibs.jcifs.smb.SmbResource;
 import org.codelibs.jcifs.smb.internal.fscc.FileBasicInfo;
@@ -375,6 +376,9 @@ public final class SmbCopyUtil {
             }
         } catch (final MalformedURLException mue) {
             throw new SmbException(src.getURL().toString(), mue);
+        } catch (final RuntimeCIFSException e) {
+            // A listing that failed part way through means the copy is missing entries, so it has not succeeded
+            throw SmbEnumerationUtil.wrapEnumerationFailure(e);
         }
     }
 

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbEnumerationUtil.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbEnumerationUtil.java
@@ -32,6 +32,7 @@ import org.codelibs.jcifs.smb.CIFSException;
 import org.codelibs.jcifs.smb.CloseableIterator;
 import org.codelibs.jcifs.smb.ResourceFilter;
 import org.codelibs.jcifs.smb.ResourceNameFilter;
+import org.codelibs.jcifs.smb.RuntimeCIFSException;
 import org.codelibs.jcifs.smb.SmbConstants;
 import org.codelibs.jcifs.smb.SmbResource;
 import org.codelibs.jcifs.smb.SmbResourceLocator;
@@ -248,9 +249,36 @@ final class SmbEnumerationUtil {
                 }
             }
             return list.toArray(new String[list.size()]);
+        } catch (final RuntimeCIFSException e) {
+            throw wrapEnumerationFailure(e);
         } catch (final CIFSException e) {
             throw SmbException.wrap(e);
         }
+    }
+
+    /**
+     * Converts a listing failure into the checked exception this class's callers declare.
+     *
+     * <p>
+     * A listing iterator reports a failure as an unchecked exception, because {@link java.util.Iterator#next()} cannot
+     * throw a checked one. The methods that return an array hide the iterator from their callers, so they keep
+     * reporting {@link SmbException}.
+     * </p>
+     *
+     * @param e the failure the iterator reported
+     * @return the equivalent checked exception
+     */
+    static SmbException wrapEnumerationFailure(final RuntimeCIFSException e) {
+        final Throwable cause = e.getCause();
+        if (!(cause instanceof CIFSException)) {
+            return new SmbException(e.getMessage(), e);
+        }
+        final SmbException wrapped = SmbException.wrap((CIFSException) cause);
+        // Carry over anything the iterator attached, such as a failure to close the listing it was giving up on
+        for (final Throwable suppressed : e.getSuppressed()) {
+            wrapped.addSuppressed(suppressed);
+        }
+        return wrapped;
     }
 
     static SmbFile[] listFiles(final SmbFile root, final String wildcard, final int searchAttributes, final SmbFilenameFilter fnf,
@@ -267,6 +295,8 @@ final class SmbEnumerationUtil {
                 }
             }
             return list.toArray(new SmbFile[list.size()]);
+        } catch (final RuntimeCIFSException e) {
+            throw wrapEnumerationFailure(e);
         } catch (final CIFSException e) {
             throw SmbException.wrap(e);
         }

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbFile.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbFile.java
@@ -33,6 +33,7 @@ import org.codelibs.jcifs.smb.CloseableIterator;
 import org.codelibs.jcifs.smb.Configuration;
 import org.codelibs.jcifs.smb.ResourceFilter;
 import org.codelibs.jcifs.smb.ResourceNameFilter;
+import org.codelibs.jcifs.smb.RuntimeCIFSException;
 import org.codelibs.jcifs.smb.SmbConstants;
 import org.codelibs.jcifs.smb.SmbFileHandle;
 import org.codelibs.jcifs.smb.SmbResource;
@@ -1477,6 +1478,14 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
                      * listFiles may generate undesirable "cannot find
                      * the file specified".
                      */
+                    log.debug("delete", se);
+                    if (se.getNtStatus() != NtStatus.NT_STATUS_NO_SUCH_FILE) {
+                        throw se;
+                    }
+                } catch (final RuntimeCIFSException e) {
+                    // A listing that failed part way through leaves entries behind, so the delete has not succeeded.
+                    // The same tolerance as above applies, since the failure can arrive either way.
+                    final SmbException se = SmbEnumerationUtil.wrapEnumerationFailure(e);
                     log.debug("delete", se);
                     if (se.getNtStatus() != NtStatus.NT_STATUS_NO_SUCH_FILE) {
                         throw se;

--- a/src/test/java/org/codelibs/jcifs/smb/impl/DirFileEntryEnumIteratorBaseTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/DirFileEntryEnumIteratorBaseTest.java
@@ -3,6 +3,7 @@ package org.codelibs.jcifs.smb.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -19,6 +20,7 @@ import java.util.List;
 
 import org.codelibs.jcifs.smb.CIFSException;
 import org.codelibs.jcifs.smb.ResourceNameFilter;
+import org.codelibs.jcifs.smb.RuntimeCIFSException;
 import org.codelibs.jcifs.smb.SmbResource;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -318,7 +320,7 @@ class DirFileEntryEnumIteratorBaseTest {
     }
 
     @Test
-    @DisplayName("advance() path handles fetchMore throwing CIFSException in next()")
+    @DisplayName("fetchMore throwing CIFSException is reported from next(), not turned into the end of the listing")
     void advanceFetchMoreThrows() throws Exception {
         // Arrange
         stubAcquireReturnsSelf();
@@ -330,10 +332,33 @@ class DirFileEntryEnumIteratorBaseTest {
         // Act
         assertTrue(it.hasNext());
         assertEquals("one", it.next().getName()); // consume initial
-        // Next call should handle CIFSException and close iterator
-        assertFalse(it.hasNext()); // After error, hasNext should return false
 
-        // Assert
+        // Assert: a caller that keeps iterating is told the listing failed, rather than seeing it end
+        RuntimeCIFSException ex = assertThrows(RuntimeCIFSException.class, it::next);
+        assertNotNull(ex.getCause(), "the failure that ended the listing should be the cause");
+        assertEquals("fetchMore fail", ex.getCause().getMessage());
+        assertFalse(it.hasNext(), "the iterator is closed once it has failed");
+        verify(tree, times(1)).release();
+    }
+
+    @Test
+    @DisplayName("an iterator that has reported a failure stays exhausted instead of going back to the server")
+    void failureIsReportedOnceAndLeavesTheIteratorExhausted() throws Exception {
+        // Arrange
+        stubAcquireReturnsSelf();
+        FileEntry initial = entry("one");
+        TestIterator it =
+                TestIterator.create(tree, parent, "*", null, 0, initial, List.of(new FileEntry[][] { new FileEntry[0] })).throwOnFetch();
+
+        // Act
+        assertEquals("one", it.next().getName()); // consume initial
+        assertThrows(RuntimeCIFSException.class, it::next);
+
+        // Assert: a caller that catches the failure inside its loop must not be handed a closed iterator that
+        // claims to have more, nor may a further call reach the server over a connection that is gone
+        assertFalse(it.hasNext(), "the iterator is exhausted once the failure has been reported");
+        assertNull(it.next(), "a further next() must not go back to the server on a closed iterator");
+        assertFalse(it.hasNext(), "the iterator stays exhausted");
         verify(tree, times(1)).release();
     }
 

--- a/src/test/java/org/codelibs/jcifs/smb/impl/FileEntryAdapterIteratorTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/FileEntryAdapterIteratorTest.java
@@ -19,6 +19,7 @@ import java.net.MalformedURLException;
 import org.codelibs.jcifs.smb.CIFSException;
 import org.codelibs.jcifs.smb.CloseableIterator;
 import org.codelibs.jcifs.smb.ResourceFilter;
+import org.codelibs.jcifs.smb.RuntimeCIFSException;
 import org.codelibs.jcifs.smb.SmbResource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -84,6 +85,22 @@ class FileEntryAdapterIteratorTest {
 
         // Without filter, resource should not be closed
         verify(resource, never()).close();
+    }
+
+    @Test
+    @DisplayName("an entry already read is handed out before a failure from the delegate is reported")
+    void failureIsDeferredUntilTheEntryAlreadyReadIsReturned() {
+        // One entry to give, then a failure: what a listing does when the connection drops between pages
+        when(delegate.hasNext()).thenReturn(true);
+        when(delegate.next()).thenReturn(fileEntry).thenThrow(new RuntimeCIFSException("Enumeration failed"));
+
+        TestIterator iterator = new TestIterator(null);
+
+        assertTrue(iterator.hasNext());
+        assertSame(resource, iterator.next(), "the entry read before the failure must still be handed out");
+        assertTrue(iterator.hasNext(), "the failure is still to be reported");
+        assertThrows(RuntimeCIFSException.class, iterator::next);
+        assertFalse(iterator.hasNext(), "the iterator is exhausted once the failure has been reported");
     }
 
     @Test

--- a/src/test/java/org/codelibs/jcifs/smb/it/EnumerationReconnectIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/EnumerationReconnectIT.java
@@ -1,0 +1,163 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.OutputStream;
+import java.util.Properties;
+import java.util.UUID;
+
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.CloseableIterator;
+import org.codelibs.jcifs.smb.RuntimeCIFSException;
+import org.codelibs.jcifs.smb.SmbResource;
+import org.codelibs.jcifs.smb.impl.SmbException;
+import org.codelibs.jcifs.smb.impl.SmbFile;
+import org.codelibs.jcifs.smb.it.env.TcpRelay;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * What a directory listing does when the connection under it goes away.
+ *
+ * <p>
+ * A listing is fetched a page at a time, so a connection that drops partway
+ * through leaves the caller with the entries fetched so far. Ending there
+ * quietly is indistinguishable from a directory that really does hold only
+ * those entries, which is the worst possible answer for anything that acts on
+ * a listing - a crawler, a sync, a delete of everything that was not listed.
+ * </p>
+ *
+ * <p>
+ * The pages are made small with {@code jcifs.client.listSize} so a directory of
+ * a few dozen files takes several round trips, leaving room to drop the
+ * connection between two of them. Each test also checks how far the listing
+ * got: a failure raised before the drop, or a listing that ran to the end,
+ * would otherwise look like a pass.
+ * </p>
+ */
+class EnumerationReconnectIT extends AbstractSmbIT {
+
+    private static final int FILE_COUNT = 120;
+
+    private static final int ENTRIES_BEFORE_DROP = 5;
+
+    /** Small enough that a page holds only a handful of entries. */
+    private static final String SMALL_PAGE_SIZE = "2048";
+
+    private String workDirName;
+
+    @AfterEach
+    void removeWorkDir() throws Exception {
+        if (this.workDirName != null) {
+            deleteQuietly(new SmbFile(server().url(server().share(), this.workDirName + "/"), server().context()));
+        }
+    }
+
+    @Test
+    @DisplayName("children() reports a connection dropped mid-listing instead of ending early")
+    void childrenReportsDroppedConnection() throws Exception {
+        final CIFSContext context = pagedContext();
+        createDirectoryOfFiles(context);
+        final int[] seen = { 0 };
+
+        try (TcpRelay relay = TcpRelay.to(server().host(), server().port()); SmbFile dir = new SmbFile(relayUrl(relay), context)) {
+            assertThrows(RuntimeCIFSException.class, () -> {
+                try (CloseableIterator<SmbResource> it = dir.children()) {
+                    while (it.hasNext()) {
+                        try (SmbResource entry = it.next()) {
+                            seen[0]++;
+                        }
+                        if (seen[0] == ENTRIES_BEFORE_DROP) {
+                            relay.dropConnections();
+                        }
+                    }
+                }
+                fail("the listing ended after " + seen[0] + " of " + FILE_COUNT + " entries without reporting the dropped connection");
+            });
+        }
+        assertDroppedMidListing(seen[0]);
+    }
+
+    @Test
+    @DisplayName("listFiles() reports a connection dropped mid-listing instead of returning a short array")
+    void listFilesReportsDroppedConnection() throws Exception {
+        final CIFSContext context = pagedContext();
+        createDirectoryOfFiles(context);
+        final int[] seen = { 0 };
+
+        try (TcpRelay relay = TcpRelay.to(server().host(), server().port()); SmbFile dir = new SmbFile(relayUrl(relay), context)) {
+            // The filter runs for every entry, which is the only way into the middle of a single listFiles call
+            assertThrows(SmbException.class, () -> {
+                final SmbFile[] listed = dir.listFiles(file -> {
+                    seen[0]++;
+                    if (seen[0] == ENTRIES_BEFORE_DROP) {
+                        relay.dropConnections();
+                    }
+                    return true;
+                });
+                fail("listFiles returned " + listed.length + " of " + FILE_COUNT + " entries without reporting the dropped connection");
+            });
+        }
+        assertDroppedMidListing(seen[0]);
+    }
+
+    /**
+     * Checks the failure came from the drop rather than from something before it, such as a relay that never
+     * connected, and that the listing had not already finished.
+     */
+    private static void assertDroppedMidListing(final int seen) {
+        assertTrue(seen >= ENTRIES_BEFORE_DROP, "the listing failed after " + seen + " entries, before the connection was dropped");
+        assertTrue(seen < FILE_COUNT, "the listing returned every entry, so the drop did not interrupt it");
+    }
+
+    /**
+     * @return a context whose directory queries are small enough to need several round trips
+     */
+    private CIFSContext pagedContext() throws Exception {
+        final Properties props = new Properties();
+        props.setProperty("jcifs.client.listSize", SMALL_PAGE_SIZE);
+        return server().context(props);
+    }
+
+    /**
+     * @return the working directory's URL through the relay, taking the address from the relay itself so it matches
+     *         whichever loopback address it bound
+     */
+    private String relayUrl(final TcpRelay relay) {
+        return "smb://" + relay.host() + ":" + relay.port() + "/" + server().share() + "/" + this.workDirName + "/";
+    }
+
+    /**
+     * Creates the directory and its files over a connection straight to the
+     * server, so only the listing goes through the relay.
+     */
+    private void createDirectoryOfFiles(final CIFSContext context) throws Exception {
+        this.workDirName = "it-" + UUID.randomUUID();
+        try (SmbFile dir = new SmbFile(server().url(server().share(), this.workDirName + "/"), context)) {
+            dir.mkdirs();
+            for (int i = 0; i < FILE_COUNT; i++) {
+                try (SmbFile file = new SmbFile(dir, String.format("entry-%03d.txt", i)); OutputStream out = file.getOutputStream()) {
+                    out.write(('e' + i) & 0xFF);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Stacked on #100 — please merge that first. The base of this PR is `fix/smb2-output-stream-truncates-on-reopen`, so the diff shown here is only this change. It reuses the `TcpRelay` test helper that PR adds.

**This changes behaviour.** A listing that fails part way through now reports the failure instead of ending quietly.

## The problem

A directory listing is fetched a page at a time. When fetching a page failed, `DirFileEntryEnumIteratorBase.next()` logged a warning and ended the iteration:

```java
} catch (final CIFSException e) {
    log.warn("Enumeration failed", e);
    this.next = null;
    ...
}
```

The caller cannot tell that listing apart from a directory that really holds only those entries. What follows depends on what the caller does with a listing, and none of it is good: a crawler treats the missing files as deleted, a sync removes them at the other end, and `SmbFile.delete()` — which lists a directory to empty it — can report success with files left behind.

Dropping the connection after five entries of a 120 entry directory ends the listing at 14 entries, with no exception and nothing in the return value to say so.

## What this changes

- **`DirFileEntryEnumIteratorBase.next()`** closes the iterator and throws `RuntimeCIFSException`. It has to be unchecked: `Iterator.next()` declares no checked exception. A failure to close is attached as a suppressed exception rather than swallowed into a debug log.
- **The methods that hide the iterator keep their checked contract**, converting it back to `SmbException` through one helper:
  - `SmbEnumerationUtil.list()` and `listFiles()`;
  - `SmbFile.delete()` in its recursive branch, which still tolerates `NT_STATUS_NO_SUCH_FILE` exactly as before (the workaround for servers that do not send `.` and `..`);
  - `SmbCopyUtil`'s recursive copy.
- **`FileEntryAdapterIterator`** defers the failure the same way. Every public listing API goes through it, so without this the entry the base iterator carefully held back would be dropped one level up, and the guarantee would not hold for any caller.
- **`children()`** is the one API where the unchecked exception surfaces, because its caller drives the iterator itself. `SmbResource.children(...)` documents it.

Not in this change: `NetServerEnumIterator`, the SMB1 workgroup and server browsing path, ends its listing the same quiet way (and does not close there either). It is a separate code path with separate tests, and is worth its own change.

## Compatibility

Callers that listed a directory over a connection that stayed up see no change.

Callers that hit a failure mid-listing now get an exception where they previously got a short result:
- `list()`, `listFiles()`, `delete()` and `copyTo()` throw `SmbException`, which they already declare, so existing `catch` blocks handle it.
- `children()` throws `RuntimeCIFSException`, which is unchecked. Code that iterates a listing and catches nothing will now propagate that failure — which is the point of the change, but it is the one case that can surface somewhere new.

## Tests

- **`EnumerationReconnectIT`** creates 120 files, turns the page size down with `jcifs.client.listSize` so the listing takes several round trips, and drops the connection after five entries — once through `children()`, once from inside a filter passed to `listFiles()`, which is the only way into the middle of a single call. Without the change both fail with "the listing ended after 14 of 120 entries without reporting the dropped connection".
- **`DirFileEntryEnumIteratorBaseTest.advanceFetchMoreThrows`** asserted the old contract ("After error, hasNext should return false"). It now asserts that `next()` throws, that the cause is the original failure, and that the tree handle is still released exactly once.

## Verification

Without the production change, the new tests fail with what the bug actually looks like:

```
the listing ended after 14 of 120 entries without reporting the dropped connection
listFiles returned 14 of 120 entries without reporting the dropped connection
```

and the rewritten unit test fails with `Expected RuntimeCIFSException to be thrown, but nothing was thrown`.

Each run below is on this branch and compared with the same run on its base, `fix/smb2-output-stream-truncates-on-reopen`. There are no failures anywhere.

| Run | Base branch (#100) | This branch |
|---|---|---|
| `mvn verify` against the Samba container | 8576 unit, 107 integration (7 skipped) | 8578 unit, 109 integration (7 skipped) |
| `build_helpers/run-it-with-dfs.sh` (Samba on port 445, DFS tests enabled) | 8576 unit, 107 integration (3 skipped) | 8578 unit, 109 integration (3 skipped) |
| `windows-smb` workflow (Windows Server 2025) | 8576 unit, 107 integration (9 skipped) | 8578 unit, 109 integration (9 skipped) |

Two unit tests are new — the deferral at each level of the iterator stack, and the exhausted state afterwards — and the one that asserted the old silent truncation was rewritten in place. The two integration tests are new. The skipped tests are the same ones as on the base branch.

`mvn apache-rat:check` passes, and `mvn formatter:format` has been applied.
