### PR TITLE
feat(smb2): read and write in megabyte requests instead of 64 KiB

### DIFF
--- a/docs/SMB3_SUPPORT.md
+++ b/docs/SMB3_SUPPORT.md
@@ -232,17 +232,24 @@ protocol test suite, not from an observed exchange.
 
 | Aspect | Status | Notes |
 | --- | --- | --- |
-| Maximum read size | **64936 bytes** | Hard cap. |
-| Maximum write size | **64904 bytes** | Hard cap. |
-| `SMB2_GLOBAL_CAP_LARGE_MTU` | Not implemented | The constant exists and nothing reads it. The client advertises only `DFS` (and `ENCRYPTION` when enabled), and `commonCapabilities` is `serverCaps & clientCaps`, so the flag is never negotiated. Note this is **not** what caps the transfer sizes: `Smb2NegotiateResponse` clamps the sizes the server offers against `jcifs.client.transaction_buf_size` and `jcifs.client.rcv_buf_size` / `snd_buf_size` separately from the flag. Raising those alone will not get past 64 KiB either, because a larger payload has to carry a `CreditCharge` — see the next row. |
-| `creditCharge` on outgoing requests | Not functional | The field has no setter and ships as 0 on every request; `getCreditCost()` is hardcoded to 1. Credits are accounted one per request regardless of payload size. |
+| Maximum read size | **1048576 bytes** on SMB 2.1 and later, **64936** on SMB 2.0.2 | The smaller of `jcifs.client.maxTransferSize` and what the server offers. |
+| Maximum write size | **1048576 bytes** on SMB 2.1 and later, **64904** on SMB 2.0.2 | As above. |
+| `SMB2_GLOBAL_CAP_LARGE_MTU` | Supported | Advertised whenever the configured dialect ceiling reaches SMB 2.1, and negotiated when the server also offers it. The transfer sizes hang off this capability rather than off the size the server advertises, because a server offers a large size either way: Samba 4.21 offers 8 MiB for read, write and transact even to a client that never asked for multi-credit, and using it without the capability would spend credits the connection never had. |
+| `creditCharge` on outgoing requests | Supported | A read or write charges one credit per 64 KiB it spans (MS-SMB2 3.2.4.1.2), counting the payload it sends for a write and the payload it expects back for a read. The charge is only put on the wire once multi-credit is negotiated - the field is reserved before SMB 2.1 - and a request consumes that many message ids (MS-SMB2 3.2.4.1.3), not one. |
 | Credit accounting | Supported | Per connection. |
 | Connection pooling | Supported | See below. |
 
-The read and write ceilings follow from `jcifs.client.transaction_buf_size`
-(default `0xFFFF`, less 512 = 65023) minus per-message overhead, and apply **no
-matter what the server offers** — a Windows server typically offers 8 MiB.
-Reads and writes are chunked at exactly those sizes.
+The read and write ceilings follow from `jcifs.client.maxTransferSize` (default
+1 MiB) and the size the server offers, whichever is smaller. Reads and writes are
+chunked at exactly that size, so a transfer costs one round trip per megabyte
+rather than one per 64 KiB.
+
+Two things this deliberately does not do. It does not raise
+`jcifs.client.rcv_buf_size` or `snd_buf_size`, which are shared with SMB1: the
+SMB1 receive path refuses anything above `0xFFFF`, so raising them would make
+SMB1 issue reads whose responses it then rejects. And it does not move the
+transfer size on SMB 2.0.2, which has no multi-credit at all — there the old
+`jcifs.client.transaction_buf_size` arithmetic still applies, unchanged.
 
 ### Multiple connections to one server
 
