### PR TITLE
feat(smb2): acknowledge oplock breaks and stop a lease break closing the connection

### DIFF
--- a/docs/SMB3_SUPPORT.md
+++ b/docs/SMB3_SUPPORT.md
@@ -149,19 +149,23 @@ errors.
 | LOCK | Not functional | `Smb2LockRequest` exists and is referenced nowhere. **There is no byte-range locking API** on `SmbResource`, `SmbFile` or `SmbRandomAccessFile`. |
 | ECHO | Not functional | `Smb2EchoRequest` exists and is referenced nowhere. There is no keepalive or liveness probe. |
 | CANCEL | Not functional | `Smb2CancelRequest` is fully built and wired into the send path, but `createCancel()` is never invoked. Nothing can cancel an in-flight request — including a pending CHANGE_NOTIFY, as `SmbWatchHandle`'s own javadoc notes. |
-| OPLOCK_BREAK | Not functional | See below. |
+| OPLOCK_BREAK | Partially supported | Breaks are decoded and acknowledged; nothing requests an oplock, so none arrive by default. See below. |
 
 ## Caching, oplocks and handles
 
-None of this works. It is the area most likely to be mistaken for working code.
+Oplock breaks are handled; everything else here is absent. Note what the first
+row means for the rest: nothing asks for an oplock or a lease, so on a
+conforming server none of the break handling below is reached in ordinary use.
+It matters for a caller that requests one itself, and for a server that sends a
+break anyway.
 
 | Feature | Status | Notes |
 | --- | --- | --- |
-| Oplock request on CREATE | Not functional | `setRequestedOplockLevel()` has no production caller, so **every CREATE requests oplock level NONE**. |
-| Granted oplock level | Not functional | Decoded into a field whose getter has no caller. |
-| Oplock break notification | Not functional | The notification is decoded and dispatched, but `handleNotification` is a single `log.info` line. No cache is invalidated, no handle is touched, and there is no override anywhere. |
-| Oplock break acknowledgement | Not implemented | There is no acknowledgement message class at all. The client cannot answer a break. |
-| SMB3 leases | Not implemented | Two unused constants. A real lease-break frame would fail the notification decode (structure size 44 vs the expected 24) and tear down the transport. |
+| Oplock request on CREATE | Not functional | `setRequestedOplockLevel()` has no production caller, so **every CREATE still requests oplock level NONE**. A conforming server therefore never breaks an oplock of ours (MS-SMB2 3.3.5.9), which is why the break handling below is inert in normal use. |
+| Granted oplock level | Supported | Decoded and recorded on the open, which is what decides whether a later break of it has to be acknowledged. |
+| Oplock break notification | Supported | Decoded and resolved to the open it names. Since the notification carries TreeId 0 and, on several servers, SessionId 0, the open is found by file id in the session open tables rather than from the header. A break naming an open the client does not have is ignored, as MS-SMB2 3.2.5.19.1 requires. jcifs caches nothing, so there is no cached data to discard. |
+| Oplock break acknowledgement | Supported | `Smb2OplockBreakAcknowledgment` is sent on the broken open's own tree, which is what gives it the session and tree id the server requires. A break from level II to none is not answered at all (MS-SMB2 2.2.24.1). The acknowledgement is sent off the receive thread, because it draws a reply and waiting for one there would stop the loop that reads it. |
+| SMB3 leases | Not implemented | Two unused constants; no lease is ever requested. A lease break is now decoded rather than fatal: before 3.0.4 its 44-byte body failed a decode that demanded 24, and that failure closed the socket, logged off every session and failed every request in flight on the connection. Such a break is logged and otherwise ignored, since no lease was ever held. |
 | Directory leasing | Not implemented | Unused capability constant; depends on leases. |
 | Durable / persistent handles | Not implemented | No DHnQ/DH2Q/DHnC/DH2C contexts, no app instance id, no handle reconnect path. |
 | Create contexts (the framework itself) | Not functional | The request side encodes correctly: `Smb2CreateRequest.setCreateContexts()` lays contexts out as MS-SMB2 2.2.13.2 requires, and `CreateContextIT` checks that a real server answers each one. But nothing outside the tests calls it, and `Smb2CreateResponse.createContext()` is `return null`, so a context in a response is skipped. Before 3.0.4 no context could be sent at all — `size()` left out each context's header and name, so the request failed before it was sent — and the encoder also zeroed every `Next` and undercounted `CreateContextsLength`. |

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbFile.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbFile.java
@@ -712,6 +712,11 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
                 info = resp;
                 fileSize = resp.getEndOfFile();
                 fh = new SmbFileHandleImpl(config, resp.getFileId(), h, uncPath, flags, access, 0, 0, resp.getEndOfFile());
