### PR TITLE
fix: make three APIs report what they actually did

### DIFF
--- a/docs/SMB3_SUPPORT.md
+++ b/docs/SMB3_SUPPORT.md
@@ -145,7 +145,7 @@ errors.
 | CHANGE_NOTIFY | Supported | Via `SmbResource.watch(int, boolean)`. Blocking. |
 | IOCTL | Partial | Reachable FSCTLs: DFS_GET_REFERRALS, PIPE_PEEK, PIPE_TRANSCEIVE, SRV_COPYCHUNK(_WRITE), SRV_REQUEST_RESUME_KEY, VALIDATE_NEGOTIATE_INFO. The other defined FSCTL constants are never sent. |
 | Async / `STATUS_PENDING` interim responses | Supported | |
-| FLUSH | Not functional | `Smb2FlushRequest` exists and is referenced nowhere. `SmbFileOutputStream` does not override `flush()`, so flushing is a silent no-op and no durability barrier is sent. |
+| FLUSH | Supported | Sent by `SmbFileOutputStream.flush()`. Every write goes out as it is made, so there is no local buffer to push; what `flush()` contributes is the durability barrier, asking the server to commit what it has taken. Before 3.0.4 the method was the inherited no-op from `OutputStream`, so a caller that flushed and saw no error had no way to tell the data was still only in the server's cache. Nothing is sent on SMB1, which has no equivalent request. |
 | LOCK | Not functional | `Smb2LockRequest` exists and is referenced nowhere. **There is no byte-range locking API** on `SmbResource`, `SmbFile` or `SmbRandomAccessFile`. |
 | ECHO | Not functional | `Smb2EchoRequest` exists and is referenced nowhere. There is no keepalive or liveness probe. |
 | CANCEL | Not functional | `Smb2CancelRequest` is fully built and wired into the send path, but `createCancel()` is never invoked. Nothing can cancel an in-flight request — including a pending CHANGE_NOTIFY, as `SmbWatchHandle`'s own javadoc notes. |
@@ -217,6 +217,20 @@ out the entries it had already read and then throws `RuntimeCIFSException` from
 the iterator; `list()`, `listFiles()`, `SmbFile.delete()` and `copyTo()` throw
 `SmbException`. Before that the listing simply ended, which a caller cannot tell
 apart from a directory that holds only those entries.
+
+SMB1 workgroup and server browsing is a separate code path that had the same
+problem, and since 3.0.4 it keeps the same contract: a browse cut short by a
+failure hands out the servers already read and then throws
+`RuntimeCIFSException`, instead of ending as though the workgroup held only
+those.
+
+A random access file no longer brings back a file that has gone. It is opened
+once and reopened by path whenever its handle is no longer valid, replaying the
+flags exactly as they stand — and `O_CREAT` was among them, for mode `r` as well
+as `rw`. So before 3.0.4 a reopen after a dropped connection resurrected a file
+deleted in the meantime as an empty one, and `openRandomAccess("r")` on a path
+that never existed created it rather than failing. Mode `rw` still creates the
+file on its first open, as it always has.
 
 ## Other features
 

--- a/src/main/java/org/codelibs/jcifs/smb/impl/NetServerEnumIterator.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/NetServerEnumIterator.java
@@ -20,6 +20,7 @@ package org.codelibs.jcifs.smb.impl;
 import org.codelibs.jcifs.smb.CIFSException;
 import org.codelibs.jcifs.smb.CloseableIterator;
 import org.codelibs.jcifs.smb.ResourceNameFilter;
+import org.codelibs.jcifs.smb.RuntimeCIFSException;
 import org.codelibs.jcifs.smb.SmbConstants;
 import org.codelibs.jcifs.smb.SmbResource;
 import org.codelibs.jcifs.smb.SmbResourceLocator;