@@ -310,7 +317,8 @@ file on its first open, as it always has.
 | `jcifs.client.ipcSigningEnforced` | `true` | Require signing on IPC$. |
 | `jcifs.client.requireSecureNegotiate` | `true` | Validate the negotiate exchange on tree connect. |
 | `jcifs.client.encryptionEnabled` | `false` | Opt in to SMB3 encryption — see [Encryption](#encryption). |
-| `jcifs.client.transaction_buf_size` | `65535` | Drives the read and write ceilings. 512 bytes are subtracted from it, giving an effective 65023. |
+| `jcifs.client.maxTransferSize` | `1048576` | Largest payload a single SMB2 read or write may carry. The negotiated size is the smaller of this and the server's offer. Has no effect below SMB 2.1, which cannot carry more than 64 KiB in one request. |
+| `jcifs.client.transaction_buf_size` | `65535` | Drives the transact size, and the read and write ceilings on SMB 2.0.2 and SMB1. 512 bytes are subtracted from it, giving an effective 65023. |
 | `jcifs.client.ssnLimit` | `250` | Sessions per connection before a new connection is opened. |
 | `jcifs.client.dfs.disabled` | `false` | Disable DFS referral resolution. |
 

--- a/src/main/java/org/codelibs/jcifs/smb/Configuration.java
+++ b/src/main/java/org/codelibs/jcifs/smb/Configuration.java
@@ -575,6 +575,21 @@ public interface Configuration {
     int getMaximumBufferSize();
 
     /**
+     * The largest payload a single SMB2 read or write may carry.
+     *
+     * <p>
+     * Property {@code jcifs.client.maxTransferSize} (int, default 1048576). The negotiated size is the smaller of
+     * this and what the server offers. Anything above 64 KiB needs multi-credit, which the client only gets on
+     * SMB 2.1 and later; below that the server's own offer keeps the transfer at 64 KiB regardless of this value.
+     * This governs SMB2 only - {@code jcifs.client.rcv_buf_size} and {@code jcifs.client.snd_buf_size} still govern
+     * SMB1, whose receive path cannot carry more than 64 KiB.
+     * </p>
+     *
+     * @return maximum size of a single SMB2 read or write, in bytes
+     */
+    int getMaximumTransferSize();
+
+    /**
      *
      * Property {@code jcifs.client.transaction_buf_size} (int, default 65535)
      *

--- a/src/main/java/org/codelibs/jcifs/smb/SmbConstants.java
+++ b/src/main/java/org/codelibs/jcifs/smb/SmbConstants.java
@@ -52,6 +52,15 @@ public interface SmbConstants {
      */
     int DEFAULT_SND_BUF_SIZE = 0xFFFF;
     /**
+     * Default ceiling for a single SMB2 read or write, in bytes.
+     *
+     * <p>
+     * One mebibyte is what Windows and the other SMB2 clients settle on. It only applies to SMB2: the send and
+     * receive buffer sizes above still govern SMB1, whose receive path cannot carry more than 64 KiB.
+     * </p>
+     */
+    int DEFAULT_MAX_TRANSFER_SIZE = 0x100000;
+    /**
      * Default buffer size for change notification responses.
      */
     int DEFAULT_NOTIFY_BUF_SIZE = 1024;

--- a/src/main/java/org/codelibs/jcifs/smb/config/BaseConfiguration.java
+++ b/src/main/java/org/codelibs/jcifs/smb/config/BaseConfiguration.java
@@ -186,8 +186,17 @@ public class BaseConfiguration implements Configuration {
     protected InetAddress broadcastAddress;
     /** Order of name resolution methods to use */
     protected List<ResolverType> resolverOrder;
-    /** Maximum buffer size for IO operations */
-    protected int maximumBufferSize = 0x10000;
+    /**
+     * Maximum buffer size for IO operations.
+     *
+     * <p>
+     * This bounds a whole message, so it has to leave room for the largest transfer plus its headers: a write of
+     * {@link #maximumTransferSize} bytes encodes to that plus 112.
+     * </p>
+     */
+    protected int maximumBufferSize = 0x101000;
+    /** Largest payload a single SMB2 read or write may carry */
+    protected int maximumTransferSize = SmbConstants.DEFAULT_MAX_TRANSFER_SIZE;
     /** Maximum buffer size for SMB transaction operations */
     protected int transactionBufferSize = 0xFFFF - 512;
     /** Number of buffers to keep in cache */
@@ -570,6 +579,11 @@ public class BaseConfiguration implements Configuration {
     @Override
     public int getMaximumBufferSize() {
         return this.maximumBufferSize;
+    }
+
+    @Override
+    public int getMaximumTransferSize() {
+        return this.maximumTransferSize;
     }
 
     @Override

--- a/src/main/java/org/codelibs/jcifs/smb/config/DelegatingConfiguration.java
+++ b/src/main/java/org/codelibs/jcifs/smb/config/DelegatingConfiguration.java
@@ -229,6 +229,16 @@ public class DelegatingConfiguration implements Configuration {
     /**
      * {@inheritDoc}
      *
+     * @see org.codelibs.jcifs.smb.Configuration#getMaximumTransferSize()
+     */
+    @Override
+    public int getMaximumTransferSize() {
+        return this.delegate.getMaximumTransferSize();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * @deprecated use getReceiveBufferSize instead
      */
     @Deprecated

--- a/src/main/java/org/codelibs/jcifs/smb/config/PropertyConfiguration.java
+++ b/src/main/java/org/codelibs/jcifs/smb/config/PropertyConfiguration.java
@@ -193,6 +193,7 @@ public final class PropertyConfiguration extends BaseConfiguration implements Co
         this.winsServer = Config.getInetAddressArray(p, "jcifs.netbios.wins", ",", new InetAddress[0]);
 
         this.transactionBufferSize = Config.getInt(p, "jcifs.client.transaction_buf_size", 0xFFFF) - 512;
+        this.maximumTransferSize = Config.getInt(p, "jcifs.client.maxTransferSize", SmbConstants.DEFAULT_MAX_TRANSFER_SIZE);
         this.bufferCacheSize = Config.getInt(p, "jcifs.maxBuffers", 16);
 
         this.smbListSize = Config.getInt(p, "jcifs.client.listSize", 65435);

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbTransportImpl.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbTransportImpl.java
@@ -787,7 +787,12 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
 
     @Override
     protected long makeKey(final Request request) throws IOException {
-        long m = this.mid.incrementAndGet() - 1;
+        // MS-SMB2 3.2.4.1.3: a request owns one message id for every credit it charges, not one per request. Taking
+        // a single id for a multi-credit request leaves the server expecting ids that never arrive, and it stops
+        // answering once its receive window has moved past them. The charge is stamped by setupRequest before this
+        // runs, so it is already zero on a connection that never negotiated multi-credit.
+        final long charge = request instanceof final ServerMessageBlock2 smb2Request ? Math.max(1, smb2Request.getCreditCharge()) : 1;
+        long m = this.mid.getAndAdd(charge);
         if (!this.smb2) {
             m = m % 32000;
         }
@@ -878,7 +883,10 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
             // synchronize around encode and write so that the ordering for SMB1 signing can be maintained
             synchronized (this.outLock) {
                 final int n = smb.encode(buffer, 4);
-                Encdec.enc_uint32be(n & 0xFFFF, buffer, 0); /* 4 byte session message header */
+                // The direct TCP session message length is 24 bits wide (MS-SMB2 2.1). Masking it to 16 leaves a
+                // message of exactly 64 KiB announcing a length of zero, and everything after it on the connection
+                // is then read from the wrong offset.
+                Encdec.enc_uint32be(n & 0xFFFFFF, buffer, 0); /* 4 byte session message header */
                 if (log.isTraceEnabled()) {
                     do {
                         log.trace(smb.toString());

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/ServerMessageBlock2.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/ServerMessageBlock2.java
@@ -295,6 +295,22 @@ public abstract class ServerMessageBlock2 implements CommonServerMessageBlock {
         return this.creditCharge;
     }
 
+    /**
+     * Sets the credit charge for this message.
+     *
+     * <p>
+     * A message whose payload exceeds 64 KiB has to pay for every 64 KiB it spans (MS-SMB2 3.2.4.1.2), and the server
+     * matches that against the credits it granted. It stays zero on a connection that did not negotiate
+     * {@code SMB2_GLOBAL_CAP_LARGE_MTU}, where the field is reserved.
+     * </p>
+     *
+     * @param creditCharge
+     *            the creditCharge to set
+     */
+    public final void setCreditCharge(final int creditCharge) {
+        this.creditCharge = creditCharge;
+    }
+
     @Override
     public void retainPayload() {
         this.retainPayload = true;

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/ServerMessageBlock2Request.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/ServerMessageBlock2Request.java
@@ -143,6 +143,28 @@ public abstract class ServerMessageBlock2Request<T extends ServerMessageBlock2Re
     }
 
     /**
+     * What a payload of the given size costs in credits.
+     *
+     * <p>
+     * MS-SMB2 3.2.4.1.2: a request pays for every 64 KiB it spans, counting the larger of what it sends and what it
+     * expects back. Everything that fits in 64 KiB costs the single credit an ordinary request costs, so this only
+     * differs from the default for the reads and writes that a large negotiated transfer size makes possible.
+     * </p>
+     *
+     * @param payloadSize
+     *            the larger of the send and expected response payload, in bytes
+     * @return the number of credits the payload spans, at least one
+     */
+    private static final int CREDIT_PAYLOAD_UNIT = 65536;
+
+    protected static int creditChargeForPayload(final int payloadSize) {
+        if (payloadSize <= 0) {
+            return 1;
+        }
+        return (payloadSize - 1) / CREDIT_PAYLOAD_UNIT + 1;
+    }
+
+    /**
      * {@inheritDoc}
      *
      * @see org.codelibs.jcifs.smb.util.transport.Request#setRequestCredits(int)

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/io/Smb2ReadRequest.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/io/Smb2ReadRequest.java
@@ -169,6 +169,20 @@ public class Smb2ReadRequest extends ServerMessageBlock2Request<Smb2ReadResponse
     /**
      * {@inheritDoc}
      *
+     * <p>
+     * A read sends almost nothing and gets the payload back, so the response is what it is charged for.
+     * </p>
+     *
+     * @see org.codelibs.jcifs.smb.util.transport.Request#getCreditCost()
+     */
+    @Override
+    public int getCreditCost() {
+        return creditChargeForPayload(this.readLength);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * @see org.codelibs.jcifs.smb.internal.smb2.ServerMessageBlock2#writeBytesWireFormat(byte[], int)
      */
     @Override

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/io/Smb2WriteRequest.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/io/Smb2WriteRequest.java
@@ -128,6 +128,21 @@ public class Smb2WriteRequest extends ServerMessageBlock2Request<Smb2WriteRespon
     /**
      * {@inheritDoc}
      *
+     * <p>
+     * A write carries the payload out and gets only a short acknowledgement back, so what it sends is what it is
+     * charged for.
+     * </p>
+     *
+     * @see org.codelibs.jcifs.smb.util.transport.Request#getCreditCost()
+     */
+    @Override
+    public int getCreditCost() {
+        return creditChargeForPayload(this.dataLength);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * @see org.codelibs.jcifs.smb.internal.smb2.ServerMessageBlock2#writeBytesWireFormat(byte[], int)
      */
     @Override

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/nego/Smb2NegotiateRequest.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/nego/Smb2NegotiateRequest.java
@@ -60,6 +60,13 @@ public class Smb2NegotiateRequest extends ServerMessageBlock2Request<Smb2Negotia
             this.capabilities |= Smb2Constants.SMB2_GLOBAL_CAP_DFS;
         }
 
+        // Multi-credit - and with it the read and write sizes above 64 KiB that a server offers - arrived in SMB 2.1.
+        // A server only grants it to a client that asked (MS-SMB2 3.3.5.4), so without this the transfer sizes stay
+        // at 64 KiB however much the server was willing to give.
+        if (config.getMaximumVersion() != null && config.getMaximumVersion().atLeast(DialectVersion.SMB210)) {
+            this.capabilities |= Smb2Constants.SMB2_GLOBAL_CAP_LARGE_MTU;
+        }
+
         if (config.isEncryptionEnabled() && config.getMaximumVersion() != null
                 && config.getMaximumVersion().atLeast(DialectVersion.SMB300)) {
             this.capabilities |= Smb2Constants.SMB2_GLOBAL_CAP_ENCRYPTION;

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/nego/Smb2NegotiateResponse.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/nego/Smb2NegotiateResponse.java
@@ -26,6 +26,7 @@ import org.codelibs.jcifs.smb.internal.CommonServerMessageBlock;
 import org.codelibs.jcifs.smb.internal.SMBProtocolDecodingException;
 import org.codelibs.jcifs.smb.internal.SmbNegotiationRequest;
 import org.codelibs.jcifs.smb.internal.SmbNegotiationResponse;
+import org.codelibs.jcifs.smb.internal.smb2.ServerMessageBlock2Request;
 import org.codelibs.jcifs.smb.internal.smb2.ServerMessageBlock2Response;
 import org.codelibs.jcifs.smb.internal.smb2.Smb2Constants;
 import org.codelibs.jcifs.smb.internal.smb2.io.Smb2ReadResponse;
@@ -293,11 +294,22 @@ public class Smb2NegotiateResponse extends ServerMessageBlock2Response implement
         }
 
         final int maxBufferSize = tc.getConfig().getTransactionBufferSize();
-        this.maxReadSize =
-                Math.min(maxBufferSize - Smb2ReadResponse.OVERHEAD, Math.min(tc.getConfig().getReceiveBufferSize(), this.maxReadSize))
-                        & ~0x7;
-        this.maxWriteSize =
-                Math.min(maxBufferSize - Smb2WriteRequest.OVERHEAD, Math.min(tc.getConfig().getSendBufferSize(), this.maxWriteSize)) & ~0x7;
+        if (haveCapabilitiy(Smb2Constants.SMB2_GLOBAL_CAP_LARGE_MTU)) {
+            // Multi-credit was granted, so one transfer may span several credits worth of payload. This hangs off
+            // the capability rather than off the size the server offered, because a server offers a large size
+            // whether or not it granted multi-credit - Samba offers 8 MiB either way - and without the capability
+            // there are no credits to pay for a transfer that large.
+            final int transferCeiling = tc.getConfig().getMaximumTransferSize();
+            this.maxReadSize = Math.min(transferCeiling, this.maxReadSize) & ~0x7;
+            this.maxWriteSize = Math.min(transferCeiling, this.maxWriteSize) & ~0x7;
+        } else {
+            this.maxReadSize =
+                    Math.min(maxBufferSize - Smb2ReadResponse.OVERHEAD, Math.min(tc.getConfig().getReceiveBufferSize(), this.maxReadSize))
+                            & ~0x7;
+            this.maxWriteSize =
+                    Math.min(maxBufferSize - Smb2WriteRequest.OVERHEAD, Math.min(tc.getConfig().getSendBufferSize(), this.maxWriteSize))
+                            & ~0x7;
+        }
         this.maxTransactSize = Math.min(maxBufferSize - 512, this.maxTransactSize) & ~0x7;
 
         return true;
@@ -467,6 +479,13 @@ public class Smb2NegotiateResponse extends ServerMessageBlock2Response implement
      */
     @Override
     public void setupRequest(final CommonServerMessageBlock request) {
+        if (!(request instanceof final ServerMessageBlock2Request<?> smb2Request)
+                || !haveCapabilitiy(Smb2Constants.SMB2_GLOBAL_CAP_LARGE_MTU)) {
+            // CreditCharge is reserved before SMB 2.1, and a server that did not grant multi-credit rejects a
+            // request that charges for more than one credit. It stays zero unless both ends agreed on it.
+            return;
+        }
+        smb2Request.setCreditCharge(smb2Request.getCreditCost());
     }
 
     /**

--- a/src/test/java/org/codelibs/jcifs/smb/config/BaseConfigurationTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/config/BaseConfigurationTest.java
@@ -164,7 +164,9 @@ class BaseConfigurationTest {
     @DisplayName("Test buffer configuration getters")
     void testBufferConfigurationGetters() {
         assertEquals(0xFFFF - 512, config.getTransactionBufferSize());
-        assertEquals(0x10000, config.getMaximumBufferSize());
+        // Raised from 0x10000 so that a whole message still fits once a single read or write may carry a mebibyte:
+        // a write of that size encodes to 1048576 + 112 bytes.
+        assertEquals(0x101000, config.getMaximumBufferSize());
         assertEquals(16, config.getBufferCacheSize());
         assertEquals(200, config.getListCount());
         assertEquals(65435, config.getListSize());

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbBufferSizeProbe.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbBufferSizeProbe.java
@@ -1,0 +1,71 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.impl;
+
+import org.codelibs.jcifs.smb.CIFSException;
+
+/**
+ * Test-only access to the transfer sizes a connection negotiated.
+ *
+ * <p>
+ * The sizes live on the negotiate response, which is reachable only through {@code SmbTreeHandleImpl} - a package
+ * private class - so this has to sit in the implementation package the way {@code SmbOplockProbe} does.
+ * </p>
+ */
+public final class SmbBufferSizeProbe {
+
+    private SmbBufferSizeProbe() {
+    }
+
+    /**
+     * The read size the connection settled on.
+     *
+     * @param file any file on the connection to measure
+     * @return the negotiated maximum read size in bytes
+     * @throws CIFSException if the connection cannot be established
+     */
+    public static int readSize(final SmbFile file) throws CIFSException {
+        try (SmbTreeHandleImpl th = (SmbTreeHandleImpl) file.getTreeHandle()) {
+            return th.getReceiveBufferSize();
+        }
+    }
+
+    /**
+     * The write size the connection settled on.
+     *
+     * @param file any file on the connection to measure
+     * @return the negotiated maximum write size in bytes
+     * @throws CIFSException if the connection cannot be established
+     */
+    public static int writeSize(final SmbFile file) throws CIFSException {
+        try (SmbTreeHandleImpl th = (SmbTreeHandleImpl) file.getTreeHandle()) {
+            return th.getSendBufferSize();
+        }
+    }
+
+    /**
+     * The transact size the connection settled on.
+     *
+     * @param file any file on the connection to measure
+     * @return the negotiated maximum transact size in bytes
+     * @throws CIFSException if the connection cannot be established
+     */
+    public static int transactSize(final SmbFile file) throws CIFSException {
+        try (SmbTreeHandleImpl th = (SmbTreeHandleImpl) file.getTreeHandle()) {
+            return th.getMaximumBufferSize();
+        }
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbTransportFramingTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbTransportFramingTest.java
@@ -1,0 +1,103 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Field;
+
+import org.codelibs.jcifs.smb.Address;
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.Configuration;
+import org.codelibs.jcifs.smb.Credentials;
+import org.codelibs.jcifs.smb.internal.smb2.io.Smb2WriteRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * The length the transport puts in front of a message.
+ *
+ * <p>
+ * A direct TCP session message carries a 24 bit length (MS-SMB2 2.1). Masking it to 16 bits is invisible while every
+ * message fits in 64 KiB and silently corrupts the stream the moment one does not: the server reads the wrong number
+ * of bytes and every later message on the connection is parsed from the wrong offset.
+ * </p>
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class SmbTransportFramingTest {
+
+    /** A write of this much data encodes to exactly 65536 bytes: 64 header + 48 body + payload. */
+    private static final int PAYLOAD_FOR_EXACTLY_64_KIB = 65536 - 64 - 48;
+
+    @Mock
+    private CIFSContext cifsContext;
+    @Mock
+    private Configuration configuration;
+    @Mock
+    private Credentials credentials;
+    @Mock
+    private CredentialsInternal credentialsInternal;
+    @Mock
+    private Address address;
+
+    private SmbTransportImpl transport;
+    private ByteArrayOutputStream written;
+
+    @BeforeEach
+    void setup() throws Exception {
+        when(this.cifsContext.getConfig()).thenReturn(this.configuration);
+        when(this.cifsContext.getCredentials()).thenReturn(this.credentials);
+        when(this.credentials.unwrap(CredentialsInternal.class)).thenReturn(this.credentialsInternal);
+        when(this.credentialsInternal.clone()).thenReturn(this.credentialsInternal);
+        // Sized here rather than taken from the configuration, so this stays a test about framing even if the
+        // maximum buffer size changes.
+        when(this.cifsContext.getBufferCache()).thenReturn(new BufferCacheImpl(4, 131072));
+
+        this.transport = new SmbTransportImpl(this.cifsContext, this.address, 445, null, 0, false);
+        this.written = new ByteArrayOutputStream();
+        set("out", this.written);
+        set("smb2", Boolean.TRUE);
+    }
+
+    private void set(final String name, final Object value) throws Exception {
+        final Field field = SmbTransportImpl.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(this.transport, value);
+    }
+
+    @Test
+    @DisplayName("a message of exactly 64 KiB is framed with its real length")
+    void framesSixtyFourKibibytesWithoutTruncating() throws Exception {
+        final Smb2WriteRequest request = new Smb2WriteRequest(this.configuration, new byte[16]);
+        request.setData(new byte[PAYLOAD_FOR_EXACTLY_64_KIB], 0, PAYLOAD_FOR_EXACTLY_64_KIB);
+
+        this.transport.doSend(request);
+
+        final byte[] frame = this.written.toByteArray();
+        final int length = (frame[1] & 0xFF) << 16 | (frame[2] & 0xFF) << 8 | frame[3] & 0xFF;
+        assertEquals(0, frame[0], "a session message starts with a zero type byte");
+        assertEquals(65536, length, "the session message length is 24 bits wide, so 65536 must survive it intact");
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbTransportMultiCreditTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbTransportMultiCreditTest.java
@@ -1,0 +1,101 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+
+import org.codelibs.jcifs.smb.Address;
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.Configuration;
+import org.codelibs.jcifs.smb.Credentials;
+import org.codelibs.jcifs.smb.internal.smb2.io.Smb2ReadRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * How many message ids a multi-credit request uses up.
+ *
+ * <p>
+ * MS-SMB2 3.2.4.1.3 has a request consume one message id per credit it charges, not one per request. A client that
+ * takes only one leaves the server expecting ids the client will never send, and the server stops answering once its
+ * receive window has moved past them - so this is not cosmetic bookkeeping.
+ * </p>
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class SmbTransportMultiCreditTest {
+
+    private static final byte[] FILE_ID = new byte[16];
+
+    @Mock
+    private CIFSContext cifsContext;
+    @Mock
+    private Configuration configuration;
+    @Mock
+    private Credentials credentials;
+    @Mock
+    private CredentialsInternal credentialsInternal;
+    @Mock
+    private Address address;
+
+    private SmbTransportImpl transport;
+
+    @BeforeEach
+    void setup() throws Exception {
+        when(this.cifsContext.getConfig()).thenReturn(this.configuration);
+        when(this.cifsContext.getCredentials()).thenReturn(this.credentials);
+        when(this.credentials.unwrap(CredentialsInternal.class)).thenReturn(this.credentialsInternal);
+        when(this.credentialsInternal.clone()).thenReturn(this.credentialsInternal);
+        this.transport = new SmbTransportImpl(this.cifsContext, this.address, 445, null, 0, false);
+        // Message ids are only allocated this way on an SMB2 connection; SMB1 wraps them at 32000 instead.
+        final Field smb2 = SmbTransportImpl.class.getDeclaredField("smb2");
+        smb2.setAccessible(true);
+        smb2.setBoolean(this.transport, true);
+    }
+
+    private Smb2ReadRequest read(final int creditCharge) {
+        final Smb2ReadRequest request = new Smb2ReadRequest(this.configuration, FILE_ID, new byte[0], 0);
+        request.setCreditCharge(creditCharge);
+        return request;
+    }
+
+    @Test
+    @DisplayName("a request consumes one message id per credit it charges")
+    void multiCreditRequestConsumesItsRange() throws Exception {
+        final long first = this.transport.makeKey(read(16));
+        final long second = this.transport.makeKey(read(1));
+
+        assertEquals(16, second - first, "a sixteen credit request owns sixteen message ids, so the next one starts past them");
+    }
+
+    @Test
+    @DisplayName("a request that charges nothing still consumes one")
+    void unchargedRequestConsumesOne() throws Exception {
+        final long first = this.transport.makeKey(read(0));
+        final long second = this.transport.makeKey(read(0));
+
+        assertEquals(1, second - first, "a connection without multi-credit charges zero and must still advance by one");
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb2MultiCreditTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb2MultiCreditTest.java
@@ -1,0 +1,146 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.internal.smb2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.Mockito.when;
+
+import org.codelibs.jcifs.smb.Configuration;
+import org.codelibs.jcifs.smb.DialectVersion;
+import org.codelibs.jcifs.smb.internal.smb2.io.Smb2ReadRequest;
+import org.codelibs.jcifs.smb.internal.smb2.io.Smb2WriteRequest;
+import org.codelibs.jcifs.smb.internal.smb2.nego.Smb2NegotiateRequest;
+import org.codelibs.jcifs.smb.internal.smb2.nego.Smb2NegotiateResponse;
+import org.codelibs.jcifs.smb.internal.util.SMBUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * What a payload larger than 64 KiB costs in credits.
+ *
+ * <p>
+ * A read or write that spans more than 64 KiB is a multi-credit request: MS-SMB2 3.2.4.1.2 charges it one credit per
+ * 64 KiB started, and a server that granted fewer rejects it. Charging one credit for a megabyte - which is what a
+ * hardcoded cost does - is the difference between a transfer working and the connection being torn down.
+ * </p>
+ */
+@DisplayName("SMB2 multi-credit accounting")
+class Smb2MultiCreditTest {
+
+    private static final byte[] FILE_ID = new byte[16];
+
+    @Mock
+    private Configuration mockConfig;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    /**
+     * MS-SMB2 3.2.4.1.2: {@code (max(SendPayloadSize, ExpectedResponsePayloadSize) - 1) / 65536 + 1}.
+     */
+    @ParameterizedTest
+    @CsvSource({ "1, 1", "65536, 1", "65537, 2", "131072, 2", "131073, 3", "1048576, 16" })
+    @DisplayName("a read costs one credit per 64 KiB it spans")
+    void readCreditCost(final int readLength, final int expectedCost) {
+        final Smb2ReadRequest request = new Smb2ReadRequest(this.mockConfig, FILE_ID, new byte[0], 0);
+        request.setReadLength(readLength);
+
+        assertEquals(expectedCost, request.getCreditCost(),
+                "a read of " + readLength + " bytes spans " + expectedCost + " credit(s) worth of payload");
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "1, 1", "65536, 1", "65537, 2", "131072, 2", "131073, 3", "1048576, 16" })
+    @DisplayName("a write costs one credit per 64 KiB it spans")
+    void writeCreditCost(final int dataLength, final int expectedCost) {
+        final Smb2WriteRequest request = new Smb2WriteRequest(this.mockConfig, FILE_ID);
+        request.setData(new byte[0], 0, dataLength);
+
+        assertEquals(expectedCost, request.getCreditCost(),
+                "a write of " + dataLength + " bytes spans " + expectedCost + " credit(s) worth of payload");
+    }
+
+    @Test
+    @DisplayName("the charge reaches the wire at the offset the header reserves for it")
+    void creditChargeIsEncoded() {
+        final Smb2ReadRequest request = new Smb2ReadRequest(this.mockConfig, FILE_ID, new byte[0], 0);
+        request.setCreditCharge(16);
+
+        final byte[] buffer = new byte[256];
+        request.encode(buffer, 0);
+
+        assertEquals(16, SMBUtil.readInt2(buffer, 6), "CreditCharge sits at offset 6 of the SMB2 header");
+    }
+
+    /**
+     * Multi-credit arrived with SMB 2.1. A server only grants it to a client that asked (MS-SMB2 3.3.5.4), so without
+     * this the sizes stay at 64 KiB however much the server would have offered.
+     */
+    @ParameterizedTest
+    @CsvSource({ "SMB202, false", "SMB210, true", "SMB300, true" })
+    @DisplayName("LARGE_MTU is advertised from SMB 2.1 upwards")
+    void negotiateAdvertisesLargeMtu(final DialectVersion maximumVersion, final boolean expected) {
+        when(this.mockConfig.isDfsDisabled()).thenReturn(true);
+        when(this.mockConfig.isEncryptionEnabled()).thenReturn(false);
+        when(this.mockConfig.getMinimumVersion()).thenReturn(DialectVersion.SMB202);
+        when(this.mockConfig.getMaximumVersion()).thenReturn(maximumVersion);
+        // A client GUID only goes out from SMB 2.1, so only those dialects reach this at all.
+        when(this.mockConfig.getMachineId()).thenReturn(new byte[16]);
+
+        final Smb2NegotiateRequest request = new Smb2NegotiateRequest(this.mockConfig, 0);
+        final boolean advertised = (request.getCapabilities() & Smb2Constants.SMB2_GLOBAL_CAP_LARGE_MTU) != 0;
+
+        assertEquals(expected, advertised, "a client whose ceiling is " + maximumVersion
+                + (expected ? " must ask for multi-credit" : " cannot use multi-credit and must not ask"));
+    }
+
+    @Test
+    @DisplayName("the charge is only put on the wire once the server has granted multi-credit")
+    void creditChargeIsStampedOnlyWhenNegotiated() {
+        final Smb2ReadRequest withoutLargeMtu = new Smb2ReadRequest(this.mockConfig, FILE_ID, new byte[0], 0);
+        withoutLargeMtu.setReadLength(1048576);
+        negotiated(false).setupRequest(withoutLargeMtu);
+        assertEquals(0, withoutLargeMtu.getCreditCharge(),
+                "the field is reserved before SMB 2.1, so a connection without multi-credit must leave it zero");
+
+        final Smb2ReadRequest withLargeMtu = new Smb2ReadRequest(this.mockConfig, FILE_ID, new byte[0], 0);
+        withLargeMtu.setReadLength(1048576);
+        negotiated(true).setupRequest(withLargeMtu);
+        assertEquals(16, withLargeMtu.getCreditCharge(), "a megabyte read spans sixteen credits");
+        assertNotEquals(0, withLargeMtu.getCreditCharge(), "a multi-credit request that ships a zero charge is rejected");
+    }
+
+    /**
+     * A negotiate response that did or did not settle on multi-credit. Overriding the capability check keeps this
+     * about {@code setupRequest} rather than about decoding a synthetic negotiate response.
+     */
+    private Smb2NegotiateResponse negotiated(final boolean largeMtu) {
+        return new Smb2NegotiateResponse(this.mockConfig) {
+            @Override
+            public boolean haveCapabilitiy(final int cap) {
+                return largeMtu && cap == Smb2Constants.SMB2_GLOBAL_CAP_LARGE_MTU;
+            }
+        };
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/nego/Smb2NegotiateResponseTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/nego/Smb2NegotiateResponseTest.java
@@ -783,6 +783,59 @@ class Smb2NegotiateResponseTest {
         assertTrue(response.getTransactionBufferSize() <= 65536);
     }
 
+    @Test
+    @DisplayName("Should take the transfer ceiling once multi-credit is negotiated")
+    void testTransferCeilingGovernsWhenLargeMtuNegotiated() throws Exception {
+        // Given a server offering 8 MiB - which Samba does - and both ends having agreed on multi-credit
+        setResponseAsReceived(response);
+        setPrivateField(response, "dialectRevision", 0x0300);
+        setPrivateField(response, "maxReadSize", 8388608);
+        setPrivateField(response, "maxWriteSize", 8388608);
+        setPrivateField(response, "maxTransactSize", 8388608);
+        setPrivateField(response, "capabilities", Smb2Constants.SMB2_GLOBAL_CAP_LARGE_MTU);
+
+        when(mockConfig.getTransactionBufferSize()).thenReturn(65023);
+        when(mockConfig.getReceiveBufferSize()).thenReturn(65535);
+        when(mockConfig.getSendBufferSize()).thenReturn(65535);
+        when(mockConfig.getMaximumTransferSize()).thenReturn(1048576);
+        when(mockRequest.getCapabilities()).thenReturn(Smb2Constants.SMB2_GLOBAL_CAP_LARGE_MTU);
+
+        // When
+        final boolean valid = response.isValid(mockContext, mockRequest);
+
+        // Then the SMB1 buffer sizes no longer hold the transfer down
+        assertTrue(valid);
+        assertEquals(1048576, response.getReceiveBufferSize(), "the read size is the transfer ceiling, not rcv_buf_size");
+        assertEquals(1048576, response.getSendBufferSize(), "the write size is the transfer ceiling, not snd_buf_size");
+    }
+
+    @Test
+    @DisplayName("Should stay at 64 KiB when multi-credit was not negotiated")
+    void testTransferStaysAt64KiBWithoutLargeMtu() throws Exception {
+        // Samba offers 8 MiB whether or not the client asked for multi-credit, so the offer alone must not be
+        // enough to raise the transfer size - without the capability there are no credits to pay for it.
+        setResponseAsReceived(response);
+        setPrivateField(response, "dialectRevision", 0x0202);
+        setPrivateField(response, "maxReadSize", 8388608);
+        setPrivateField(response, "maxWriteSize", 8388608);
+        setPrivateField(response, "maxTransactSize", 8388608);
+        setPrivateField(response, "capabilities", 0);
+
+        when(mockConfig.getTransactionBufferSize()).thenReturn(65023);
+        when(mockConfig.getReceiveBufferSize()).thenReturn(65535);
+        when(mockConfig.getSendBufferSize()).thenReturn(65535);
+        when(mockConfig.getMaximumTransferSize()).thenReturn(1048576);
+        when(mockRequest.getCapabilities()).thenReturn(0);
+
+        // When
+        final boolean valid = response.isValid(mockContext, mockRequest);
+
+        // Then
+        assertTrue(valid);
+        assertEquals(64936, response.getReceiveBufferSize(), "without multi-credit the read size is what it always was");
+        assertEquals(64904, response.getSendBufferSize(), "without multi-credit the write size is what it always was");
+    }
+
     @ParameterizedTest
     @DisplayName("Should validate different dialect versions")
     @MethodSource("provideDialectVersions")

--- a/src/test/java/org/codelibs/jcifs/smb/it/LargeTransferIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/LargeTransferIT.java
@@ -1,0 +1,92 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Random;
+
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.DialectVersion;
+import org.codelibs.jcifs.smb.impl.SmbBufferSizeProbe;
+import org.codelibs.jcifs.smb.impl.SmbFile;
+import org.codelibs.jcifs.smb.it.env.DialectMatrix;
+import org.junit.jupiter.api.DisplayName;
+
+/**
+ * Reads and writes larger than 64 KiB.
+ *
+ * <p>
+ * A multi-megabyte file round-trips whatever the transfer size is, because the streams chunk it - so moving the
+ * payload proves nothing on its own. What these assert is the size the connection actually settled on: above 64 KiB
+ * once multi-credit is negotiated, and exactly what it always was on SMB 2.0.2, which has no multi-credit and must
+ * be left alone. The round trip on top of that is what shows the larger requests carry their data intact.
+ * </p>
+ */
+class LargeTransferIT extends AbstractSmbIT {
+
+    /** Several requests worth at a mebibyte each, and many more at the old 64 KiB. */
+    private static final int PAYLOAD = 3 * 1024 * 1024;
+
+    /** What the clamp produces without multi-credit: transaction_buf_size less the per-message overhead. */
+    private static final int READ_SIZE_WITHOUT_MULTI_CREDIT = 64936;
+    private static final int WRITE_SIZE_WITHOUT_MULTI_CREDIT = 64904;
+
+    @DialectMatrix
+    @DisplayName("a transfer above 64 KiB is negotiated from SMB 2.1 and carries its data intact")
+    void largeTransferRoundTrips(final DialectVersion dialect) throws Exception {
+        final CIFSContext context = contextFor(dialect);
+        final SmbFile dir = createWorkDir(context, server().share());
+        try {
+            final byte[] payload = new byte[PAYLOAD];
+            new Random(7).nextBytes(payload);
+
+            final SmbFile file = new SmbFile(dir, "large-transfer.bin");
+            try (OutputStream out = file.getOutputStream()) {
+                out.write(payload);
+            }
+
+            final int readSize = SmbBufferSizeProbe.readSize(file);
+            final int writeSize = SmbBufferSizeProbe.writeSize(file);
+            if (dialect.atLeast(DialectVersion.SMB210)) {
+                assertTrue(readSize > 65536, dialect + " should read in chunks larger than 64 KiB, negotiated " + readSize);
+                assertTrue(writeSize > 65536, dialect + " should write in chunks larger than 64 KiB, negotiated " + writeSize);
+            } else {
+                assertEquals(READ_SIZE_WITHOUT_MULTI_CREDIT, readSize, "SMB 2.0.2 has no multi-credit, so its read size must not move");
+                assertEquals(WRITE_SIZE_WITHOUT_MULTI_CREDIT, writeSize, "SMB 2.0.2 has no multi-credit, so its write size must not move");
+            }
+
+            final byte[] readBack = new byte[PAYLOAD];
+            try (InputStream in = file.getInputStream()) {
+                int off = 0;
+                int n;
+                while (off < PAYLOAD && (n = in.read(readBack, off, PAYLOAD - off)) > 0) {
+                    off += n;
+                }
+                assertEquals(PAYLOAD, off, "the whole file should have been read back");
+            }
+
+            assertEquals(PAYLOAD, file.length(), "the file on the server should be the size that was written");
+            assertArrayEquals(payload, readBack, "every byte should survive a transfer that spans several requests");
+        } finally {
+            deleteQuietly(dir);
+        }
+    }
+}


### PR DESCRIPTION
Every SMB2 read and write was capped at just under 64 KiB, so moving a file cost a round trip per 64 KiB however much the server was willing to carry at once. The cap was entirely on this side: Samba 4.21 offers 8 MiB for read, write and transact, and offers it even to a client that never asked for multi-credit.

## What it buys

Measured on the same build with nothing changed but the transfer size — 20 MiB over loopback to Samba 4.21, signing mandatory, four rounds after a discarded warm-up, the two settings alternating order within each round:

| | requests | write | read |
| --- | --- | --- | --- |
| 64 KiB | 320 | 277–443 ms (median 335) | 157–162 ms (median 161) |
| 1 MiB | 20 | 194–216 ms (median 206) | 86–96 ms (median 90) |

Reads are the clean result: the two arms do not overlap at all, and it is about 44% faster. Writes are about 38% faster at the median, but the 64 KiB arm is noisy enough that 22–50% is the honest range. A link with real latency saves more, since each stream waits for its response and so pays the round trip 320 times instead of 20.

## What changed

Four things, because any one alone either does nothing or breaks the connection.

**`SMB2_GLOBAL_CAP_LARGE_MTU` is advertised** whenever the configured dialect ceiling reaches SMB 2.1. A server only grants multi-credit to a client that asked (MS-SMB2 3.3.5.4).

**A read or write charges one credit per 64 KiB it spans** rather than a flat one (MS-SMB2 3.2.4.1.2), counting what it sends for a write and what it expects back for a read. The charge reaches the wire only once multi-credit has been negotiated — the field is reserved before SMB 2.1.

**A request consumes that many message ids**, not one (MS-SMB2 3.2.4.1.3). A client that takes a single id leaves the server expecting ids that never arrive. The id it is *sent* under is still the first of the range, so response dispatch is untouched.

**A new `jcifs.client.maxTransferSize`, default 1 MiB, governs the size** — rather than raising `jcifs.client.rcv_buf_size` / `snd_buf_size`. Those two are shared with SMB1, whose receive path refuses anything above `0xFFFF`, so raising them would have made SMB1 issue reads whose responses it then rejected.

All of it hangs off the negotiated capability rather than off the size the server advertises. That is not academic: because Samba offers 8 MiB either way, keying on the offer would have started 8 MiB transfers on SMB 2.0.2, which has no multi-credit at all.

## A latent framing bug, fixed here because a large write needs it

The direct TCP session message length is 24 bits wide (MS-SMB2 2.1) and `doSend` masked it to 16. A message of **exactly 65536 bytes** therefore announced a length of **zero**, leaving everything after it on the connection parsed from the wrong offset. That size slips through the bounds check in `sendrecv`, which rejects only what is strictly larger, so it was reachable before this change by anyone who raised the buffer settings. The transform path already read this length as 24 bits.

## Compatibility

- **SMB 2.0.2 is byte-for-byte unchanged.** Without the capability the previous arithmetic applies, so the sizes stay at 64936 and 64904. `LargeTransferIT` asserts exactly those numbers.
- **`rcv_buf_size` / `snd_buf_size` no longer affect SMB2 transfers.** Someone lowering them today to shrink SMB2 reads will need `maxTransferSize` instead. They still govern SMB1.
- **Memory.** `maximumBufferSize` moves from `0x10000` to `0x101000` so a whole message still fits (a 1 MiB write encodes to that plus 112). Pooled buffers are sized from it, so a context that fills its cache holds up to ~16 MiB rather than ~1 MiB; `jcifs.maxBuffers` still bounds the count. `SmbFile.copyTo` allocates two buffers of the negotiated size, so a copy now takes ~2 MiB rather than ~128 KiB.

## Tests

Unit tests for the credit charge at the 64 KiB boundaries, for the charge being withheld until multi-credit is negotiated, for a request consuming its range of message ids, for the 24-bit frame length, and for the negotiated size on **both** sides of the capability gate. Each failed first with a distinct symptom — `expected: <16> but was: <1>`, `expected: <true> but was: <false>`, `expected: <65536> but was: <0>`, `expected: <1048576> but was: <64936>`.

`LargeTransferIT` moves three megabytes per dialect and asserts **the size the connection settled on**, because the payload alone round-trips at any transfer size and would have proved nothing either way.

One existing test changed: `BaseConfigurationTest` pinned the old `maximumBufferSize` default. `Smb2NegotiateResponseTest.testBufferSizeCalculations`, which pins that the SMB1 buffer sizes govern the clamp, still passes **unmodified** — the capability gate leaves that path exactly as it was.

## Verification

| Run | `main` (51132cc) | This branch |
| --- | --- | --- |
| `mvn test` | 8776 unit, 0 failures | 8798 unit, 0 failures |
| `build_helpers/run-it-with-dfs.sh` (Samba on 445) | — | 8798 unit, 212 integration, 0 failures, 5 skipped; `DfsIT` 4/4, `LargeTransferIT` 5/5 |

`mvn apache-rat:check` and `clirr:check` run as part of `verify` and pass. The Windows Server 2025 job runs on this pull request.
