### PR TITLE
feat(smb2): cancel a pending change notification

### DIFF
--- a/docs/SMB3_SUPPORT.md
+++ b/docs/SMB3_SUPPORT.md
@@ -142,13 +142,13 @@ errors.
 | READ, WRITE | Supported | See [Throughput](#throughput-and-credits) for size limits. |
 | QUERY_INFO, SET_INFO | Supported | |
 | QUERY_DIRECTORY | Supported | Streaming enumeration. A listing cut short by a failure reports it rather than ending quietly — see [Reconnecting after a dropped connection](#reconnecting-after-a-dropped-connection). |
-| CHANGE_NOTIFY | Supported | Via `SmbResource.watch(int, boolean)`. Blocking. |
+| CHANGE_NOTIFY | Supported | Via `SmbResource.watch(int, boolean)`. Blocking; `SmbWatchHandle.cancel()` ends a pending call. |
 | IOCTL | Partial | Reachable FSCTLs: DFS_GET_REFERRALS, PIPE_PEEK, PIPE_TRANSCEIVE, SRV_COPYCHUNK(_WRITE), SRV_REQUEST_RESUME_KEY, VALIDATE_NEGOTIATE_INFO. The other defined FSCTL constants are never sent. |
 | Async / `STATUS_PENDING` interim responses | Supported | |
 | FLUSH | Supported | Sent by `SmbFileOutputStream.flush()`. Every write goes out as it is made, so there is no local buffer to push; what `flush()` contributes is the durability barrier, asking the server to commit what it has taken. Before 3.0.4 the method was the inherited no-op from `OutputStream`, so a caller that flushed and saw no error had no way to tell the data was still only in the server's cache. Nothing is sent on SMB1, which has no equivalent request. |
 | LOCK | Not functional | `Smb2LockRequest` exists and is referenced nowhere. **There is no byte-range locking API** on `SmbResource`, `SmbFile` or `SmbRandomAccessFile`. |
 | ECHO | Not functional | `Smb2EchoRequest` exists and is referenced nowhere. There is no keepalive or liveness probe. |
-| CANCEL | Not functional | `Smb2CancelRequest` is fully built and wired into the send path, but `createCancel()` is never invoked. Nothing can cancel an in-flight request — including a pending CHANGE_NOTIFY, as `SmbWatchHandle`'s own javadoc notes. |
+| CANCEL | Supported | Sent by `SmbWatchHandle.cancel()`, which is the only caller: CHANGE_NOTIFY is the one request the API blocks in. The cancelled `watch()` returns `null` rather than a set of changes, and the open survives, so the directory can be watched again. Closing the handle also ends a pending watch, but as a side effect of closing the open, and what the server then answers the notify with is up to it — Samba sends STATUS_NOTIFY_CLEANUP and an empty set. Actually sending one required fixing the header encoder: it chose between the async and sync header layouts from a field only ever set while decoding, so a cancel whose flags said async still carried a tree id where the server reads the AsyncId, and was discarded. |
 | OPLOCK_BREAK | Partially supported | Breaks are decoded and acknowledged; nothing requests an oplock, so none arrive by default. See below. |
 
 ## Caching, oplocks and handles

--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,11 @@
 							<differenceType>7012</differenceType>
 							<method>void setFileTimes(long, long, long)</method>
 						</difference>
+						<difference>
+							<className>org/codelibs/jcifs/smb/SmbWatchHandle</className>
+							<differenceType>7012</differenceType>
+							<method>void cancel()</method>
+						</difference>
 					</ignored>
 				</configuration>
 			</plugin>

--- a/src/main/java/org/codelibs/jcifs/smb/SmbWatchHandle.java
+++ b/src/main/java/org/codelibs/jcifs/smb/SmbWatchHandle.java
@@ -36,8 +36,10 @@ public interface SmbWatchHandle extends AutoCloseable, Callable<List<FileNotifyI
      * opened if it is not and should be closed with {@link #close()} when no longer
      * needed.
      *
-     * Closing the context should cancel a pending notify request, but that does not seem to work reliable in all
-     * implementations.
+     * A call blocked here is ended by {@link #cancel()}, which leaves the file open, or by {@link #close()}, which
+     * gives the open up. How the server reports a close to the waiting request is up to it, so only a cancel is
+     * reliably distinguishable: it is answered with {@code STATUS_CANCELLED} and this method then returns
+     * {@code null}.
      *
      * Changes in between these calls (as long as the file is open) are buffered by the server, so iteratively calling
      * this method should provide all changes (size of that buffer can be adjusted through
@@ -45,10 +47,24 @@ public interface SmbWatchHandle extends AutoCloseable, Callable<List<FileNotifyI
      * If the server cannot fulfill the request because the changes did not fit the buffer
      * it will return an empty list of changes.
      *
-     * @return changes since the last invocation
+     * @return changes since the last invocation, or {@code null} if the request was cancelled
      * @throws CIFSException if an error occurs retrieving file notifications
      */
     List<FileNotifyInformation> watch() throws CIFSException;
+
+    /**
+     * Cancel a pending {@link #watch()}
+     *
+     * Sends a CANCEL naming the notify request another thread is blocked in, so that {@link #watch()} returns
+     * {@code null} rather than a set of changes. The file stays open and watching can be resumed by calling
+     * {@link #watch()} again; use {@link #close()} to give the open up as well.
+     *
+     * Does nothing when no watch is pending. The server can only match a cancel to a request that has reached it, so
+     * cancelling in the same instant a watch is started may not take effect.
+     *
+     * @throws CIFSException if sending the cancel fails
+     */
+    void cancel() throws CIFSException;
 
     /**
      * {@inheritDoc}

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbWatchHandleImpl.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbWatchHandleImpl.java
@@ -44,6 +44,16 @@ class SmbWatchHandleImpl implements SmbWatchHandle {
     private final boolean recursive;
 
     /**
+     * The notify request {@link #watch()} is waiting for a response to, or null when no watch is pending.
+     *
+     * <p>
+     * A cancel has to name the request it cancels, and only the thread blocked in {@link #watch()} has it, so it is
+     * published here for {@link #cancel()} to pick up from whatever thread calls that.
+     * </p>
+     */
+    private volatile CommonServerMessageBlockRequest pending;
+
+    /**
      * @param fh
      * @param filter
      * @param recursive
@@ -89,6 +99,7 @@ class SmbWatchHandleImpl implements SmbWatchHandle {
             if (log.isTraceEnabled()) {
                 log.trace("Sending NtTransNotifyChange for " + this.handle);
             }
+            this.pending = req;
             try {
                 resp = th.send(req, resp, RequestParam.NO_TIMEOUT, RequestParam.NO_RETRY);
             } catch (final SmbException e) {
@@ -98,6 +109,8 @@ class SmbWatchHandleImpl implements SmbWatchHandle {
                     return null;
                 }
                 throw e;
+            } finally {
+                this.pending = null;
             }
             if (log.isTraceEnabled()) {
                 log.trace("Returned from NtTransNotifyChange " + resp.getErrorCode());
@@ -125,6 +138,30 @@ class SmbWatchHandleImpl implements SmbWatchHandle {
     @Override
     public List<FileNotifyInformation> call() throws CIFSException {
         return watch();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.codelibs.jcifs.smb.SmbWatchHandle#cancel()
+     */
+    @Override
+    public void cancel() throws CIFSException {
+        final CommonServerMessageBlockRequest req = this.pending;
+        if (req == null || !this.handle.isValid()) {
+            return;
+        }
+        final CommonServerMessageBlockRequest cancel = req.createCancel();
+        if (cancel == null) {
+            return;
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Cancelling " + req);
+        }
+        // A cancel is not answered, so it is sent without a response to wait for
+        try (SmbTreeHandleImpl th = this.handle.getTree()) {
+            th.send(cancel, null, RequestParam.NO_RETRY);
+        }
     }
 
     /**

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/ServerMessageBlock2.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/ServerMessageBlock2.java
@@ -760,7 +760,11 @@ public abstract class ServerMessageBlock2 implements CommonServerMessageBlock {
         SMBUtil.writeInt4(this.nextCommand, dst, dstIndex + 20);
         SMBUtil.writeInt8(this.mid, dst, dstIndex + 24);
 
-        if (this.async) {
+        // MS-SMB2 2.2.1.2: these eight bytes are the AsyncId when SMB2_FLAGS_ASYNC_COMMAND is set, and reserved plus
+        // the TreeId when it is not, so the flag decides the layout - as it already does when one is read back. The
+        // async field is only ever set while decoding a received message, so keying on it here meant a message we
+        // sent with the flag set still carried a tree id where the peer reads the async id.
+        if ((this.flags & SMB2_FLAGS_ASYNC_COMMAND) == SMB2_FLAGS_ASYNC_COMMAND) {
             SMBUtil.writeInt8(this.asyncId, dst, dstIndex + 32);
         } else {
             // 4 reserved

--- a/src/test/java/org/codelibs/jcifs/smb/SmbWatchHandleTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/SmbWatchHandleTest.java
@@ -152,6 +152,11 @@ class SmbWatchHandleTest {
             }
 
             @Override
+            public void cancel() throws CIFSException {
+                // Do nothing
+            }
+
+            @Override
             public void close() throws CIFSException {
                 // Do nothing
             }
@@ -324,6 +329,11 @@ class SmbWatchHandleTest {
             }
 
             @Override
+            public void cancel() throws CIFSException {
+                // Do nothing
+            }
+
+            @Override
             public void close() throws CIFSException {
                 // Do nothing
             }
@@ -380,6 +390,11 @@ class SmbWatchHandleTest {
             @Override
             public List<FileNotifyInformation> call() throws CIFSException {
                 return watch();
+            }
+
+            @Override
+            public void cancel() throws CIFSException {
+                // Do nothing
             }
 
             @Override

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbWatchHandleImplTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbWatchHandleImplTest.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -18,6 +20,11 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import org.codelibs.jcifs.smb.CIFSException;
 import org.codelibs.jcifs.smb.Configuration;
@@ -26,12 +33,15 @@ import org.codelibs.jcifs.smb.SmbConstants;
 import org.codelibs.jcifs.smb.internal.CommonServerMessageBlockRequest;
 import org.codelibs.jcifs.smb.internal.NotifyResponse;
 import org.codelibs.jcifs.smb.internal.smb1.trans.nt.NtTransNotifyChange;
+import org.codelibs.jcifs.smb.internal.smb1.trans.nt.SmbComNtCancel;
+import org.codelibs.jcifs.smb.internal.smb2.Smb2CancelRequest;
 import org.codelibs.jcifs.smb.internal.smb2.notify.Smb2ChangeNotifyRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -260,5 +270,84 @@ class SmbWatchHandleImplTest {
         assertThrows(NullPointerException.class, () -> {
             sut.watch();
         });
+    }
+
+    // Nothing is in flight, so a cancel must not even reach for the connection
+    @Test
+    @DisplayName("cancel() sends nothing when no watch is pending")
+    void cancel_noWatchPending_sendsNothing() throws Exception {
+        SmbWatchHandleImpl sut = new SmbWatchHandleImpl(handle, 0, false);
+
+        sut.cancel();
+
+        verify(handle, never()).getTree();
+    }
+
+    // The point of cancel(): while watch() is blocked in send(), a cancel naming that very request goes out
+    @ParameterizedTest(name = "smb2={0}")
+    @ValueSource(booleans = { true, false })
+    @DisplayName("cancel() sends a cancel for the request watch() is waiting on")
+    void cancel_watchPending_sendsCancelForThatRequest(boolean smb2) throws Exception {
+        NotifyResponse resp = mock(NotifyResponse.class);
+        when(resp.isReceived()).thenReturn(true);
+        when(resp.getErrorCode()).thenReturn(0);
+        when(resp.getNotifyInformation()).thenReturn(new ArrayList<>());
+        when(handle.isValid()).thenReturn(true);
+        when(handle.getTree()).thenReturn(tree);
+        when(tree.isSMB2()).thenReturn(smb2);
+        when(tree.getConfig()).thenReturn(mock(Configuration.class));
+        if (smb2) {
+            when(handle.getFileId()).thenReturn(new byte[16]);
+        } else {
+            when(tree.hasCapability(SmbConstants.CAP_NT_SMBS)).thenReturn(true);
+            when(handle.getFid()).thenReturn(42);
+        }
+
+        // The notify send blocks, as it does on the wire, so that cancel() runs against a genuinely pending request
+        CountDownLatch watchSent = new CountDownLatch(1);
+        CountDownLatch cancelDone = new CountDownLatch(1);
+        when(tree.send(any(CommonServerMessageBlockRequest.class), any(), any(), any())).thenAnswer(inv -> {
+            if (inv.getArgument(0) instanceof Smb2CancelRequest || inv.getArgument(0) instanceof SmbComNtCancel) {
+                return null;
+            }
+            watchSent.countDown();
+            assertTrue(cancelDone.await(10, TimeUnit.SECONDS), "cancel() never returned");
+            return resp;
+        });
+
+        SmbWatchHandleImpl sut = new SmbWatchHandleImpl(handle, 0, false);
+        ExecutorService worker = Executors.newSingleThreadExecutor();
+        try {
+            Future<List<FileNotifyInformation>> watching = worker.submit(sut::watch);
+            assertTrue(watchSent.await(10, TimeUnit.SECONDS), "watch() never sent its request");
+
+            sut.cancel();
+            cancelDone.countDown();
+            watching.get(10, TimeUnit.SECONDS);
+        } finally {
+            worker.shutdownNow();
+        }
+
+        ArgumentCaptor<CommonServerMessageBlockRequest> cancelCap = ArgumentCaptor.forClass(CommonServerMessageBlockRequest.class);
+        verify(tree).send(cancelCap.capture(), isNull(), eq(RequestParam.NO_RETRY));
+        Class<?> expected = smb2 ? Smb2CancelRequest.class : SmbComNtCancel.class;
+        assertTrue(expected.isInstance(cancelCap.getValue()), "unexpected cancel request: " + cancelCap.getValue());
+    }
+
+    // The request has been answered, so there is nothing left for a cancel to name
+    @Test
+    @DisplayName("cancel() sends nothing once watch() has returned")
+    void cancel_afterWatchReturned_sendsNothing() throws Exception {
+        NotifyResponse resp = mock(NotifyResponse.class);
+        when(resp.isReceived()).thenReturn(true);
+        when(resp.getErrorCode()).thenReturn(0);
+        when(resp.getNotifyInformation()).thenReturn(new ArrayList<>());
+        setupSmb2(resp, new byte[16]);
+        SmbWatchHandleImpl sut = new SmbWatchHandleImpl(handle, 0, false);
+        sut.watch();
+
+        sut.cancel();
+
+        verify(tree, never()).send(any(CommonServerMessageBlockRequest.class), isNull(), eq(RequestParam.NO_RETRY));
     }
 }

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb2CancelRequestTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb2CancelRequestTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.mock;
 
 import org.codelibs.jcifs.smb.Configuration;
 import org.codelibs.jcifs.smb.internal.CommonServerMessageBlockRequest;
+import org.codelibs.jcifs.smb.internal.util.SMBUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -302,5 +303,40 @@ class Smb2CancelRequestTest {
         assertEquals(negativeMid, request.getMid(), "Should handle negative MID");
         assertEquals(negativeAsyncId, request.getAsyncId(), "Should handle negative AsyncId");
         assertTrue((request.getFlags() & SMB2_FLAGS_ASYNC_COMMAND) != 0, "Async flag should be set for non-zero (negative) asyncId");
+    }
+
+    /**
+     * MS-SMB2 2.2.1.2: bytes 32-39 of the header are the AsyncId when SMB2_FLAGS_ASYNC_COMMAND is set, and reserved
+     * plus the TreeId when it is not. A server matches a cancel to the request it names by reading that field, so a
+     * cancel that sets the flag but leaves a tree id there names nothing and is dropped.
+     */
+    @Test
+    @DisplayName("An async cancel puts the AsyncId in the header, not a tree id")
+    void testAsyncCancelEncodesAsyncIdInHeader() {
+        long mid = 12345L;
+        long asyncId = 0x1122334455667788L;
+        Smb2CancelRequest request = new Smb2CancelRequest(mockConfig, mid, asyncId);
+        request.setTid(42); // the tree layer stamps this on every request it sends
+
+        byte[] buffer = new byte[256];
+        request.encode(buffer, 0);
+
+        assertTrue((SMBUtil.readInt4(buffer, 16) & SMB2_FLAGS_ASYNC_COMMAND) != 0, "the encoded flags should say async");
+        assertEquals(mid, SMBUtil.readInt8(buffer, 24), "the cancel should name the message id it cancels");
+        assertEquals(asyncId, SMBUtil.readInt8(buffer, 32), "the async id field should carry the async id");
+    }
+
+    @Test
+    @DisplayName("A cancel that is not async puts the tree id in the header")
+    void testSyncCancelEncodesTreeIdInHeader() {
+        Smb2CancelRequest request = new Smb2CancelRequest(mockConfig, 7L, 0L);
+        request.setTid(42);
+
+        byte[] buffer = new byte[256];
+        request.encode(buffer, 0);
+
+        assertFalse((SMBUtil.readInt4(buffer, 16) & SMB2_FLAGS_ASYNC_COMMAND) != 0, "the encoded flags should not say async");
+        assertEquals(7L, SMBUtil.readInt8(buffer, 24), "the cancel should name the message id it cancels");
+        assertEquals(42, SMBUtil.readInt4(buffer, 36), "the tree id field should carry the tree id");
     }
 }

--- a/src/test/java/org/codelibs/jcifs/smb/it/ChangeNotifyIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/ChangeNotifyIT.java
@@ -17,6 +17,7 @@ package org.codelibs.jcifs.smb.it;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -127,6 +128,40 @@ class ChangeNotifyIT extends AbstractSmbIT {
             assertFalse(events.isEmpty(), "the recursive watcher should have been told about the nested file");
             assertTrue(events.stream().anyMatch(e -> e.getFileName() != null && e.getFileName().endsWith("deep.txt")),
                     "no event named the nested file: " + events);
+        }
+    }
+
+    /**
+     * What separates {@code cancel()} from {@code close()}: both end a pending watch, but a cancel is answered with
+     * STATUS_CANCELLED and leaves the open in place, so the directory can still be watched afterwards. A close is
+     * answered - on Samba at least - with STATUS_NOTIFY_CLEANUP and an empty change set, and the open is gone.
+     */
+    @Test
+    @DisplayName("cancel() ends a pending watch and leaves the file open")
+    void cancelEndsAPendingWatch() throws Exception {
+        final CIFSContext context = server().context();
+        this.workDir = createWorkDir(context, server().share());
+
+        try (SmbWatchHandle handle = this.workDir.watch(FileNotifyInformation.FILE_NOTIFY_CHANGE_FILE_NAME, false)) {
+            final ExecutorService executor = Executors.newSingleThreadExecutor();
+            try {
+                final Future<List<FileNotifyInformation>> watching = executor.submit(handle::watch);
+                Thread.sleep(SETTLE_MILLIS);
+                assertFalse(watching.isDone(), "the watch already returned, so cancelling it would prove nothing");
+
+                handle.cancel();
+
+                assertNull(watching.get(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                        "a cancelled watch reports itself cancelled, it does not return a change set");
+            } finally {
+                executor.shutdownNow();
+            }
+
+            final List<FileNotifyInformation> events = watchWhile(handle, () -> {
+                writeFile(this.workDir, "after-cancel.txt", "payload");
+                return null;
+            });
+            assertFalse(events.isEmpty(), "the open should have survived the cancel and still report changes");
         }
     }
 }


### PR DESCRIPTION
## What this changes

`SmbWatchHandle.watch()` blocks until the server reports a change, and until now
nothing could end that wait except closing the file. `Smb2CancelRequest` and
`createCancel()` were both complete and wired into the send path, but
`createCancel()` had no caller, so the client never sent a CANCEL for anything.
`SmbWatchHandle`'s own javadoc put this down to servers not handling cancellation
reliably; the client simply never asked.

`SmbWatchHandle.cancel()` ends a pending watch. The watch returns `null` instead
of a set of changes and the open survives, so the directory can be watched again.
That is what separates it from `close()`, which also ends a pending watch but as
a side effect of giving the open up — and what the server answers the notify with
in that case is its own choice, Samba sending `STATUS_NOTIFY_CLEANUP` and an
empty set.

## The encoder defect this uncovered

MS-SMB2 2.2.1.2 makes bytes 32 to 39 of the SMB2 header the `AsyncId` when
`SMB2_FLAGS_ASYNC_COMMAND` is set, and reserved plus the `TreeId` when it is not.
The decoder chooses between the two layouts on that flag. The encoder chose on a
field that is only ever assigned while decoding a received message, so it was
never set on a message being sent.

A cancel of a notify the server had made async therefore went out with its flags
saying async while those same bytes carried the tree id that the tree layer
stamps on every request. The server read an `AsyncId` matching no outstanding
request, dropped the cancel, and the watch stayed blocked. Both sides now key on
the flag. The cancel is the only message in `src/main` that sets that flag on the
way out, and a decoded async message has both the flag and the field set, so no
other message changes shape.

## Verification

- Unit tests: 8804, 0 failures (6 new).
- Integration tests against Samba: 213, 0 failures, 5 skipped (1 new).
- `ChangeNotifyIT` pinned to each dialect CI covers — SMB 2.0.2, 2.1, 3.0 and
  3.1.1 — 4/4 green on each. The SMB 2.0.2 leg was run together with
  `EncryptionIT` to confirm the pin had actually applied: its four
  `@RequiresDialect(SMB300)` cases skipped, rather than the run quietly
  negotiating 3.1.1 four times over.
- apache-rat: 0 unapproved, 400 approved.
- The new integration case is known to fail without this change. It was written
  against the unfixed encoder first and timed out there, and it asserts the watch
  is still pending before cancelling it, so it cannot pass without a cancel that
  the server actually matches.

## Compatibility

`cancel()` is a new method on the public `SmbWatchHandle` interface, so an
external class implementing that interface would have to supply it. The interface
is obtained from `SmbResource.watch(int, boolean)` and is not meant to be
implemented outside the library. It is recorded in the clirr `<ignored>` list
next to the existing 7012 entries for `Configuration` and `SmbResource`.