@@ -47,6 +48,12 @@ public class NetServerEnumIterator implements CloseableIterator<FileEntry> {
     private final boolean workgroup;
     private int ridx;
     private FileEntry next;
+
+    /**
+     * The failure that ended the browse, held until every entry read before it has been handed out. Null while the
+     * browse is going normally.
+     */
+    private RuntimeCIFSException failure;
 
     /**
      * Constructs a NetServerEnumIterator for enumerating network servers
@@ -157,16 +164,28 @@ public class NetServerEnumIterator implements CloseableIterator<FileEntry> {
      */
     @Override
     public boolean hasNext() {
-        return this.next != null;
+        return this.next != null || this.failure != null;
     }
 
     /**
      * {@inheritDoc}
      *
+     * @throws RuntimeCIFSException if the browse could not be read to its end, so that one cut short by a failure is
+     *             not mistaken for the end of the list. Every entry that was read is returned before it is thrown.
      * @see java.util.Iterator#next()
      */
     @Override
     public FileEntry next() {
+        if (this.next == null) {
+            // Nothing left to hand out. Report the failure that ended the browse, once, and stay exhausted: asking
+            // for another page here would go back to a server over a connection that is already gone.
+            final RuntimeCIFSException pending = this.failure;
+            if (pending != null) {
+                this.failure = null;
+                throw pending;
+            }
+            return null;
+        }
         final FileEntry n = this.next;
         try {
             final FileEntry ne = advance();
@@ -176,8 +195,11 @@ public class NetServerEnumIterator implements CloseableIterator<FileEntry> {
             }
             this.next = ne;
         } catch (final CIFSException e) {
-            log.warn("Enumeration failed", e);
+            // Ending the browse here would look exactly like a workgroup holding only the entries read so far. The
+            // failure waits until this entry, which was read before it happened, has been handed out.
             this.next = null;
+            this.failure = new RuntimeCIFSException("Enumeration failed", e);
+            doClose();
         }
         return n;
     }

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbFileOutputStream.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbFileOutputStream.java
@@ -29,6 +29,7 @@ import org.codelibs.jcifs.smb.internal.smb1.com.SmbComWriteAndX;
 import org.codelibs.jcifs.smb.internal.smb1.com.SmbComWriteAndXResponse;
 import org.codelibs.jcifs.smb.internal.smb1.com.SmbComWriteResponse;
 import org.codelibs.jcifs.smb.internal.smb2.info.Smb2SetInfoRequest;
+import org.codelibs.jcifs.smb.internal.smb2.io.Smb2FlushRequest;
 import org.codelibs.jcifs.smb.internal.smb2.io.Smb2WriteRequest;
 import org.codelibs.jcifs.smb.internal.smb2.io.Smb2WriteResponse;
 import org.slf4j.Logger;
@@ -215,6 +216,34 @@ public class SmbFileOutputStream extends OutputStream {
         } finally {
             this.file.clearAttributeCache();
             this.tmp = null;
+        }
+    }
+
+    /**
+     * Asks the server to commit what has been written to stable storage.
+     *
+     * <p>
+     * Every write is sent as it is made, so there is no buffer here to push. What this does is send the durability
+     * barrier: without it the data a write returned from can still be sitting in the server's cache, and a caller
+     * that called {@code flush()} has no way to tell. Nothing is sent on SMB1, which has no equivalent request, or
+     * for a stream that is not open.
+     * </p>
+     *
+     * @throws IOException if the flush cannot be sent
+     */
+    @Override
+    public void flush() throws IOException {
+        if (!this.smb2) {
+            return;
+        }
+        try (SmbFileHandleImpl fh = ensureOpen()) {
+            // Not gated on the handle still being valid: ensureOpen() reopens a stale one, and a reconnect is
+            // exactly when the caller most wants what it wrote committed.
+            try (SmbTreeHandleImpl th = fh.getTree()) {
+                th.send(new Smb2FlushRequest(th.getConfig(), fh.getFileId()), RequestParam.NO_RETRY);
+            }
+        } catch (final CIFSException e) {
+            throw SmbException.wrap(e);
         }
     }
 

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbRandomAccessFile.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbRandomAccessFile.java
@@ -108,7 +108,9 @@ public class SmbRandomAccessFile implements SmbRandomAccess {
 
         try (SmbTreeHandleInternal th = this.file.ensureTreeConnected()) {
             if (mode.equals("r")) {
-                this.openFlags = SmbConstants.O_CREAT | SmbConstants.O_RDONLY;
+                // Deliberately no O_CREAT: it becomes FILE_OPEN_IF, so opening for reading would bring a missing
+                // file into existence as an empty one instead of failing.
+                this.openFlags = SmbConstants.O_RDONLY;
                 this.access = SmbConstants.FILE_READ_DATA;
             } else if (mode.equals("rw")) {
                 this.openFlags = SmbConstants.O_CREAT | SmbConstants.O_RDWR | SmbConstants.O_APPEND;
@@ -120,6 +122,10 @@ public class SmbRandomAccessFile implements SmbRandomAccess {
             }
 
             try (SmbFileHandle h = ensureOpen()) {}
+            // The file is open by now, so a reopen after a dropped connection must not create it again: that would
+            // resurrect a file deleted in the meantime rather than failing, and ensureOpen() replays these flags as
+            // they stand.
+            this.openFlags &= ~SmbConstants.O_CREAT;
             this.readSize = th.getReceiveBufferSize() - 70;
             this.writeSize = th.getSendBufferSize() - 70;
 

--- a/src/test/java/org/codelibs/jcifs/smb/impl/NetServerEnumIteratorTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/NetServerEnumIteratorTest.java
@@ -19,9 +19,11 @@ import java.net.URL;
 import org.codelibs.jcifs.smb.CIFSException;
 import org.codelibs.jcifs.smb.Configuration;
 import org.codelibs.jcifs.smb.ResourceNameFilter;
+import org.codelibs.jcifs.smb.RuntimeCIFSException;
 import org.codelibs.jcifs.smb.SmbConstants;
 import org.codelibs.jcifs.smb.SmbResource;
 import org.codelibs.jcifs.smb.SmbResourceLocator;
+import org.codelibs.jcifs.smb.internal.CommonServerMessageBlockRequest;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -244,6 +246,103 @@ class NetServerEnumIteratorTest {
 
         // Cleanup
         iterator.close();
+    }
+
+    @Test
+    @DisplayName("A browse cut short by a failure is reported, not passed off as the end of the list")
+    void testIterator_FetchFailureIsReported() throws Exception {
+        // Given: a first page that reports more data to come, so the iterator has an entry to hand out and a reason
+        // to go back for another page
+        when(locator.getType()).thenReturn(SmbConstants.TYPE_WORKGROUP);
+        when(locator.getURL()).thenReturn(createSmbURL("smb://"));
+
+        // The iterator calls the two-argument send(request, response), which reaches the varargs overload with an
+        // empty array. A (RequestParam[]) any() matcher expects an array argument and does not match that, which is
+        // why stubbing it that way leaves the page empty.
+        final java.util.concurrent.atomic.AtomicInteger sends = new java.util.concurrent.atomic.AtomicInteger();
+        when(treeHandle.send(any(CommonServerMessageBlockRequest.class), any())).thenAnswer(invocation -> {
+            if (sends.incrementAndGet() > 1) {
+                // The second page is the one that fails - a dropped connection, a revoked session, anything
+                throw new CIFSException("browse fetch failed");
+            }
+            final Object response = invocation.getArgument(1);
+            // ERROR_MORE_DATA makes advance() yield numEntries - 1 entries and then go back for the rest
+            setPrivate(response, "status", 234); // WinError.ERROR_MORE_DATA
+            setPrivate(response, "numEntries", 2);
+            setPrivate(response, "results", new FileEntry[] { serverEntry("ALPHA"), serverEntry("BETA") });
+            return response;
+        });
+
+        NetServerEnumIterator iterator = new NetServerEnumIterator(parent, treeHandle, "*", 0, null);
+
+        // Then: the entry read before the failure is still handed out ...
+        assertTrue(iterator.hasNext());
+        assertEquals("ALPHA", iterator.next().getName());
+
+        // ... and the caller is told the browse failed, rather than seeing it end quietly at one entry
+        RuntimeCIFSException ex = assertThrows(RuntimeCIFSException.class, iterator::next);
+        assertNotNull(ex.getCause(), "the failure that ended the browse should be the cause");
+        assertEquals("browse fetch failed", ex.getCause().getMessage());
+        assertFalse(iterator.hasNext(), "the iterator is finished once it has reported the failure");
+    }
+
+    /** Sets a private field declared anywhere up the hierarchy; the transaction response keeps these package private. */
+    private static void setPrivate(Object target, String name, Object value) throws Exception {
+        for (Class<?> c = target.getClass(); c != null; c = c.getSuperclass()) {
+            try {
+                java.lang.reflect.Field f = c.getDeclaredField(name);
+                f.setAccessible(true);
+                f.set(target, value);
+                return;
+            } catch (NoSuchFieldException e) {
+                // keep walking up
+            }
+        }
+        throw new NoSuchFieldException(name);
+    }
+
+    private static FileEntry serverEntry(String name) {
+        return new FileEntry() {
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public int getType() {
+                return SmbConstants.TYPE_SERVER;
+            }
+
+            @Override
+            public int getAttributes() {
+                return 0;
+            }
+
+            @Override
+            public long createTime() {
+                return 0;
+            }
+
+            @Override
+            public long lastModified() {
+                return 0;
+            }
+
+            @Override
+            public long lastAccess() {
+                return 0;
+            }
+
+            @Override
+            public long length() {
+                return 0;
+            }
+
+            @Override
+            public int getFileIndex() {
+                return 0;
+            }
+        };
     }
 
     // Helper method to create SMB URLs with proper handler

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbFileOutputStreamTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbFileOutputStreamTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import org.codelibs.jcifs.smb.CIFSException;
 import org.codelibs.jcifs.smb.Configuration;
 import org.codelibs.jcifs.smb.SmbConstants;
+import org.codelibs.jcifs.smb.internal.smb2.io.Smb2FlushRequest;
 import org.codelibs.jcifs.smb.internal.smb2.io.Smb2WriteRequest;
 import org.codelibs.jcifs.smb.internal.smb2.io.Smb2WriteResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -107,6 +108,28 @@ class SmbFileOutputStreamTest {
     }
 
     @Test
+    void testFlushSendsFlushRequest() throws IOException, CIFSException {
+        // Given
+        when(mockTreeHandle.isSMB2()).thenReturn(true);
+        when(mockTreeHandle.getSendBufferSize()).thenReturn(65536);
+        when(mockFileHandle.isValid()).thenReturn(false, true);
+        when(mockFileHandle.getFileId()).thenReturn(new byte[16]);
+        when(mockFileHandle.acquire()).thenReturn(mockFileHandle);
+        when(mockFile.openUnshared(anyInt(), anyInt(), anyInt(), anyInt(), anyInt())).thenReturn(mockFileHandle);
+
+        outputStream = new SmbFileOutputStream(mockFile, mockTreeHandle, mockFileHandle,
+                SmbConstants.O_CREAT | SmbConstants.O_WRONLY | SmbConstants.O_TRUNC, SmbConstants.FILE_WRITE_DATA,
+                SmbConstants.DEFAULT_SHARING);
+
+        // When: a write already went straight to the wire, so there is no local buffer for flush() to push. What it
+        // owes the caller is the durability barrier - without FLUSH the data may still sit in the server's cache.
+        outputStream.flush();
+
+        // Then
+        verify(mockTreeHandle).send(any(Smb2FlushRequest.class), any());
+    }
+
+    @Test
     void testWriteByteArrayWithOffset() throws IOException, CIFSException {
         // Given
         when(mockTreeHandle.isSMB2()).thenReturn(true);
@@ -139,6 +162,10 @@ class SmbFileOutputStreamTest {
         when(mockTreeHandle.isSMB2()).thenReturn(true);
         when(mockTreeHandle.getSendBufferSize()).thenReturn(65536);
         when(mockFileHandle.isValid()).thenReturn(true);
+        // ensureOpen() hands back handle.acquire() for a handle that is already open, so flush() needs this stubbed
+        // as the write tests do. SmbFileHandleImpl.acquire() always returns itself, so it is never null in practice.
+        when(mockFileHandle.acquire()).thenReturn(mockFileHandle);
+        when(mockFileHandle.getFileId()).thenReturn(new byte[16]);
 
         outputStream = new SmbFileOutputStream(mockFile, mockTreeHandle, mockFileHandle,
                 SmbConstants.O_CREAT | SmbConstants.O_WRONLY | SmbConstants.O_TRUNC, SmbConstants.FILE_WRITE_DATA,

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbRandomAccessFileTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbRandomAccessFileTest.java
@@ -80,6 +80,34 @@ public class SmbRandomAccessFileTest {
     }
 
     @Test
+    @DisplayName("Read-only mode does not ask the server to create the file")
+    void readOnlyMode_doesNotRequestCreate() throws Exception {
+        SmbFile file = mock(SmbFile.class);
+        SmbTreeHandleImpl tree = mock(SmbTreeHandleImpl.class);
+        Configuration cfg = mock(Configuration.class);
+        SmbFileHandleImpl fh = mock(SmbFileHandleImpl.class);
+
+        when(file.ensureTreeConnected()).thenReturn(tree);
+        when(tree.getConfig()).thenReturn(cfg);
+        when(tree.getReceiveBufferSize()).thenReturn(1024);
+        when(tree.getSendBufferSize()).thenReturn(1024);
+        when(tree.isSMB2()).thenReturn(true);
+        when(file.openUnshared(anyInt(), anyInt(), anyInt(), anyInt(), anyInt())).thenReturn(fh);
+        when(fh.acquire()).thenReturn(fh);
+        when(fh.isValid()).thenReturn(true);
+
+        new SmbRandomAccessFile(file, "r", SmbConstants.DEFAULT_SHARING, false);
+
+        // O_CREAT becomes FILE_OPEN_IF, which opens a missing file by creating an empty one. Asking for that while
+        // opening read-only is wrong on the first open, and wrong again on every reopen after a dropped connection,
+        // because the flags are replayed as they were.
+        ArgumentCaptor<Integer> flags = ArgumentCaptor.forClass(Integer.class);
+        verify(file).openUnshared(flags.capture(), anyInt(), anyInt(), anyInt(), anyInt());
+        assertEquals(0, flags.getValue() & SmbConstants.O_CREAT,
+                "read-only open must not carry O_CREAT, or a missing file comes back as an empty one");
+    }
+
+    @Test
     @DisplayName("open(): acquires and releases handle (no I/O)")
     void open_acquiresAndReleasesHandle() throws Exception {
         SmbRandomAccessFile raf = spy(newInstance("rw", false, true, false));

--- a/src/test/java/org/codelibs/jcifs/smb/it/RandomAccessOpenIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/RandomAccessOpenIT.java
@@ -1,0 +1,76 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.impl.SmbException;
+import org.codelibs.jcifs.smb.impl.SmbFile;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * What opening a random access file does to a file that is not there.
+ *
+ * <p>
+ * The flags a random access file opens with are replayed whenever its handle has to be reopened, so asking the server
+ * to create the file is not a one-off: it applies again after every dropped connection. A unit test can show which
+ * flags are sent; only a real server shows what they do.
+ * </p>
+ */
+class RandomAccessOpenIT extends AbstractSmbIT {
+
+    private SmbFile workDir;
+
+    @AfterEach
+    void removeWorkDir() {
+        deleteQuietly(this.workDir);
+    }
+
+    @Test
+    @DisplayName("opening a missing file read-only fails instead of creating it")
+    void testReadOnlyOpenDoesNotCreate() throws Exception {
+        final CIFSContext context = server().context();
+        this.workDir = createWorkDir(context, server().share());
+        final SmbFile missing = new SmbFile(this.workDir, "never-written.txt");
+
+        assertFalse(missing.exists(), "the file must not exist for this test to mean anything");
+
+        // The constructor opens the file straight away, so a refused open surfaces here.
+        assertThrows(SmbException.class, () -> missing.openRandomAccess("r"), "opening a file that is not there read-only should fail");
+
+        assertFalse(missing.exists(), "a read-only open must not bring the file into existence");
+    }
+
+    @Test
+    @DisplayName("read-write mode still creates the file, as it always has")
+    void testReadWriteOpenStillCreates() throws Exception {
+        final CIFSContext context = server().context();
+        this.workDir = createWorkDir(context, server().share());
+        final SmbFile created = new SmbFile(this.workDir, "written-by-rw.txt");
+
+        assertFalse(created.exists(), "the file must not exist beforehand");
+
+        created.openRandomAccess("rw").close();
+
+        // Dropping O_CREAT for read-only must not have taken it away from read-write, which callers rely on.
+        assertTrue(created.exists(), "opening read-write should still create the file");
+    }
+}


### PR DESCRIPTION
Three unrelated places where a call returned normally while doing something other than what its name says. Each is small, and they travel together because each also updates `docs/SMB3_SUPPORT.md` — separate branches would conflict there, and stacking three small changes costs more than it buys.

## `flush()` did nothing

`SmbFileOutputStream` never overrode it, so `flush()` was the no-op inherited from `OutputStream`. Every write is sent as it is made, so there was never a buffer to lose — what was missing is the **durability barrier**. A caller that wrote, called `flush()`, saw no error and then lost the server had no way to know the data had only been cached.

It now sends SMB2 FLUSH, which `Smb2FlushRequest` had been built for and nothing called. Two deliberate choices: nothing is sent on SMB1, which has no equivalent request; and the flush is **not** gated on the handle still being valid, because `ensureOpen()` reopens a stale one and a reconnect is exactly when committing matters most.

## An SMB1 browse ended quietly when it failed

`NetServerEnumIterator` logged the failure at warn level and set `next` to null, so a browse cut short looked exactly like a workgroup holding only the servers read so far.

This is the same defect #101 fixed for SMB2 directory listings, in the separate code path that change deliberately left alone and flagged as its own follow-up. It now keeps the same contract: the servers already read are handed out, `RuntimeCIFSException` is thrown once, and the iterator stays exhausted rather than going back to a connection that is already gone.

## A random access file created files it was only asked to read

`SmbRandomAccessFile` set `O_CREAT` even for mode `"r"`. `O_CREAT` becomes `FILE_OPEN_IF`, so `openRandomAccess("r")` on a path that did not exist **created an empty file** instead of failing.

It also persisted: `ensureOpen()` replays the flags exactly as they stand on every reopen, so a dropped connection brought back a file deleted in the meantime. Mode `"r"` no longer sets `O_CREAT`, and the flag is cleared after the first open so no reopen can create anything. Mode `"rw"` still creates the file on its first open, which callers rely on.

## Compatibility

All three change observable behaviour, which is the point, but they are worth stating plainly:

- **`flush()` now costs a round trip and can throw.** Previously it did nothing and could not fail. Code that flushes per record will notice the cost; code that ignored `flush()` failures never had any to ignore.
- **A failed SMB1 browse now throws.** `children()` on a workgroup throws `RuntimeCIFSException` from the iterator; `list()` wraps the same iterator, so it surfaces there the way a failed directory listing already does since #101. A caller that previously got a short list silently now gets an exception.
- **`openRandomAccess("r")` on a missing file now fails.** Anything relying on read-only mode to create the file — deliberately or not — changes behaviour. `"rw"` is unaffected.

## Tests

One unit test per fix, each of which fails against the previous code, with a distinct symptom:

- `SmbFileOutputStreamTest.testFlushSendsFlushRequest` — "Wanted but not invoked: send(Smb2FlushRequest)".
- `NetServerEnumIteratorTest.testIterator_FetchFailureIsReported` — "Expected RuntimeCIFSException to be thrown, but nothing was thrown", after an entry has been handed out and the second page has failed.
- `SmbRandomAccessFileTest.readOnlyMode_doesNotRequestCreate` — the captured open flags contain `O_CREAT` (`expected: <0> but was: <16>`).

`RandomAccessOpenIT` adds what a unit test on flags cannot show: against a real server, a read-only open of a missing file now fails **and leaves no file behind**, and read-write still creates one. The second case is there because dropping `O_CREAT` for `"r"` must not take it away from `"rw"`.

One pre-existing test needed a stubbing fix rather than a contract change: `testFlush` stubbed `isValid()` but not `acquire()`, which only mattered once `flush()` started calling `ensureOpen()`. `SmbFileHandleImpl.acquire()` returns `this` unconditionally, so `ensureOpen()` cannot return null in production — no defensive check was added for a case that cannot happen.

## Verification

Measured on this branch against `main` (`aa68b03`), zero failures everywhere.

| Run | `main` | This branch |
|---|---|---|
| `mvn verify` against the Samba container | 8605 unit, 110 integration (7 skipped) | 8608 unit, 112 integration (7 skipped) |
| `build_helpers/run-it-with-dfs.sh` (Samba on 445, DFS enabled) | 8605 unit, 110 integration (3 skipped) | 8608 unit, 112 integration (3 skipped) |
| `windows-smb` workflow (Windows Server 2025) | 8605 unit, 110 integration (9 skipped) | 8608 unit, 112 integration (9 skipped) |

Three new unit tests and two new integration tests; the skipped tests are the same ones as on `main` in each environment.

`RandomAccessOpenIT` passing on both backends matters more than a single green run: it asserts what the *server* does with the create disposition — that `FILE_OPEN` on a missing file is refused and `FILE_OPEN_IF` creates one — and Samba 4.21.9 and Windows Server 2025 agree. The flag change was read off the code; this is the part that was measured.

`mvn apache-rat:check` passes and `mvn formatter:format` has been applied.