+                // An oplock break names nothing but the file id, so the open has to be findable by it. getSession()
+                // hands out an acquired reference, hence the try-with-resources.
+                try (SmbSessionImpl session = h.getSession()) {
+                    fh.registerWith(session, resp.getOplockLevel());
+                }
             } else if (h.hasCapability(SmbConstants.CAP_NT_SMBS)) {
                 final SmbComNTCreateAndXResponse resp = new SmbComNTCreateAndXResponse(config);
                 final SmbComNTCreateAndX req = new SmbComNTCreateAndX(config, uncPath, flags, access, sharing, attrs, options, null);

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbFileHandleImpl.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbFileHandleImpl.java
@@ -45,6 +45,20 @@ class SmbFileHandleImpl implements SmbFileHandle {
     private final long tree_num; // for checking whether the tree changed
     private SmbTreeHandleImpl tree;
 
+    /**
+     * The session this open is registered with, or null when it is not registered.
+     *
+     * <p>
+     * Only an open that is in its session's table can be found again from an oplock break, which names nothing but
+     * the file id. Handles built without a session - every SMB1 handle, and anything that does not go through
+     * {@link #registerWith(SmbSessionImpl)} - simply never appear there.
+     * </p>
+     */
+    private volatile SmbSessionImpl registeredSession;
+
+    /** The oplock level the server granted, {@code SMB2_OPLOCK_LEVEL_NONE} when none was asked for. */
+    private volatile byte oplockLevel;
+
     private final AtomicLong usageCount = new AtomicLong(1);
     private final int flags;
     private final int access;
@@ -196,6 +210,7 @@ class SmbFileHandleImpl implements SmbFileHandle {
                 }
             }
         } finally {
+            unregister();
             this.open = false;
             if (t != null) {
                 // release tree usage
@@ -262,7 +277,75 @@ class SmbFileHandleImpl implements SmbFileHandle {
      *
      */
     public void markClosed() {
+        unregister();
         this.open = false;
+    }
+
+    /**
+     * Adds this open to its session's open table, so that an oplock break naming its file id can be resolved back to
+     * it.
+     *
+     * <p>
+     * Only SMB2 opens are registered; an SMB1 handle has no file id for a break to name.
+     * </p>
+     *
+     * @param session the session this open belongs to
+     */
+    void registerWith(final SmbSessionImpl session, final byte grantedOplockLevel) {
+        if (session == null || this.fileId == null) {
+            return;
+        }
+        this.oplockLevel = grantedOplockLevel;
+        this.registeredSession = session;
+        session.registerOpen(this.fileId, this);
+    }
+
+    /**
+     * The oplock level the server granted this open, which decides whether a break of it has to be acknowledged.
+     *
+     * @return the granted oplock level, {@code SMB2_OPLOCK_LEVEL_NONE} unless an oplock was asked for and granted
+     */
+    byte getOplockLevel() {
+        return this.oplockLevel;
+    }
+
+    /**
+     * Whether this open holds an oplock at all.
+     *
+     * @return true when the server granted one and it has not been given up
+     */
+    boolean hasOplock() {
+        return this.oplockLevel != 0; // SMB2_OPLOCK_LEVEL_NONE
+    }
+
+    /**
+     * Records the level a break left this open at, so that a further break of it is answered - or not - on what it
+     * actually holds now.
+     *
+     * @param oplockLevel the level the open now holds
+     */
+    void setOplockLevel(final byte oplockLevel) {
+        this.oplockLevel = oplockLevel;
+    }
+
+    /**
+     * Gives up any oplock on this open. MS-SMB2 3.2.5.19.3: an acknowledgement the server refuses leaves the open
+     * holding nothing.
+     */
+    void dropOplock() {
+        this.oplockLevel = 0; // SMB2_OPLOCK_LEVEL_NONE
+    }
+
+    /**
+     * Takes this open back out of its session's open table. Doing nothing for a handle that was never registered is
+     * what keeps this off the SMB1 path.
+     */
+    private void unregister() {
+        final SmbSessionImpl session = this.registeredSession;
+        if (session != null) {
+            this.registeredSession = null;
+            session.unregisterOpen(this.fileId);
+        }
     }
 
     /**

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbSessionImpl.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbSessionImpl.java
@@ -19,6 +19,8 @@
 package org.codelibs.jcifs.smb.impl;
 
 import java.io.IOException;
+import java.lang.ref.WeakReference;
+import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
@@ -26,8 +28,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -98,6 +102,17 @@ final class SmbSessionImpl implements SmbSessionInternal {
     private final AtomicBoolean transportAcquired = new AtomicBoolean(true);
 
     private long sessionId;
+
+    /**
+     * The opens of this session, by file id - MS-SMB2 Session.OpenTable.
+     *
+     * <p>
+     * An oplock break names only the file it breaks, so 3.2.5.19.1 has the client find the open here in order to
+     * acknowledge it: the acknowledgement has to carry the session and tree of the open, and the notification's own
+     * header carries neither (TreeId is always zero, SessionId is zero on several servers).
+     * </p>
+     */
+    private final Map<ByteBuffer, WeakReference<SmbFileHandleImpl>> opens = new ConcurrentHashMap<>();
 
     private SMBSigningDigest digest;
     private Smb2EncryptionContext encryptionContext;
@@ -1172,11 +1187,68 @@ final class SmbSessionImpl implements SmbSessionInternal {
             this.connectionState.set(0);
             this.digest = null;
             this.transport.unregisterSessionId(this.sessionId);
+            // The handles are gone with the session, and holding them here would keep them alive for the life of
+            // the connection.
+            this.opens.clear();
             this.encryptionContext = null;
             this.encryptData = false;
             this.transport.notifyAll();
         }
         return wasInUse;
+    }
+
+    /**
+     * @return this session's server-assigned id, zero until it has authenticated
+     */
+    long getSessionId() {
+        return this.sessionId;
+    }
+
+    /**
+     * Adds an open to this session's open table so a break naming it can be resolved.
+     *
+     * @param fileId the 16 byte file id the server assigned the open
+     * @param handle the open
+     */
+    void registerOpen(final byte[] fileId, final SmbFileHandleImpl handle) {
+        if (fileId != null) {
+            // Held weakly: an application that drops a handle without closing it should still have it collected and
+            // its "not properly closed" warning raised, rather than being kept alive here until the session ends.
+            this.opens.put(ByteBuffer.wrap(fileId.clone()), new WeakReference<>(handle));
+        }
+    }
+
+    /**
+     * Removes an open from this session's open table.
+     *
+     * @param fileId the 16 byte file id the open was registered under
+     */
+    void unregisterOpen(final byte[] fileId) {
+        if (fileId != null) {
+            this.opens.remove(ByteBuffer.wrap(fileId));
+        }
+    }
+
+    /**
+     * Finds an open of this session by its file id.
+     *
+     * @param fileId the file id named by a break notification
+     * @return the open, or null if this session has no such open
+     */
+    SmbFileHandleImpl getOpen(final byte[] fileId) {
+        if (fileId == null) {
+            return null;
+        }
+        final ByteBuffer key = ByteBuffer.wrap(fileId);
+        final WeakReference<SmbFileHandleImpl> reference = this.opens.get(key);
+        if (reference == null) {
+            return null;
+        }
+        final SmbFileHandleImpl open = reference.get();
+        if (open == null) {
+            this.opens.remove(key, reference);
+        }
+        return open;
     }
 
     @Override

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbTransportImpl.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbTransportImpl.java
@@ -84,6 +84,7 @@ import org.codelibs.jcifs.smb.internal.smb2.Smb3KeyDerivation;
 import org.codelibs.jcifs.smb.internal.smb2.io.Smb2ReadResponse;
 import org.codelibs.jcifs.smb.internal.smb2.ioctl.Smb2IoctlRequest;
 import org.codelibs.jcifs.smb.internal.smb2.ioctl.Smb2IoctlResponse;
+import org.codelibs.jcifs.smb.internal.smb2.lock.Smb2OplockBreakAcknowledgment;
 import org.codelibs.jcifs.smb.internal.smb2.lock.Smb2OplockBreakNotification;
 import org.codelibs.jcifs.smb.internal.smb2.nego.EncryptionNegotiateContext;
 import org.codelibs.jcifs.smb.internal.smb2.nego.Smb2NegotiateRequest;
@@ -1479,8 +1480,22 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
                 final Response notification = createNotification(key);
                 if (notification != null) {
                     log.debug("Parsing notification");
-                    doRecv(notification);
-                    handleNotification(notification);
+                    // Only a message that is not part of a compound chain is read in full before it is decoded. In a
+                    // chain, decoding stops with the rest of the chain still unread, so a failure there has to stay
+                    // fatal - carrying on would read every later message from the wrong offset.
+                    final boolean standalone = !this.isSMB2() || Encdec.dec_uint32le(this.sbuf, 4 + 20) == 0;
+                    try {
+                        doRecv(notification);
+                        handleNotification(notification);
+                    } catch (final SMBProtocolDecodingException | RuntimeException e) {
+                        if (!standalone) {
+                            throw e;
+                        }
+                        // The whole message is read before it is decoded, so the stream is already at the next one
+                        // and only this notification is lost. Nothing is waiting on it, whereas failing here would
+                        // take down the connection along with every request in flight on every session sharing it.
+                        log.warn("Ignoring a notification that could not be handled", e);
+                    }
                     return;
                 }
                 log.warn("Skipping message " + key);
@@ -1497,7 +1512,119 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
      * @param notification
      */
     protected void handleNotification(final Response notification) {
+        if (notification instanceof final Smb2OplockBreakNotification brk) {
+            handleBreak(brk);
+            return;
+        }
         log.info("Received notification " + notification);
+    }
+
+    /**
+     * Answers an oplock break, MS-SMB2 3.2.5.19.1.
+     *
+     * <p>
+     * A break names nothing but a file id. Its own header is no help - the TreeId is always zero and the SessionId is
+     * zero on several servers - so the open is found in the session open tables and the acknowledgement is sent on
+     * that open's own tree, which is what gives it the right session and tree id. A break naming an open we do not
+     * have is ignored, as the specification requires.
+     * </p>
+     *
+     * @param brk the break notification
+     */
+    private void handleBreak(final Smb2OplockBreakNotification brk) {
+        if (brk.isLeaseBreak()) {
+            // jcifs never asks for a lease, so it holds no lease state to give up.
+            log.info("Ignoring a lease break for a lease that was never requested: " + brk);
+            return;
+        }
+
+        final byte[] fileId = brk.getFileId();
+        final SmbFileHandleImpl open = findOpen(brk.getSessionId(), fileId);
+        if (open == null) {
+            log.debug("Ignoring an oplock break naming an open we do not have: " + brk);
+            return;
+        }
+
+        if (!open.hasOplock()) {
+            // 3.2.5.19.1 stops processing for an open that holds no oplock, and nothing may be recorded from the
+            // notification either: it is not authenticated, so taking a level from it would let a server raise what
+            // this open appears to hold and make the next break answerable. Every ordinary open is in this state,
+            // because jcifs asks for no oplock.
+            log.debug("Ignoring an oplock break for an open that holds no oplock: " + brk);
+            return;
+        }
+
+        final byte newOplockLevel = brk.getOplockLevel();
+        final boolean acknowledge = Smb2OplockBreakAcknowledgment.isRequired(open.getOplockLevel(), newOplockLevel);
+        open.setOplockLevel(newOplockLevel);
+        if (acknowledge) {
+            acknowledgeBreak(open, fileId, newOplockLevel);
+        } else if (log.isDebugEnabled()) {
+            log.debug("Oplock break needs no acknowledgement: " + brk);
+        }
+    }
+
+    /**
+     * Finds the open a break names.
+     *
+     * @param sessionId the session id the notification carried, which is zero on several servers
+     * @param fileId    the file id the notification named
+     * @return the open, or null if no session of this connection has it
+     */
+    private SmbFileHandleImpl findOpen(final long sessionId, final byte[] fileId) {
+        if (sessionId != 0) {
+            final SmbSessionImpl session = getSessionById(sessionId);
+            if (session != null) {
+                // The server named the session, so only its opens are candidates. File ids are unique within a
+                // session, not across them, so searching the others could match an unrelated open.
+                return session.getOpen(fileId);
+            }
+        }
+        for (final SmbSessionImpl session : this.sessionsById.values()) {
+            final SmbFileHandleImpl open = session.getOpen(fileId);
+            if (open != null) {
+                return open;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Sends the acknowledgement, off the receive thread.
+     *
+     * <p>
+     * An acknowledgement draws a reply, and waiting for one here would stop the loop that reads it; it would also
+     * hold up every other session sharing the connection while it waited. The tree is acquired here rather than in
+     * the worker so that the open cannot go away in between.
+     * </p>
+     */
+    private void acknowledgeBreak(final SmbFileHandleImpl open, final byte[] fileId, final byte oplockLevel) {
+        final SmbTreeHandleImpl tree;
+        try {
+            tree = open.getTree();
+        } catch (final RuntimeException e) {
+            log.debug("Open went away before its oplock break could be acknowledged", e);
+            return;
+        }
+
+        final Thread worker = new Thread(() -> {
+            try (SmbTreeHandleImpl th = tree) {
+                th.send(new Smb2OplockBreakAcknowledgment(getContext().getConfig(), fileId, oplockLevel), RequestParam.NO_RETRY);
+            } catch (final Exception e) {
+                // 3.2.5.19.3: an acknowledgement the server refuses leaves the open holding no oplock at all.
+                open.dropOplock();
+                log.warn("Failed to acknowledge an oplock break", e);
+            }
+        }, "jcifs-oplock-break-ack");
+        worker.setDaemon(true);
+        try {
+            worker.start();
+        } catch (final Throwable t) {
+            // The worker releases the tree once it runs. If it never runs - the machine is out of threads - nothing
+            // else would, and the tree connection would be pinned for the life of the connection.
+            tree.release();
+            throw t;
+        }
     }
 
     /**

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/lock/Smb2OplockBreakAcknowledgment.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/lock/Smb2OplockBreakAcknowledgment.java
@@ -1,0 +1,127 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.internal.smb2.lock;
+
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.Configuration;
+import org.codelibs.jcifs.smb.internal.smb2.ServerMessageBlock2Request;
+import org.codelibs.jcifs.smb.internal.smb2.Smb2Constants;
+import org.codelibs.jcifs.smb.internal.smb2.create.Smb2CreateRequest;
+import org.codelibs.jcifs.smb.internal.util.SMBUtil;
+
+/**
+ * SMB2 Oplock Break Acknowledgment, MS-SMB2 2.2.24.1.
+ *
+ * <p>
+ * Answers an oplock break notification, telling the server which oplock level the client is keeping. The
+ * acknowledgement travels on the same command as the notification, SMB2_OPLOCK_BREAK, and carries the file id of the
+ * open being broken; its header has to name the session and tree of that open, which is why the open is looked up
+ * rather than taken from the notification's own header (MS-SMB2 3.2.5.19.1).
+ * </p>
+ */
+public class Smb2OplockBreakAcknowledgment extends ServerMessageBlock2Request<Smb2OplockBreakResponse> {
+
+    private static final int STRUCTURE_SIZE = 24;
+
+    private final byte[] fileId;
+    private final byte oplockLevel;
+
+    /**
+     * Constructs an acknowledgement for a broken oplock.
+     *
+     * @param config      the configuration to use
+     * @param fileId      the 16 byte file id of the open being broken
+     * @param oplockLevel the oplock level the client keeps, one of the {@code SMB2_OPLOCK_LEVEL_*} values
+     */
+    public Smb2OplockBreakAcknowledgment(final Configuration config, final byte[] fileId, final byte oplockLevel) {
+        super(config, SMB2_OPLOCK_BREAK);
+        this.fileId = fileId;
+        this.oplockLevel = oplockLevel;
+    }
+
+    /**
+     * Whether a break of an open holding {@code currentOplockLevel} down to {@code newOplockLevel} has to be
+     * acknowledged.
+     *
+     * <p>
+     * A break from level II always transitions to none, so MS-SMB2 2.2.24.1 has the client make that transition
+     * without telling the server: "there is no question how the transition was made". Answering one anyway is
+     * refused - Samba does not arm its acknowledgement timer for a level II break. An open that holds no oplock has
+     * nothing to give up either.
+     * </p>
+     *
+     * @param currentOplockLevel the level the open holds
+     * @param newOplockLevel     the level the server is breaking to
+     * @return true when an acknowledgement has to be sent
+     */
+    public static boolean isRequired(final byte currentOplockLevel, final byte newOplockLevel) {
+        if (currentOplockLevel == Smb2CreateRequest.SMB2_OPLOCK_LEVEL_NONE
+                || currentOplockLevel == Smb2CreateRequest.SMB2_OPLOCK_LEVEL_II) {
+            // Nothing is held, or a level II oplock is held and the only break it can take is to none, which
+            // 2.2.24.1 says is made without telling the server.
+            return false;
+        }
+        // Only an exclusive or batch oplock is left, and only a break that actually lowers it is one. Answering a
+        // level the server did not break to would be refused: 2.2.24.1 allows none and level II only.
+        return newOplockLevel != currentOplockLevel;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.codelibs.jcifs.smb.internal.smb2.ServerMessageBlock2Request#createResponse(org.codelibs.jcifs.smb.CIFSContext,
+     *      org.codelibs.jcifs.smb.internal.smb2.ServerMessageBlock2Request)
+     */
+    @Override
+    protected Smb2OplockBreakResponse createResponse(final CIFSContext tc, final ServerMessageBlock2Request<Smb2OplockBreakResponse> req) {
+        return new Smb2OplockBreakResponse(tc.getConfig());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.codelibs.jcifs.smb.internal.CommonServerMessageBlockRequest#size()
+     */
+    @Override
+    public int size() {
+        return size8(Smb2Constants.SMB2_HEADER_LENGTH + STRUCTURE_SIZE);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.codelibs.jcifs.smb.internal.smb2.ServerMessageBlock2#writeBytesWireFormat(byte[], int)
+     */
+    @Override
+    protected int writeBytesWireFormat(final byte[] dst, final int dstIndex) {
+        SMBUtil.writeInt2(STRUCTURE_SIZE, dst, dstIndex);
+        dst[dstIndex + 2] = this.oplockLevel;
+        dst[dstIndex + 3] = 0; // Reserved
+        SMBUtil.writeInt4(0, dst, dstIndex + 4); // Reserved2
+        System.arraycopy(this.fileId, 0, dst, dstIndex + 8, 16);
+        return STRUCTURE_SIZE;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.codelibs.jcifs.smb.internal.smb2.ServerMessageBlock2#readBytesWireFormat(byte[], int)
+     */
+    @Override
+    protected int readBytesWireFormat(final byte[] buffer, final int bufferIndex) {
+        return 0;
+    }
+}

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/lock/Smb2OplockBreakNotification.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/lock/Smb2OplockBreakNotification.java
@@ -32,8 +32,21 @@ import org.codelibs.jcifs.smb.util.Hexdump;
  */
 public class Smb2OplockBreakNotification extends ServerMessageBlock2Response {
 
+    /** Body size of an oplock break notification, MS-SMB2 2.2.23.1 */
+    private static final int OPLOCK_BREAK_STRUCTURE_SIZE = 24;
+
+    /** Body size of a lease break notification, MS-SMB2 2.2.23.2 */
+    private static final int LEASE_BREAK_STRUCTURE_SIZE = 44;
+
     private byte oplockLevel;
     private byte[] fileId;
+
+    private boolean leaseBreak;
+    private int newEpoch;
+    private int breakFlags;
+    private byte[] leaseKey;
+    private int currentLeaseState;
+    private int newLeaseState;
 
     /**
      * Constructs an SMB2 oplock break notification with the given configuration.
@@ -60,22 +73,109 @@ public class Smb2OplockBreakNotification extends ServerMessageBlock2Response {
      * @see org.codelibs.jcifs.smb.internal.smb2.ServerMessageBlock2#readBytesWireFormat(byte[], int)
      */
     @Override
-    protected int readBytesWireFormat(final byte[] buffer, int bufferIndex) throws SMBProtocolDecodingException {
-        final int start = bufferIndex;
+    protected int readBytesWireFormat(final byte[] buffer, final int bufferIndex) throws SMBProtocolDecodingException {
         final int structureSize = SMBUtil.readInt2(buffer, bufferIndex);
-        if (structureSize != 24) {
-            throw new SMBProtocolDecodingException("Expected structureSize = 24");
+        if (structureSize == OPLOCK_BREAK_STRUCTURE_SIZE) {
+            return readOplockBreak(buffer, bufferIndex);
         }
+        if (structureSize == LEASE_BREAK_STRUCTURE_SIZE) {
+            return readLeaseBreak(buffer, bufferIndex);
+        }
+        throw new SMBProtocolDecodingException("Expected structureSize = 24 or 44");
+    }
 
+    /**
+     * Reads an oplock break notification body, MS-SMB2 2.2.23.1.
+     */
+    private int readOplockBreak(final byte[] buffer, final int bufferIndex) {
+        this.leaseBreak = false;
         this.oplockLevel = buffer[bufferIndex + 2];
-        bufferIndex += 4;
-        bufferIndex += 4; // Reserved2
-
+        // 1 byte Reserved, 4 bytes Reserved2
         this.fileId = new byte[16];
-        System.arraycopy(buffer, bufferIndex, this.fileId, 0, 16);
-        bufferIndex += 16;
+        System.arraycopy(buffer, bufferIndex + 8, this.fileId, 0, 16);
+        return OPLOCK_BREAK_STRUCTURE_SIZE;
+    }
 
-        return bufferIndex - start;
+    /**
+     * Reads a lease break notification body, MS-SMB2 2.2.23.2.
+     *
+     * <p>
+     * BreakReason, AccessMaskHint and ShareMaskHint are reserved and are not decoded.
+     * </p>
+     */
+    private int readLeaseBreak(final byte[] buffer, final int bufferIndex) {
+        this.leaseBreak = true;
+        this.newEpoch = SMBUtil.readInt2(buffer, bufferIndex + 2);
+        this.breakFlags = SMBUtil.readInt4(buffer, bufferIndex + 4);
+        this.leaseKey = new byte[16];
+        System.arraycopy(buffer, bufferIndex + 8, this.leaseKey, 0, 16);
+        this.currentLeaseState = SMBUtil.readInt4(buffer, bufferIndex + 24);
+        this.newLeaseState = SMBUtil.readInt4(buffer, bufferIndex + 28);
+        return LEASE_BREAK_STRUCTURE_SIZE;
+    }
+
+    /**
+     * Whether this is a lease break rather than an oplock break.
+     *
+     * <p>
+     * Both arrive as SMB2_OPLOCK_BREAK and are told apart only by their structure size, MS-SMB2 3.2.5.19. The lease
+     * accessors carry a value only when this returns {@code true}, and the oplock accessors only when it returns
+     * {@code false}.
+     * </p>
+     *
+     * @return true when a lease break was decoded
+     */
+    public boolean isLeaseBreak() {
+        return this.leaseBreak;
+    }
+
+    /**
+     * @return the oplock level the server is breaking to, one of the {@code SMB2_OPLOCK_LEVEL_*} values
+     */
+    public byte getOplockLevel() {
+        return this.oplockLevel;
+    }
+
+    /**
+     * @return the file id of the open whose oplock is being broken, 16 bytes, or null for a lease break
+     */
+    public byte[] getFileId() {
+        return this.fileId;
+    }
+
+    /**
+     * @return the key of the lease being broken, 16 bytes, or null for an oplock break
+     */
+    public byte[] getLeaseKey() {
+        return this.leaseKey;
+    }
+
+    /**
+     * @return the lease epoch after the break, zero before SMB 3.0
+     */
+    public int getNewEpoch() {
+        return this.newEpoch;
+    }
+
+    /**
+     * @return the lease break flags; bit 0 is SMB2_NOTIFY_BREAK_LEASE_FLAG_ACK_REQUIRED
+     */
+    public int getBreakFlags() {
+        return this.breakFlags;
+    }
+
+    /**
+     * @return the lease state held before the break
+     */
+    public int getCurrentLeaseState() {
+        return this.currentLeaseState;
+    }
+
+    /**
+     * @return the lease state the server is breaking to
+     */
+    public int getNewLeaseState() {
+        return this.newLeaseState;
     }
 
     /**
@@ -85,6 +185,13 @@ public class Smb2OplockBreakNotification extends ServerMessageBlock2Response {
      */
     @Override
     public String toString() {
+        if (this.leaseBreak) {
+            // A lease break carries a lease key and no file id, so it cannot be printed as though it had one - and
+            // the break path logs the notification, so getting this wrong takes the whole path down with it.
+            return "Smb2LeaseBreakNotification[leaseKey=" + Hexdump.toHexString(this.leaseKey) + ",currentLeaseState="
+                    + this.currentLeaseState + ",newLeaseState=" + this.newLeaseState + ",flags=" + this.breakFlags + ",epoch="
+                    + this.newEpoch + "]";
+        }
         return "Smb2OpblockBreakNotification[oplockLevel=" + this.oplockLevel + ",fileId=" + Hexdump.toHexString(this.fileId) + "]";
     }
 }

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/lock/Smb2OplockBreakResponse.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/lock/Smb2OplockBreakResponse.java
@@ -1,0 +1,87 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.internal.smb2.lock;
+
+import org.codelibs.jcifs.smb.Configuration;
+import org.codelibs.jcifs.smb.internal.SMBProtocolDecodingException;
+import org.codelibs.jcifs.smb.internal.smb2.ServerMessageBlock2Response;
+import org.codelibs.jcifs.smb.internal.util.SMBUtil;
+
+/**
+ * SMB2 Oplock Break Response, MS-SMB2 2.2.25.1.
+ *
+ * <p>
+ * The server's reply to an oplock break acknowledgement, naming the level the open is left at. A non-zero status
+ * means the acknowledgement was refused, in which case the client keeps no oplock at all (MS-SMB2 3.2.5.19.3).
+ * </p>
+ */
+public class Smb2OplockBreakResponse extends ServerMessageBlock2Response {
+
+    private static final int STRUCTURE_SIZE = 24;
+
+    private byte oplockLevel;
+    private byte[] fileId;
+
+    /**
+     * Constructs an oplock break response with the given configuration.
+     *
+     * @param config the configuration for this response
+     */
+    public Smb2OplockBreakResponse(final Configuration config) {
+        super(config);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.codelibs.jcifs.smb.internal.smb2.ServerMessageBlock2#writeBytesWireFormat(byte[], int)
+     */
+    @Override
+    protected int writeBytesWireFormat(final byte[] dst, final int dstIndex) {
+        return 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.codelibs.jcifs.smb.internal.smb2.ServerMessageBlock2#readBytesWireFormat(byte[], int)
+     */
+    @Override
+    protected int readBytesWireFormat(final byte[] buffer, final int bufferIndex) throws SMBProtocolDecodingException {
+        final int structureSize = SMBUtil.readInt2(buffer, bufferIndex);
+        if (structureSize != STRUCTURE_SIZE) {
+            throw new SMBProtocolDecodingException("Expected structureSize = 24");
+        }
+        this.oplockLevel = buffer[bufferIndex + 2];
+        this.fileId = new byte[16];
+        System.arraycopy(buffer, bufferIndex + 8, this.fileId, 0, 16);
+        return STRUCTURE_SIZE;
+    }
+
+    /**
+     * @return the oplock level the open is left at
+     */
+    public byte getOplockLevel() {
+        return this.oplockLevel;
+    }
+
+    /**
+     * @return the file id of the open, 16 bytes
+     */
+    public byte[] getFileId() {
+        return this.fileId;
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbOplockProbe.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbOplockProbe.java
@@ -1,0 +1,100 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.impl;
+
+import org.codelibs.jcifs.smb.CIFSException;
+import org.codelibs.jcifs.smb.SmbConstants;
+import org.codelibs.jcifs.smb.internal.smb2.create.Smb2CreateRequest;
+import org.codelibs.jcifs.smb.internal.smb2.create.Smb2CreateResponse;
+
+/**
+ * Test-only way to hold a file open with an oplock.
+ *
+ * <p>
+ * Nothing in jcifs asks for an oplock - every CREATE requests {@code SMB2_OPLOCK_LEVEL_NONE} - so a conforming
+ * server never has a reason to send a break. This opens a file the way a client that wanted one would, which is what
+ * makes a real break arrive. It lives in the implementation package because {@code SmbTreeHandleImpl} and
+ * {@code SmbFileHandleImpl} are package private.
+ * </p>
+ */
+public final class SmbOplockProbe implements AutoCloseable {
+
+    private final SmbFileHandleImpl handle;
+    private final byte grantedOplockLevel;
+
+    private SmbOplockProbe(final SmbFileHandleImpl handle, final byte grantedOplockLevel) {
+        this.handle = handle;
+        this.grantedOplockLevel = grantedOplockLevel;
+    }
+
+    /**
+     * Opens an existing file asking for the given oplock level, and keeps it open.
+     *
+     * @param file                 an existing file
+     * @param requestedOplockLevel one of the {@code SMB2_OPLOCK_LEVEL_*} values
+     * @return the open, which the caller closes
+     * @throws CIFSException if the server refuses the open
+     */
+    public static SmbOplockProbe open(final SmbFile file, final byte requestedOplockLevel) throws CIFSException {
+        try (SmbTreeHandleImpl th = (SmbTreeHandleImpl) file.getTreeHandle()) {
+            if (!th.isSMB2()) {
+                throw new IllegalStateException("Oplocks need an SMB2 connection");
+            }
+            final Smb2CreateRequest create = new Smb2CreateRequest(th.getConfig(), file.getUncPath());
+            create.setDesiredAccess(SmbConstants.FILE_READ_DATA | SmbConstants.FILE_WRITE_DATA);
+            create.setShareAccess(SmbConstants.FILE_SHARE_READ | SmbConstants.FILE_SHARE_WRITE);
+            create.setCreateDisposition(Smb2CreateRequest.FILE_OPEN);
+            create.setRequestedOplockLevel(requestedOplockLevel);
+
+            final Smb2CreateResponse response = th.send(create);
+            final SmbFileHandleImpl handle = new SmbFileHandleImpl(th.getConfig(), response.getFileId(), th, file.getUncPath(), 0,
+                    SmbConstants.FILE_READ_DATA, 0, 0, response.getEndOfFile());
+            // openUnshared() does this for every ordinary open; the probe builds its own CREATE, so it has to do it
+            // itself or the break would name an open nothing can resolve.
+            try (SmbSessionImpl session = th.getSession()) {
+                handle.registerWith(session, response.getOplockLevel());
+            }
+            return new SmbOplockProbe(handle, response.getOplockLevel());
+        }
+    }
+
+    /**
+     * @return the oplock level the server actually granted, which may be lower than the one asked for
+     */
+    public byte grantedOplockLevel() {
+        return this.grantedOplockLevel;
+    }
+
+    /**
+     * The level this open holds now.
+     *
+     * <p>
+     * A break moves it to the level the server broke to. An acknowledgement the server refuses moves it to
+     * {@code SMB2_OPLOCK_LEVEL_NONE} instead, so this tells a refused acknowledgement apart from an accepted break to
+     * level II - which timing alone cannot, because the server completes the break either way.
+     * </p>
+     *
+     * @return the current oplock level of the open
+     */
+    public byte currentOplockLevel() {
+        return this.handle.getOplockLevel();
+    }
+
+    @Override
+    public void close() throws CIFSException {
+        this.handle.close();
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbSessionImplTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbSessionImplTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -28,6 +29,7 @@ import org.codelibs.jcifs.smb.Credentials;
 import org.codelibs.jcifs.smb.RuntimeCIFSException;
 import org.codelibs.jcifs.smb.internal.SMBSigningDigest;
 import org.codelibs.jcifs.smb.internal.smb2.Smb2EncryptionContext;
+import org.codelibs.jcifs.smb.internal.smb2.create.Smb2CreateRequest;
 import org.codelibs.jcifs.smb.internal.smb2.session.Smb2SessionSetupResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -366,5 +368,121 @@ class SmbSessionImplTest {
         // Cause the inner reauthenticate to fail at first transport call
         when(transport.getNegotiateResponse()).thenThrow(new SmbException("fail"));
         assertThrows(CIFSException.class, session::reauthenticate);
+    }
+
+    /**
+     * An oplock break names only the file it breaks. MS-SMB2 3.2.5.19.1 has the client find the open in
+     * Session.OpenTable by that file id, because the acknowledgement has to carry the session and tree of the open -
+     * the notification's own header carries TreeId 0 and, on several servers, SessionId 0.
+     */
+    @Test
+    @DisplayName("an open is found by its file id once registered")
+    void testOpenTableLookup() {
+        SmbSessionImpl session = newSession();
+        byte[] fileId = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+        SmbFileHandleImpl handle = mock(SmbFileHandleImpl.class);
+
+        assertNull(session.getOpen(fileId), "nothing is registered yet");
+
+        session.registerOpen(fileId, handle);
+
+        assertSame(handle, session.getOpen(fileId));
+        assertSame(handle, session.getOpen(fileId.clone()), "lookup is by contents, not identity");
+    }
+
+    @Test
+    @DisplayName("an open is gone from the table once unregistered")
+    void testOpenTableUnregister() {
+        SmbSessionImpl session = newSession();
+        byte[] fileId = new byte[] { 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1 };
+        SmbFileHandleImpl handle = mock(SmbFileHandleImpl.class);
+        session.registerOpen(fileId, handle);
+
+        session.unregisterOpen(fileId);
+
+        assertNull(session.getOpen(fileId), "a closed open must not be left behind");
+    }
+
+    @Test
+    @DisplayName("an unknown file id resolves to nothing rather than failing")
+    void testOpenTableMiss() {
+        SmbSessionImpl session = newSession();
+        session.registerOpen(new byte[16], mock(SmbFileHandleImpl.class));
+
+        // 3.2.5.19.1: a break naming no open of ours is ignored, so a miss must be quiet
+        assertNull(session.getOpen(new byte[] { 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9 }));
+        assertNull(session.getOpen(null));
+    }
+
+    @Test
+    @DisplayName("the session id is readable for the break acknowledgement header")
+    void testSessionIdAccessor() throws Exception {
+        SmbSessionImpl session = newSession();
+        assertEquals(0L, session.getSessionId(), "a session that has not authenticated has no id yet");
+
+        setField(session, "sessionId", 0x4142434445464748L);
+
+        assertEquals(0x4142434445464748L, session.getSessionId());
+    }
+
+    private SmbTreeHandleImpl stubbedTree() {
+        SmbTreeHandleImpl tree = mock(SmbTreeHandleImpl.class);
+        lenient().when(tree.acquire()).thenReturn(tree);
+        lenient().when(tree.getTreeId()).thenReturn(7L);
+        lenient().when(tree.isConnected()).thenReturn(true);
+        lenient().when(tree.isSMB2()).thenReturn(true);
+        return tree;
+    }
+
+    @Test
+    @DisplayName("an open registers itself with its session and is found by file id")
+    void testHandleRegistersWithSession() {
+        SmbSessionImpl session = newSession();
+        byte[] fileId = new byte[] { 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32 };
+        SmbFileHandleImpl handle = new SmbFileHandleImpl(configuration, fileId, stubbedTree(), "//server/share/f", 0, 0, 0, 0, 0L);
+
+        assertNull(session.getOpen(fileId), "an unattached handle is not in the table");
+
+        handle.registerWith(session, Smb2CreateRequest.SMB2_OPLOCK_LEVEL_BATCH);
+
+        assertSame(handle, session.getOpen(fileId));
+    }
+
+    @Test
+    @DisplayName("closing an open takes it out of the session's table")
+    void testHandleUnregistersOnClose() throws Exception {
+        SmbSessionImpl session = newSession();
+        byte[] fileId = new byte[] { 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 4, 7, 11, 18, 29 };
+        SmbFileHandleImpl handle = new SmbFileHandleImpl(configuration, fileId, stubbedTree(), "//server/share/f", 0, 0, 0, 0, 0L);
+        handle.registerWith(session, Smb2CreateRequest.SMB2_OPLOCK_LEVEL_BATCH);
+
+        handle.close();
+
+        assertNull(session.getOpen(fileId), "a closed open must not be left in the table");
+    }
+
+    @Test
+    @DisplayName("an open marked closed without a close request is also taken out of the table")
+    void testHandleUnregistersOnMarkClosed() {
+        SmbSessionImpl session = newSession();
+        byte[] fileId = new byte[] { 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45, 48 };
+        SmbFileHandleImpl handle = new SmbFileHandleImpl(configuration, fileId, stubbedTree(), "//server/share/f", 0, 0, 0, 0, 0L);
+        handle.registerWith(session, Smb2CreateRequest.SMB2_OPLOCK_LEVEL_BATCH);
+
+        // A handle invalidated without a close request - a reconnect drops it - must not be left behind either,
+        // or the table pins it for the life of the session.
+        handle.markClosed();
+
+        assertNull(session.getOpen(fileId), "an invalidated open must not be left in the table");
+    }
+
+    @Test
+    @DisplayName("an open that was never attached to a session closes without failing")
+    void testUnattachedHandleCloses() throws Exception {
+        // Every existing caller builds handles without a session, and SMB1 handles have no file id at all.
+        SmbFileHandleImpl handle = new SmbFileHandleImpl(configuration, 42, stubbedTree(), "//server/share/f", 0, 0, 0, 0, 0L);
+
+        handle.close();
+        handle.markClosed();
     }
 }

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbTransportOplockBreakTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbTransportOplockBreakTest.java
@@ -1,0 +1,172 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.impl;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.codelibs.jcifs.smb.Address;
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.Configuration;
+import org.codelibs.jcifs.smb.Credentials;
+import org.codelibs.jcifs.smb.internal.smb2.create.Smb2CreateRequest;
+import org.codelibs.jcifs.smb.internal.smb2.lock.Smb2BreakNotifications;
+import org.codelibs.jcifs.smb.internal.smb2.lock.Smb2OplockBreakNotification;
+import org.codelibs.jcifs.smb.internal.util.SMBUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * What the transport does with a break notification.
+ *
+ * <p>
+ * A break arrives on the thread that reads the connection, so anything that goes wrong here costs more than a failed
+ * request. These cover the paths that must not reach the network at all: a lease break, a break naming an open this
+ * client does not have, and a break of an open that holds no oplock.
+ * </p>
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class SmbTransportOplockBreakTest {
+
+    private static final byte[] FILE_ID =
+            { 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58 };
+
+    @Mock
+    private CIFSContext cifsContext;
+    @Mock
+    private Configuration configuration;
+    @Mock
+    private Credentials credentials;
+    @Mock
+    private CredentialsInternal credentialsInternal;
+    @Mock
+    private Address address;
+
+    private SmbTransportImpl transport;
+
+    @BeforeEach
+    void setup() {
+        when(this.cifsContext.getConfig()).thenReturn(this.configuration);
+        when(this.cifsContext.getCredentials()).thenReturn(this.credentials);
+        when(this.credentials.unwrap(CredentialsInternal.class)).thenReturn(this.credentialsInternal);
+        when(this.credentialsInternal.clone()).thenReturn(this.credentialsInternal);
+        this.transport = new SmbTransportImpl(this.cifsContext, this.address, 445, null, 0, false);
+    }
+
+    /**
+     * Builds a session holding one open, and indexes it on the transport the way a completed session setup does.
+     */
+    private SmbFileHandleImpl registerOpen(final long sessionId, final byte[] fileId, final byte oplockLevel) {
+        final SmbSessionImpl session = new SmbSessionImpl(this.cifsContext, "server.example", "EXAMPLE", this.transport);
+        final SmbTreeHandleImpl tree = mock(SmbTreeHandleImpl.class);
+        lenient().when(tree.acquire()).thenReturn(tree);
+        lenient().when(tree.getTreeId()).thenReturn(11L);
+        lenient().when(tree.isConnected()).thenReturn(true);
+        lenient().when(tree.isSMB2()).thenReturn(true);
+
+        final SmbFileHandleImpl handle = new SmbFileHandleImpl(this.configuration, fileId, tree, "//server/share/f", 0, 0, 0, 0, 0L);
+        handle.registerWith(session, oplockLevel);
+        this.transport.registerSessionId(sessionId, session);
+        return handle;
+    }
+
+    private Smb2OplockBreakNotification oplockBreak(final long sessionId, final byte[] fileId, final byte newLevel) throws Exception {
+        final byte[] body = new byte[24];
+        SMBUtil.writeInt2(24, body, 0);
+        body[2] = newLevel;
+        System.arraycopy(fileId, 0, body, 8, 16);
+        final Smb2OplockBreakNotification notification = Smb2BreakNotifications.decodeBody(this.configuration, body);
+        notification.setSessionId(sessionId);
+        return notification;
+    }
+
+    @Test
+    @DisplayName("a break of an open that holds no oplock is ignored outright")
+    void testBreakOfOpenWithoutOplock() throws Exception {
+        // Every ordinary open is in this state: jcifs asks for SMB2_OPLOCK_LEVEL_NONE on every create. MS-SMB2
+        // 3.2.5.19.1 has the client stop processing, so nothing may be recorded from the notification either -
+        // recording it would let an unverified message raise the level and make the next break answerable.
+        final SmbFileHandleImpl open = registerOpen(0x1111L, FILE_ID, Smb2CreateRequest.SMB2_OPLOCK_LEVEL_NONE);
+
+        this.transport.handleNotification(oplockBreak(0x1111L, FILE_ID, Smb2CreateRequest.SMB2_OPLOCK_LEVEL_BATCH));
+
+        assertEquals(Smb2CreateRequest.SMB2_OPLOCK_LEVEL_NONE, open.getOplockLevel(),
+                "an open that holds no oplock must not take a level from a break notification");
+    }
+
+    @Test
+    @DisplayName("a lease break is handled without failing")
+    void testLeaseBreakIsHandled() throws Exception {
+        // A lease break has a lease key and no file id. jcifs never asks for a lease, so there is nothing to do with
+        // it, but handling it must not throw: the break path runs on the receive thread.
+        final byte[] body = new byte[44];
+        SMBUtil.writeInt2(44, body, 0);
+        SMBUtil.writeInt4(1, body, 4);
+        SMBUtil.writeInt4(0x07, body, 24);
+        SMBUtil.writeInt4(0x01, body, 28);
+        final Smb2OplockBreakNotification notification = Smb2BreakNotifications.decodeBody(this.configuration, body);
+
+        assertDoesNotThrow(() -> this.transport.handleNotification(notification));
+    }
+
+    @Test
+    @DisplayName("a break naming an open this client does not have is ignored")
+    void testBreakForUnknownOpen() throws Exception {
+        final SmbFileHandleImpl open = registerOpen(0x2222L, FILE_ID, Smb2CreateRequest.SMB2_OPLOCK_LEVEL_BATCH);
+        final byte[] otherFileId = new byte[16];
+
+        assertDoesNotThrow(
+                () -> this.transport.handleNotification(oplockBreak(0x2222L, otherFileId, Smb2CreateRequest.SMB2_OPLOCK_LEVEL_II)));
+
+        assertEquals(Smb2CreateRequest.SMB2_OPLOCK_LEVEL_BATCH, open.getOplockLevel(),
+                "a break for another file must leave this open alone");
+    }
+
+    @Test
+    @DisplayName("an open is found by file id even when the notification names no session")
+    void testOpenFoundWhenSessionIdIsZero() throws Exception {
+        // Windows up to 2012 R2 and ksmbd send SessionId 0 in a break notification, so the file id is all there is.
+        final SmbFileHandleImpl open = registerOpen(0x3333L, FILE_ID, Smb2CreateRequest.SMB2_OPLOCK_LEVEL_NONE);
+
+        this.transport.handleNotification(oplockBreak(0L, FILE_ID, Smb2CreateRequest.SMB2_OPLOCK_LEVEL_II));
+
+        // Nothing to assert about the level - the open holds no oplock - but it must have been resolved, which the
+        // next test covers through the table itself.
+        assertSame(open, this.transport.getSessionById(0x3333L).getOpen(FILE_ID));
+    }
+
+    @Test
+    @DisplayName("a closed open is gone from the table a break would search")
+    void testClosedOpenIsNotFound() throws Exception {
+        final SmbFileHandleImpl open = registerOpen(0x4444L, FILE_ID, Smb2CreateRequest.SMB2_OPLOCK_LEVEL_BATCH);
+
+        open.markClosed();
+
+        assertNull(this.transport.getSessionById(0x4444L).getOpen(FILE_ID), "a closed open must not be resolvable from a break");
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/lock/Smb2BreakNotifications.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/lock/Smb2BreakNotifications.java
@@ -1,0 +1,49 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.internal.smb2.lock;
+
+import org.codelibs.jcifs.smb.Configuration;
+import org.codelibs.jcifs.smb.internal.SMBProtocolDecodingException;
+
+/**
+ * Test-only way to build a decoded break notification from its body alone.
+ *
+ * <p>
+ * A test of what the transport does with a break needs the transport, which is package private in the
+ * implementation package, and the notification's decoder, which is protected here. No single package sees both, so
+ * this exposes the decode without making a test hand-build a whole SMB2 header to reach the public one.
+ * </p>
+ */
+public final class Smb2BreakNotifications {
+
+    private Smb2BreakNotifications() {
+    }
+
+    /**
+     * Decodes a break notification body - 24 bytes for an oplock break, 44 for a lease break.
+     *
+     * @param config the configuration to build it with
+     * @param body   the notification body, starting at its structure size
+     * @return the decoded notification
+     * @throws SMBProtocolDecodingException if the body is neither shape
+     */
+    public static Smb2OplockBreakNotification decodeBody(final Configuration config, final byte[] body)
+            throws SMBProtocolDecodingException {
+        final Smb2OplockBreakNotification notification = new Smb2OplockBreakNotification(config);
+        notification.readBytesWireFormat(body, 0);
+        return notification;
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/lock/Smb2OplockBreakAcknowledgmentTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/lock/Smb2OplockBreakAcknowledgmentTest.java
@@ -1,0 +1,164 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.internal.smb2.lock;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.util.Arrays;
+
+import org.codelibs.jcifs.smb.Configuration;
+import org.codelibs.jcifs.smb.internal.SMBProtocolDecodingException;
+import org.codelibs.jcifs.smb.internal.smb2.Smb2Constants;
+import org.codelibs.jcifs.smb.internal.smb2.create.Smb2CreateRequest;
+import org.codelibs.jcifs.smb.internal.util.SMBUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The acknowledgement a client sends for an oplock break, MS-SMB2 2.2.24.1, and the reply it draws, 2.2.25.1. Both
+ * are 24 byte bodies on the SMB2_OPLOCK_BREAK command, which is also how the break notification itself arrives - the
+ * three are told apart by direction and structure size.
+ */
+class Smb2OplockBreakAcknowledgmentTest {
+
+    private static final int SMB2_OPLOCK_BREAK = 0x12;
+
+    private static final byte[] FILE_ID =
+            { 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27 };
+
+    private final Configuration config = mock(Configuration.class);
+
+    @Test
+    @DisplayName("writes the 24 byte acknowledgement body of MS-SMB2 2.2.24.1")
+    void testWireFormat() {
+        final Smb2OplockBreakAcknowledgment ack = new Smb2OplockBreakAcknowledgment(this.config, FILE_ID, (byte) 0x00);
+        final byte[] buffer = new byte[128];
+
+        final int written = ack.writeBytesWireFormat(buffer, 0);
+
+        assertEquals(24, written, "the acknowledgement body is 24 bytes");
+        assertEquals(24, SMBUtil.readInt2(buffer, 0), "StructureSize");
+        assertEquals(0x00, buffer[2], "OplockLevel");
+        assertEquals(0, buffer[3], "Reserved");
+        assertEquals(0, SMBUtil.readInt4(buffer, 4), "Reserved2");
+        assertArrayEquals(FILE_ID, Arrays.copyOfRange(buffer, 8, 24), "FileId");
+    }
+
+    @Test
+    @DisplayName("writes the acknowledgement at an offset without disturbing what is before it")
+    void testWireFormatAtOffset() {
+        final Smb2OplockBreakAcknowledgment ack = new Smb2OplockBreakAcknowledgment(this.config, FILE_ID, (byte) 0x01);
+        final byte[] buffer = new byte[128];
+        Arrays.fill(buffer, 0, 16, (byte) 0xEE);
+
+        assertEquals(24, ack.writeBytesWireFormat(buffer, 16));
+
+        assertEquals(24, SMBUtil.readInt2(buffer, 16), "StructureSize");
+        assertEquals(0x01, buffer[18], "OplockLevel");
+        assertArrayEquals(FILE_ID, Arrays.copyOfRange(buffer, 24, 40), "FileId");
+        for (int i = 0; i < 16; i++) {
+            assertEquals((byte) 0xEE, buffer[i], "byte " + i + " before the body was overwritten");
+        }
+    }
+
+    @Test
+    @DisplayName("is sent as SMB2_OPLOCK_BREAK and sized to header plus body")
+    void testCommandAndSize() {
+        final Smb2OplockBreakAcknowledgment ack = new Smb2OplockBreakAcknowledgment(this.config, FILE_ID, (byte) 0x00);
+
+        assertEquals(SMB2_OPLOCK_BREAK, ack.getCommand(), "acknowledgements share the break command");
+        assertEquals(Smb2Constants.SMB2_HEADER_LENGTH + 24, ack.size());
+    }
+
+    @Test
+    @DisplayName("reads the 24 byte reply of MS-SMB2 2.2.25.1")
+    void testResponseWireFormat() throws Exception {
+        final Smb2OplockBreakResponse response = new Smb2OplockBreakResponse(this.config);
+        final byte[] buffer = new byte[64];
+        SMBUtil.writeInt2(24, buffer, 0);
+        buffer[2] = 0x01;
+        System.arraycopy(FILE_ID, 0, buffer, 8, 16);
+
+        assertEquals(24, response.readBytesWireFormat(buffer, 0));
+
+        assertEquals((byte) 0x01, response.getOplockLevel());
+        assertArrayEquals(FILE_ID, response.getFileId());
+    }
+
+    @Test
+    @DisplayName("a break from level II to none is not acknowledged")
+    void testLevelTwoToNoneNeedsNoAcknowledgement() {
+        // MS-SMB2 2.2.24.1: "A break from level II MUST transition to none. Thus, the client does not send a request
+        // to the server because there is no question how the transition was made." Answering anyway is refused -
+        // Samba does not arm its acknowledgement timer for a level II break and returns
+        // STATUS_INVALID_OPLOCK_PROTOCOL.
+        assertFalse(
+                Smb2OplockBreakAcknowledgment.isRequired(Smb2CreateRequest.SMB2_OPLOCK_LEVEL_II, Smb2CreateRequest.SMB2_OPLOCK_LEVEL_NONE));
+    }
+
+    @Test
+    @DisplayName("a break of an exclusive or batch oplock is acknowledged")
+    void testExclusiveAndBatchBreaksAreAcknowledged() {
+        assertTrue(Smb2OplockBreakAcknowledgment.isRequired(Smb2CreateRequest.SMB2_OPLOCK_LEVEL_EXCLUSIVE,
+                Smb2CreateRequest.SMB2_OPLOCK_LEVEL_II));
+        assertTrue(Smb2OplockBreakAcknowledgment.isRequired(Smb2CreateRequest.SMB2_OPLOCK_LEVEL_EXCLUSIVE,
+                Smb2CreateRequest.SMB2_OPLOCK_LEVEL_NONE));
+        assertTrue(Smb2OplockBreakAcknowledgment.isRequired(Smb2CreateRequest.SMB2_OPLOCK_LEVEL_BATCH,
+                Smb2CreateRequest.SMB2_OPLOCK_LEVEL_II));
+        assertTrue(Smb2OplockBreakAcknowledgment.isRequired(Smb2CreateRequest.SMB2_OPLOCK_LEVEL_BATCH,
+                Smb2CreateRequest.SMB2_OPLOCK_LEVEL_NONE));
+    }
+
+    @Test
+    @DisplayName("a break that does not lower the level is not acknowledged")
+    void testUnchangedLevelNeedsNoAcknowledgement() {
+        // Not a break at all. Answering it would echo a level 2.2.24.1 does not allow - only none and level II are
+        // legal in an acknowledgement - and Samba rejects anything else outright.
+        assertFalse(Smb2OplockBreakAcknowledgment.isRequired(Smb2CreateRequest.SMB2_OPLOCK_LEVEL_BATCH,
+                Smb2CreateRequest.SMB2_OPLOCK_LEVEL_BATCH));
+        assertFalse(
+                Smb2OplockBreakAcknowledgment.isRequired(Smb2CreateRequest.SMB2_OPLOCK_LEVEL_II, Smb2CreateRequest.SMB2_OPLOCK_LEVEL_II));
+    }
+
+    @Test
+    @DisplayName("a break of an open that holds no oplock is not acknowledged")
+    void testNoOplockHeldNeedsNoAcknowledgement() {
+        // jcifs asks for no oplock on every create, so this is what a stray notification would find. 3.2.5.19.1 has
+        // the client stop processing rather than answer.
+        assertFalse(Smb2OplockBreakAcknowledgment.isRequired(Smb2CreateRequest.SMB2_OPLOCK_LEVEL_NONE,
+                Smb2CreateRequest.SMB2_OPLOCK_LEVEL_NONE));
+        assertFalse(
+                Smb2OplockBreakAcknowledgment.isRequired(Smb2CreateRequest.SMB2_OPLOCK_LEVEL_NONE, Smb2CreateRequest.SMB2_OPLOCK_LEVEL_II));
+    }
+
+    @Test
+    @DisplayName("rejects a reply that is not 24 bytes")
+    void testResponseRejectsOtherSizes() {
+        final Smb2OplockBreakResponse response = new Smb2OplockBreakResponse(this.config);
+        final byte[] buffer = new byte[64];
+        SMBUtil.writeInt2(44, buffer, 0);
+
+        final SMBProtocolDecodingException exception =
+                assertThrows(SMBProtocolDecodingException.class, () -> response.readBytesWireFormat(buffer, 0));
+
+        assertEquals("Expected structureSize = 24", exception.getMessage());
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/lock/Smb2OplockBreakNotificationTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/lock/Smb2OplockBreakNotificationTest.java
@@ -1,7 +1,9 @@
 package org.codelibs.jcifs.smb.internal.smb2.lock;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -105,12 +107,12 @@ class Smb2OplockBreakNotificationTest extends BaseTest {
         void testReadInvalidStructureSize() {
             // Create buffer with invalid structure size
             byte[] buffer = new byte[64];
-            SMBUtil.writeInt2(23, buffer, 0); // Invalid size (should be 24)
+            SMBUtil.writeInt2(23, buffer, 0); // Invalid size (should be 24 for an oplock break, 44 for a lease break)
 
             SMBProtocolDecodingException exception =
                     assertThrows(SMBProtocolDecodingException.class, () -> notification.readBytesWireFormat(buffer, 0));
 
-            assertEquals("Expected structureSize = 24", exception.getMessage());
+            assertEquals("Expected structureSize = 24 or 44", exception.getMessage());
         }
 
         @ParameterizedTest
@@ -184,6 +186,102 @@ class Smb2OplockBreakNotificationTest extends BaseTest {
             SMBUtil.writeInt2(24, buffer, 0);
             buffer[2] = oplockLevel;
             System.arraycopy(fileId, 0, buffer, 8, 16);
+            return buffer;
+        }
+    }
+
+    /**
+     * MS-SMB2 puts an oplock break (2.2.23.1, structure size 24) and a lease break (2.2.23.2, structure size 44) on
+     * the same command, SMB2_OPLOCK_BREAK, and 3.2.5.19 says the two are told apart only by their structure size.
+     * The command code is all the transport knows when it builds the notification, so this one class has to decode
+     * either shape.
+     */
+    @Nested
+    @DisplayName("Break body shapes")
+    class BreakBodyTests {
+
+        @Test
+        @DisplayName("Should decode a lease break instead of rejecting it")
+        void testReadLeaseBreak() throws Exception {
+            final byte[] leaseKey = createTestData(16);
+            final byte[] buffer = createLeaseBreakBuffer(leaseKey, 0x1234, 0x01, 0x07, 0x01);
+
+            final int bytesRead = notification.readBytesWireFormat(buffer, 0);
+
+            assertEquals(44, bytesRead, "a lease break body is 44 bytes");
+            assertTrue(notification.isLeaseBreak(), "should be recognised as a lease break");
+            assertArrayEquals(leaseKey, notification.getLeaseKey());
+            assertEquals(0x1234, notification.getNewEpoch());
+            assertEquals(0x01, notification.getBreakFlags());
+            assertEquals(0x07, notification.getCurrentLeaseState());
+            assertEquals(0x01, notification.getNewLeaseState());
+        }
+
+        @Test
+        @DisplayName("Should decode a lease break at a buffer offset")
+        void testReadLeaseBreakAtOffset() throws Exception {
+            final int offset = 16;
+            final byte[] leaseKey = createTestData(16);
+            final byte[] body = createLeaseBreakBuffer(leaseKey, 0, 0, 0x03, 0x00);
+            final byte[] buffer = new byte[offset + body.length];
+            Arrays.fill(buffer, 0, offset, (byte) 0xCD);
+            System.arraycopy(body, 0, buffer, offset, body.length);
+
+            assertEquals(44, notification.readBytesWireFormat(buffer, offset));
+            assertArrayEquals(leaseKey, notification.getLeaseKey());
+            assertEquals(0x03, notification.getCurrentLeaseState());
+        }
+
+        @Test
+        @DisplayName("Should expose the oplock level and file id of an oplock break")
+        void testOplockBreakAccessors() throws Exception {
+            final byte[] fileId = createTestData(16);
+            final byte[] buffer = new byte[64];
+            SMBUtil.writeInt2(24, buffer, 0);
+            buffer[2] = 0x01;
+            System.arraycopy(fileId, 0, buffer, 8, 16);
+
+            assertEquals(24, notification.readBytesWireFormat(buffer, 0));
+
+            assertFalse(notification.isLeaseBreak(), "an oplock break is not a lease break");
+            assertEquals((byte) 0x01, notification.getOplockLevel());
+            assertArrayEquals(fileId, notification.getFileId());
+        }
+
+        @Test
+        @DisplayName("Should reject a body that is neither an oplock nor a lease break")
+        void testReadUnknownStructureSize() {
+            final byte[] buffer = new byte[64];
+            SMBUtil.writeInt2(36, buffer, 0);
+
+            final SMBProtocolDecodingException exception =
+                    assertThrows(SMBProtocolDecodingException.class, () -> notification.readBytesWireFormat(buffer, 0));
+
+            assertEquals("Expected structureSize = 24 or 44", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("a decoded lease break can be turned into a log line")
+        void testLeaseBreakIsPrintable() throws Exception {
+            final byte[] buffer = createLeaseBreakBuffer(createTestData(16), 1, 1, 0x07, 0x01);
+            notification.readBytesWireFormat(buffer, 0);
+
+            // The break path logs the notification, so one that cannot be printed takes the whole path down with it.
+            // A lease break carries a lease key and no file id, so printing it as though it had one fails.
+            final String printed = assertDoesNotThrow(notification::toString);
+            assertTrue(printed.contains("lease"), "a lease break should describe itself as one, but was: " + printed);
+        }
+
+        private byte[] createLeaseBreakBuffer(final byte[] leaseKey, final int newEpoch, final int flags, final int currentLeaseState,
+                final int newLeaseState) {
+            final byte[] buffer = new byte[44];
+            SMBUtil.writeInt2(44, buffer, 0);
+            SMBUtil.writeInt2(newEpoch, buffer, 2);
+            SMBUtil.writeInt4(flags, buffer, 4);
+            System.arraycopy(leaseKey, 0, buffer, 8, 16);
+            SMBUtil.writeInt4(currentLeaseState, buffer, 24);
+            SMBUtil.writeInt4(newLeaseState, buffer, 28);
+            // BreakReason, AccessMaskHint and ShareMaskHint are reserved and stay zero
             return buffer;
         }
     }

--- a/src/test/java/org/codelibs/jcifs/smb/it/OplockBreakIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/OplockBreakIT.java
@@ -1,0 +1,126 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.InputStream;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.impl.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbOplockProbe;
+import org.codelibs.jcifs.smb.internal.smb2.create.Smb2CreateRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Holds a file open with an oplock and then opens it from somewhere else, which is the only way to make a real server
+ * send an oplock break.
+ *
+ * <p>
+ * A server that gets no acknowledgement does not fail the conflicting open, it waits out its break timeout - about
+ * 35 seconds - and then breaks the oplock itself. So the acknowledgement shows up as the conflicting open returning
+ * promptly, and its absence as that open stalling.
+ * </p>
+ */
+class OplockBreakIT extends AbstractSmbIT {
+
+    /** Comfortably below a server break timeout, comfortably above a round trip. */
+    private static final long PROMPT_MILLIS = 15_000;
+
+    private SmbFile workDir;
+
+    @AfterEach
+    void removeWorkDir() {
+        deleteQuietly(this.workDir);
+    }
+
+    @Test
+    @DisplayName("a broken oplock is acknowledged, so the conflicting open is not left waiting")
+    void testBreakIsAcknowledged() throws Exception {
+        final CIFSContext context = server().context();
+        this.workDir = createWorkDir(context, server().share());
+        final SmbFile file = writeFile(this.workDir, "oplock.txt", "oplock target");
+
+        try (SmbOplockProbe probe = SmbOplockProbe.open(file, Smb2CreateRequest.SMB2_OPLOCK_LEVEL_BATCH)) {
+            // It is not enough that some oplock was granted, it has to be one whose break needs an acknowledgement.
+            // An open registers itself holding the level it was granted, so had the server handed out level II here,
+            // the open would already sit at level II and the check at the end of this test would pass without any
+            // break having happened at all.
+            assertEquals(Smb2CreateRequest.SMB2_OPLOCK_LEVEL_BATCH, probe.grantedOplockLevel(),
+                    "the server did not grant the batch oplock this test needs in order to provoke a break");
+
+            final long elapsed = openFromAnotherConnection(file);
+
+            assertTrue(elapsed < PROMPT_MILLIS, "the conflicting open took " + elapsed
+                    + " ms, so the oplock break went unacknowledged and the server had to " + "wait out its break timeout");
+
+            // The acknowledgement is sent on its own thread, and only a refused one lowers the level again, so the
+            // level has to be read after that thread is done or a refusal could be missed.
+            awaitAcknowledgement();
+
+            // Timing alone cannot tell an accepted acknowledgement from a refused one: a server that refuses it
+            // completes the break itself, so the conflicting open returns just as promptly either way. A refused
+            // acknowledgement drops the open to NONE, an accepted break to level II leaves it at level II.
+            assertEquals(Smb2CreateRequest.SMB2_OPLOCK_LEVEL_II, probe.currentOplockLevel(),
+                    "the open should hold the level the server broke to; NONE here means the acknowledgement was refused");
+        }
+    }
+
+    /**
+     * Waits for the thread that sends the acknowledgement to finish.
+     *
+     * <p>
+     * The thread exists only while an acknowledgement is in flight, so its absence means the send has either
+     * succeeded or failed and recorded that.
+     * </p>
+     */
+    private static void awaitAcknowledgement() throws InterruptedException {
+        final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+        while (System.nanoTime() < deadline) {
+            if (Thread.getAllStackTraces().keySet().stream().noneMatch(t -> t.isAlive() && "jcifs-oplock-break-ack".equals(t.getName()))) {
+                return;
+            }
+            Thread.sleep(20);
+        }
+        fail("the oplock break acknowledgement was still in flight after 30 s");
+    }
+
+    /**
+     * Opens the file over a second, separate connection and returns how long that took.
+     *
+     * <p>
+     * {@code ssnLimit=1} keeps this off the pooled connection the probe is using, so the break really does cross
+     * connections rather than being resolved inside one.
+     * </p>
+     */
+    private long openFromAnotherConnection(final SmbFile file) throws Exception {
+        final Properties properties = server().defaultProperties();
+        properties.setProperty("jcifs.client.ssnLimit", "1");
+        final CIFSContext other = server().context(properties);
+
+        final long start = System.nanoTime();
+        try (SmbFile conflicting = new SmbFile(file.getURL().toString(), other); InputStream in = conflicting.getInputStream()) {
+            assertEquals('o', in.read(), "the conflicting open should read the file that was written");
+        }
+        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+    }
+}


### PR DESCRIPTION
An oplock break notification names only a file id. Its own header is no help: MS-SMB2 3.3.4.6 has the server send **TreeId 0**, and SessionId is 0 on several servers (Windows ≤ 2012 R2 and ksmbd send 0; Samba sends the real one). jcifs had nowhere to look the open up — it decoded the notification, logged it at INFO and did nothing else.

Two consequences, one of them a connection-killer.

## What was broken

**A broken oplock was never acknowledged.** The server waited out its break timeout — about 35 seconds — before breaking the oplock itself, stalling whoever had opened the file in the meantime.

**A lease break took the whole connection down.** Both kinds of break arrive on `SMB2_OPLOCK_BREAK` and are told apart only by structure size (MS-SMB2 3.2.5.19). The 44-byte lease body failed a decode that demanded 24, and nothing between there and `Transport.loop()`'s catch-all handled it: the socket closed, every session logged off, and every request in flight on every session sharing that transport failed. One unexpected body shape, and the connection is gone.

## What this changes

- **`Smb2OplockBreakNotification`** decodes both shapes — 24-byte oplock break (2.2.23.1) and 44-byte lease break (2.2.23.2) — and exposes the decoded fields, which previously had no accessors at all.
- **Opens are registered with their session** as they are created and removed as they are closed (MS-SMB2 `Session.OpenTable`), so a break can be resolved to the open it names. Removal covers `closeInternal()` *and* `markClosed()`, the path that invalidates a handle without a close request.
- **`Smb2OplockBreakAcknowledgment` is sent on the broken open's own tree**, which is what gives it the session and tree id the server requires — and signing for free. Echoing the notification's header instead would draw `STATUS_NETWORK_NAME_DELETED`, since TreeId 0 is never a valid tree connect.
- **A break from level II to none is not answered at all** (2.2.24.1: "there is no question how the transition was made"). Samba does not arm its acknowledgement timer for a level II break and answers one with `STATUS_INVALID_OPLOCK_PROTOCOL`, so "always acknowledge" would be wrong for the most common break.
- **The acknowledgement is sent off the receive thread.** It draws a reply, and waiting for that reply on the very thread that reads replies would deadlock on the credit semaphore, besides holding up every other session sharing the connection.
- **A notification that still cannot be handled is logged and skipped** rather than failing the connection — provided it is not part of a compound chain, where the rest of the chain is still unread and stopping mid-stream would desync every message after it. Only a standalone message is read in full before it is decoded. Genuine socket failures still tear the connection down either way.

## Compatibility

**Nothing in jcifs requests an oplock** — every CREATE still sends `SMB2_OPLOCK_LEVEL_NONE` — so a conforming server has no reason to send a break (3.3.5.9), and none of the new handling is reached in ordinary use. `SMB2_SHAREFLAG_FORCE_LEVELII_OPLOCK` only caps a level you asked for; it cannot grant one you did not. The default behaviour is unchanged.

What does change: a caller that requests an oplock itself now gets it acknowledged, and a server that sends a break anyway no longer kills the connection.

## Tests

- **`OplockBreakIT`** holds a batch oplock and then opens the same file from a second connection (`ssnLimit=1`, so it is a separate connection rather than the pooled one). Without the acknowledgement that open takes **35,034 ms**; with it, **1.7 s**.

  Two things keep it from passing vacuously. It pins the granted level to **batch**, because an open registers itself holding the level it was granted — had the server handed out level II, the open would already sit at level II and the final check would pass with no break having happened. And it waits for the acknowledgement to finish before checking the open was left at level II: a *refused* acknowledgement drops it to none, and timing alone cannot tell the two apart, because a server that refuses the acknowledgement completes the break itself and the conflicting open returns just as promptly.

- **Unit tests** cover the 24/44 decode split and the new accessors, the session open table (lookup by content, removal on close and on `markClosed`), the acknowledgement wire format at offset 0 and at an offset, the level rules — including that a level II → none break is not acknowledged, and that one which does not lower the level is not either — and what the transport itself does with a break it must not answer: a lease break, one naming an open this client does not have, and one for an open that holds no oplock.

- **`SmbOplockProbe`** is test-only. Nothing in jcifs asks for an oplock, so a real break cannot be provoked without a client that wants one; it lives in the implementation package because `SmbTreeHandleImpl` and `SmbFileHandleImpl` are package private, the same arrangement `SmbCreateContextProbe` already uses.

One existing test changed: `Smb2OplockBreakNotificationTest.testReadInvalidStructureSize` pinned the exact message `Expected structureSize = 24`, which is no longer the contract now that 44 is also valid.

Not covered by a direct test: the catch that keeps an undecodable notification from failing the connection. Proving it needs a malformed frame injected into a live connection, which the harness cannot do today. What sits either side of it is covered — the decode by unit tests, the break path by `SmbTransportOplockBreakTest` — but the catch itself rests on reasoning.

## Review fixes

An independent review of the first version found two defects the tests above would not have caught. Both are now covered by tests that failed, with specific symptoms, before the fix.

- **Every lease break threw.** `readLeaseBreak` leaves `fileId` null and `toString()` formatted it unconditionally, so logging the notification raised a `NullPointerException`. The transport survived only because the new catch swallowed it — meaning the intended handling never ran, and narrowing that catch later would have brought back the connection-killer this change exists to remove. `toString()` now describes a lease break as one.
- **A break could raise the level an open appears to hold.** The new level was recorded before checking whether the open held an oplock at all. Every ordinary open holds none, so an unauthenticated notification could set one; a second notification would then satisfy the acknowledgement rule and start a thread, repeatably and without limit, each worker blocking on the shared credit semaphore. An open holding no oplock is now ignored outright, as MS-SMB2 3.2.5.19.1 requires, and nothing is taken from the notification.

Three smaller ones, also from the review:

- The catch that keeps a bad notification from failing the connection now applies only to a message that is **not** part of a compound chain. Only a standalone message is read in full before it is decoded; in a chain the rest is still unread, so swallowing a failure there would leave the stream mid-chain and every later message read from the wrong offset — silently, where the old behaviour failed loudly.
- The open table holds handles **weakly**. Holding them strongly pinned an abandoned handle until logoff and, worse, stopped it being collected at all — which is what raises the existing "File handle was not properly closed" warning. This one rests on reasoning rather than a test: forcing collection deterministically is not something a test can do without `System.gc()`.
- A break is no longer acknowledged when it does not actually lower the level, and the search for the open no longer falls back to other sessions once the session the server named has been found.

One review point deliberately not taken: the acknowledgement records the level the server offered rather than the one its reply returns. The two differ only if a server answers with something other than what it broke to, and the recorded level affects nothing but whether a later break of the same open is acknowledged — so the change would put a verified-green integration test at risk for no behavioural gain.

## Verification

Measured on this branch against `main` (f2cba36), zero failures everywhere.

| Run | `main` | This branch |
|---|---|---|
| `mvn verify` against the Samba container | 8578 unit, 109 integration (7 skipped) | 8605 unit, 110 integration (7 skipped) |
| `build_helpers/run-it-with-dfs.sh` (Samba on 445, DFS enabled) | 8578 unit, 109 integration (3 skipped) | 8605 unit, 110 integration (3 skipped) |
| `windows-smb` workflow (Windows Server 2025) | 8578 unit, 109 integration (9 skipped) | 8605 unit, 110 integration (9 skipped) |

The 27 new unit tests are the decode split, the open table, handle registration, the acknowledgement rules, and what the transport does with a break it must not answer - a lease break, a break naming an open this client does not have, and a break of an open holding no oplock. The new integration test is `OplockBreakIT`. The skipped tests are the same ones as on `main` in each environment.

`OplockBreakIT` passes against both backends, which is worth more than it looks: it asserts that the server grants the batch oplock and then breaks it to level II, and that the acknowledgement is not refused. Samba 4.21.9 and Windows Server 2025 both behave that way, so the acknowledgement is accepted by two independent server implementations rather than only the one it was developed against.

`mvn apache-rat:check` passes and `mvn formatter:format` has been applied.
