### PR TITLE
feat(smb2): take byte range locks on a random access file

### DIFF
--- a/docs/SMB3_SUPPORT.md
+++ b/docs/SMB3_SUPPORT.md
@@ -146,7 +146,7 @@ errors.
 | IOCTL | Partial | Reachable FSCTLs: DFS_GET_REFERRALS, PIPE_PEEK, PIPE_TRANSCEIVE, SRV_COPYCHUNK(_WRITE), SRV_REQUEST_RESUME_KEY, VALIDATE_NEGOTIATE_INFO. The other defined FSCTL constants are never sent. |
 | Async / `STATUS_PENDING` interim responses | Supported | |
 | FLUSH | Supported | Sent by `SmbFileOutputStream.flush()`. Every write goes out as it is made, so there is no local buffer to push; what `flush()` contributes is the durability barrier, asking the server to commit what it has taken. Before 3.0.4 the method was the inherited no-op from `OutputStream`, so a caller that flushed and saw no error had no way to tell the data was still only in the server's cache. Nothing is sent on SMB1, which has no equivalent request. |
-| LOCK | Not functional | `Smb2LockRequest` exists and is referenced nowhere. **There is no byte-range locking API** on `SmbResource`, `SmbFile` or `SmbRandomAccessFile`. |
+| LOCK | Supported | Sent by `SmbRandomAccess.lock()`, `tryLock()` and `unlock()`, which a caller reaches through `SmbResource.openRandomAccess()`. `tryLock` sets `SMB2_LOCKFLAG_FAIL_IMMEDIATELY` and reports a range another open holds as `false` rather than raising: Samba answers such a request `STATUS_LOCK_NOT_GRANTED`, and a server answering `STATUS_FILE_LOCK_CONFLICT` instead is read the same way. An unlock has to name the range that was locked, because a server matches it against the ranges it recorded rather than against overlapping bytes. SMB2 only: SMB1 has LOCKING_ANDX, but this client builds it solely to decode an inbound oplock break and has no outbound lock path, so a lock over SMB1 is refused rather than silently skipped. A lock belongs to the open that took it and does not survive a reconnect; see [Why durable handles are not planned](#why-durable-handles-are-not-planned). |
 | ECHO | Not functional | `Smb2EchoRequest` exists and is referenced nowhere. There is no keepalive or liveness probe. |
 | CANCEL | Supported | Sent by `SmbWatchHandle.cancel()`, which is the only caller: CHANGE_NOTIFY is the one request the API blocks in. The cancelled `watch()` returns `null` rather than a set of changes, and the open survives, so the directory can be watched again. Closing the handle also ends a pending watch, but as a side effect of closing the open, and what the server then answers the notify with is up to it — Samba sends STATUS_NOTIFY_CLEANUP and an empty set. Actually sending one required fixing the header encoder: it chose between the async and sync header layouts from a field only ever set while decoding, so a cancel whose flags said async still carried a tree id where the server reads the AsyncId, and was discarded. |
 | OPLOCK_BREAK | Partially supported | Breaks are decoded and acknowledged; nothing requests an oplock, so none arrive by default. See below. |
@@ -210,13 +210,21 @@ refused for directories, and it has no directory leases to qualify with. Since
 directory enumeration is much of what this library does, the feature would not
 apply to it.
 
-**What it buys is not what this client uses.** A durable handle preserves
+**What it buys is mostly not what this client uses.** A durable handle preserves
 byte-range locks across the reconnect — the reason the Linux client implemented
-it — along with share-mode semantics and handle identity across a rename. jcifs
-takes no byte-range locks, and SMB2 reads and writes carry explicit offsets, so
-there is nothing to resume: reopening by path and continuing at the recorded
-offset loses none of it, which is what the streams already do. See
+it — along with share-mode semantics and handle identity across a rename. For
+reads and writes there is nothing to resume: SMB2 carries explicit offsets, so
+reopening by path and continuing at the recorded offset loses none of it, which
+is what the streams already do. See
 [Reconnecting after a dropped connection](#reconnecting-after-a-dropped-connection).
+
+Byte-range locks are the exception, now that `SmbRandomAccess` can take them. A
+lock belongs to the open that took it, and a dropped connection is recovered by
+reopening the path, which gives a new open holding no locks — so a lock taken
+before the drop is gone afterwards and nothing replays it. That is a caveat for
+callers who lock rather than an argument for durable handles, since what rules
+those out still holds: the batch oplock or `R|H` lease that a durable open has to
+qualify with cannot be requested at all today.
 
 **And it is least reliable exactly when it would be wanted.** If another client
 opens the file while the connection is down, the server closes the durable open

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,21 @@
 							<differenceType>7012</differenceType>
 							<method>void cancel()</method>
 						</difference>
+						<difference>
+							<className>org/codelibs/jcifs/smb/SmbRandomAccess</className>
+							<differenceType>7012</differenceType>
+							<method>void lock(long, long, boolean)</method>
+						</difference>
+						<difference>
+							<className>org/codelibs/jcifs/smb/SmbRandomAccess</className>
+							<differenceType>7012</differenceType>
+							<method>boolean tryLock(long, long, boolean)</method>
+						</difference>
+						<difference>
+							<className>org/codelibs/jcifs/smb/SmbRandomAccess</className>
+							<differenceType>7012</differenceType>
+							<method>void unlock(long, long)</method>
+						</difference>
 					</ignored>
 				</configuration>
 			</plugin>

--- a/src/main/java/org/codelibs/jcifs/smb/SmbRandomAccess.java
+++ b/src/main/java/org/codelibs/jcifs/smb/SmbRandomAccess.java
@@ -101,4 +101,52 @@ public interface SmbRandomAccess extends DataOutput, DataInput, AutoCloseable {
      */
     void setLength(long newLength) throws SmbException;
 
+    /**
+     * Lock a range of bytes, waiting for it if another open holds it
+     *
+     * A lock belongs to the open it was taken on, so ranges locked through this instance never conflict with each
+     * other, only with locks taken elsewhere. Requires SMB2 or later.
+     *
+     * @param position
+     *            first byte of the range
+     * @param size
+     *            number of bytes to lock
+     * @param shared
+     *            take a shared lock, which other shared locks of the same range are allowed alongside, rather than
+     *            an exclusive one
+     * @throws SmbException if the lock cannot be taken
+     */
+    void lock(long position, long size, boolean shared) throws SmbException;
+
+    /**
+     * Lock a range of bytes, giving up at once if another open holds it
+     *
+     * Unlike {@link #lock(long, long, boolean)} this never waits: a range that is held is reported rather than
+     * queued for. Requires SMB2 or later.
+     *
+     * @param position
+     *            first byte of the range
+     * @param size
+     *            number of bytes to lock
+     * @param shared
+     *            take a shared lock rather than an exclusive one
+     * @return whether the lock was taken
+     * @throws SmbException if the attempt fails for any reason other than the range being held
+     */
+    boolean tryLock(long position, long size, boolean shared) throws SmbException;
+
+    /**
+     * Release a range locked earlier
+     *
+     * The range has to be one that was locked: a server matches an unlock against the ranges it recorded, not
+     * against whatever bytes happen to overlap. Requires SMB2 or later.
+     *
+     * @param position
+     *            first byte of the range, as it was given to the lock
+     * @param size
+     *            number of bytes, as it was given to the lock
+     * @throws SmbException if the range was not locked or the unlock fails
+     */
+    void unlock(long position, long size) throws SmbException;
+
 }

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbRandomAccessFile.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbRandomAccessFile.java
@@ -40,6 +40,8 @@ import org.codelibs.jcifs.smb.internal.smb2.io.Smb2ReadRequest;
 import org.codelibs.jcifs.smb.internal.smb2.io.Smb2ReadResponse;
 import org.codelibs.jcifs.smb.internal.smb2.io.Smb2WriteRequest;
 import org.codelibs.jcifs.smb.internal.smb2.io.Smb2WriteResponse;
+import org.codelibs.jcifs.smb.internal.smb2.lock.Smb2Lock;
+import org.codelibs.jcifs.smb.internal.smb2.lock.Smb2LockRequest;
 import org.codelibs.jcifs.smb.util.Encdec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -168,6 +170,54 @@ public class SmbRandomAccessFile implements SmbRandomAccess {
      */
     public void open() throws CIFSException {
         try (SmbFileHandleImpl fh = ensureOpen()) {}
+    }
+
+    @Override
+    public void lock(final long position, final long size, final boolean shared) throws SmbException {
+        sendLock(new Smb2Lock(position, size, shared ? Smb2Lock.SMB2_LOCKFLAG_SHARED_LOCK : Smb2Lock.SMB2_LOCKFLAG_EXCLUSIVE_LOCK));
+    }
+
+    @Override
+    public boolean tryLock(final long position, final long size, final boolean shared) throws SmbException {
+        final int type = shared ? Smb2Lock.SMB2_LOCKFLAG_SHARED_LOCK : Smb2Lock.SMB2_LOCKFLAG_EXCLUSIVE_LOCK;
+        try {
+            sendLock(new Smb2Lock(position, size, type | Smb2Lock.SMB2_LOCKFLAG_FAIL_IMMEDIATELY));
+            return true;
+        } catch (final SmbException e) {
+            // A server that will not grant a lock asked to fail immediately answers STATUS_LOCK_NOT_GRANTED, and
+            // some answer STATUS_FILE_LOCK_CONFLICT instead. Either way the range is held by someone else, which is
+            // the answer this method exists to return rather than a failure to raise.
+            if (e.getNtStatus() == 0xC0000055 || e.getNtStatus() == 0xC0000054) {
+                log.debug("Range is already locked", e);
+                return false;
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    public void unlock(final long position, final long size) throws SmbException {
+        sendLock(new Smb2Lock(position, size, Smb2Lock.SMB2_LOCKFLAG_UNLOCK));
+    }
+
+    /**
+     * Sends a single lock element against the open file.
+     *
+     * @param lock
+     *            the range and flags to send
+     * @throws SmbException if the request fails, or the connection is not SMB2
+     */
+    private void sendLock(final Smb2Lock lock) throws SmbException {
+        try (SmbFileHandleImpl fh = ensureOpen(); SmbTreeHandleImpl th = fh.getTree()) {
+            if (!th.isSMB2()) {
+                // SMB1 has LOCKING_ANDX, but this client only ever builds it to decode an inbound oplock break and
+                // has no outbound lock path at all, so there is nothing to fall back to here.
+                throw new SmbUnsupportedOperationException("Byte range locking requires SMB2 or later");
+            }
+            th.send(new Smb2LockRequest(th.getConfig(), fh.getFileId(), new Smb2Lock[] { lock }), RequestParam.NO_RETRY);
+        } catch (final CIFSException e) {
+            throw SmbException.wrap(e);
+        }
     }
 
     @Override

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbRandomAccessFileTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbRandomAccessFileTest.java
@@ -2,6 +2,7 @@ package org.codelibs.jcifs.smb.impl;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -31,6 +32,9 @@ import org.codelibs.jcifs.smb.internal.smb1.com.SmbComWriteResponse;
 import org.codelibs.jcifs.smb.internal.smb1.trans2.Trans2SetFileInformation;
 import org.codelibs.jcifs.smb.internal.smb1.trans2.Trans2SetFileInformationResponse;
 import org.codelibs.jcifs.smb.internal.smb2.info.Smb2SetInfoRequest;
+import org.codelibs.jcifs.smb.internal.smb2.lock.Smb2Lock;
+import org.codelibs.jcifs.smb.internal.smb2.lock.Smb2LockRequest;
+import org.codelibs.jcifs.smb.internal.util.SMBUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -70,6 +74,121 @@ public class SmbRandomAccessFileTest {
 
         // build via package-private constructor to control unshared flag
         return new SmbRandomAccessFile(file, mode, SmbConstants.DEFAULT_SHARING, unshared);
+    }
+
+    // Helper: like newInstance, but the caller keeps the tree mock so it can pin what went onto the wire
+    private SmbRandomAccessFile newWithTree(SmbTreeHandleImpl tree, boolean smb2) throws CIFSException {
+        SmbFile file = mock(SmbFile.class);
+        Configuration cfg = mock(Configuration.class);
+        SmbFileHandleImpl fh = mock(SmbFileHandleImpl.class);
+
+        when(file.ensureTreeConnected()).thenReturn(tree);
+        when(tree.getConfig()).thenReturn(cfg);
+        when(tree.getReceiveBufferSize()).thenReturn(1024);
+        when(tree.getSendBufferSize()).thenReturn(1024);
+        when(tree.areSignaturesActive()).thenReturn(false);
+        when(tree.isSMB2()).thenReturn(smb2);
+
+        when(file.openUnshared(anyInt(), anyInt(), anyInt(), anyInt(), anyInt())).thenReturn(fh);
+        when(fh.acquire()).thenReturn(fh);
+        when(fh.isValid()).thenReturn(true);
+        when(fh.getTree()).thenReturn(tree);
+        when(fh.getFileId()).thenReturn(new byte[16]);
+        when(fh.getFid()).thenReturn(1);
+
+        return new SmbRandomAccessFile(file, "rw", SmbConstants.DEFAULT_SHARING, false);
+    }
+
+    // Helper: the encoded bytes of the single lock request that was sent. Asserting on the wire rather than on the
+    // object is deliberate - a lock element that is built correctly but laid out wrongly is exactly the defect that
+    // only shows up once a server has to read it.
+    private static byte[] sentLockRequest(SmbTreeHandleImpl tree) throws CIFSException {
+        ArgumentCaptor<Smb2LockRequest> captor = ArgumentCaptor.forClass(Smb2LockRequest.class);
+        verify(tree).send(captor.capture(), eq(RequestParam.NO_RETRY));
+        byte[] buffer = new byte[captor.getValue().size()];
+        captor.getValue().encode(buffer, 0);
+        return buffer;
+    }
+
+    // Header is 64 bytes, then StructureSize/LockCount/LockSequence/FileId take 24, so the lock element starts at 88
+    // and carries Offset(8) at 88, Length(8) at 96 and Flags(4) at 104.
+    private static final int LOCK_OFFSET = 88;
+    private static final int LOCK_LENGTH = 96;
+    private static final int LOCK_FLAGS = 104;
+
+    @Test
+    @DisplayName("lock(): locks exactly the range given, exclusively")
+    void lock_sendsExclusiveLockForTheRange() throws Exception {
+        SmbTreeHandleImpl tree = mock(SmbTreeHandleImpl.class);
+        SmbRandomAccessFile raf = newWithTree(tree, true);
+
+        raf.lock(64, 16, false);
+
+        byte[] sent = sentLockRequest(tree);
+        assertEquals(64L, SMBUtil.readInt8(sent, LOCK_OFFSET), "the lock should start where it was asked to");
+        assertEquals(16L, SMBUtil.readInt8(sent, LOCK_LENGTH), "the lock should cover the length it was asked to");
+        assertEquals(Smb2Lock.SMB2_LOCKFLAG_EXCLUSIVE_LOCK, SMBUtil.readInt4(sent, LOCK_FLAGS),
+                "a lock that is not shared goes out as an exclusive one, and must not ask to fail immediately");
+    }
+
+    @Test
+    @DisplayName("lock(shared): asks for a shared lock instead")
+    void lock_shared_sendsSharedLock() throws Exception {
+        SmbTreeHandleImpl tree = mock(SmbTreeHandleImpl.class);
+        SmbRandomAccessFile raf = newWithTree(tree, true);
+
+        raf.lock(0, 8, true);
+
+        assertEquals(Smb2Lock.SMB2_LOCKFLAG_SHARED_LOCK, SMBUtil.readInt4(sentLockRequest(tree), LOCK_FLAGS),
+                "a shared lock must not go out as an exclusive one, or it would lock other readers out");
+    }
+
+    @Test
+    @DisplayName("tryLock(): asks the server to fail immediately rather than queue the lock")
+    void tryLock_asksToFailImmediately() throws Exception {
+        SmbTreeHandleImpl tree = mock(SmbTreeHandleImpl.class);
+        SmbRandomAccessFile raf = newWithTree(tree, true);
+
+        assertTrue(raf.tryLock(0, 8, false), "a lock the server did not refuse should be reported as taken");
+
+        assertEquals(Smb2Lock.SMB2_LOCKFLAG_EXCLUSIVE_LOCK | Smb2Lock.SMB2_LOCKFLAG_FAIL_IMMEDIATELY,
+                SMBUtil.readInt4(sentLockRequest(tree), LOCK_FLAGS),
+                "without FAIL_IMMEDIATELY the server queues the request, and tryLock would block instead of returning");
+    }
+
+    @Test
+    @DisplayName("tryLock(): returns false, rather than throwing, when another open holds the range")
+    void tryLock_returnsFalseWhenTheRangeIsHeld() throws Exception {
+        SmbTreeHandleImpl tree = mock(SmbTreeHandleImpl.class);
+        SmbRandomAccessFile raf = newWithTree(tree, true);
+        // 0xC0000055 is STATUS_LOCK_NOT_GRANTED, what a server answers a FAIL_IMMEDIATELY lock it will not grant
+        doThrow(new SmbException(0xC0000055, false)).when(tree).send(any(Smb2LockRequest.class), eq(RequestParam.NO_RETRY));
+
+        assertFalse(raf.tryLock(0, 8, false), "a range another open holds is the answer tryLock exists to give, not an error");
+    }
+
+    @Test
+    @DisplayName("unlock(): releases the range with the unlock flag")
+    void unlock_sendsUnlockFlag() throws Exception {
+        SmbTreeHandleImpl tree = mock(SmbTreeHandleImpl.class);
+        SmbRandomAccessFile raf = newWithTree(tree, true);
+
+        raf.unlock(32, 8);
+
+        byte[] sent = sentLockRequest(tree);
+        assertEquals(32L, SMBUtil.readInt8(sent, LOCK_OFFSET), "the unlock has to name the range that was locked");
+        assertEquals(Smb2Lock.SMB2_LOCKFLAG_UNLOCK, SMBUtil.readInt4(sent, LOCK_FLAGS), "an unlock must carry the unlock flag alone");
+    }
+
+    @Test
+    @DisplayName("locking over SMB1 is refused rather than silently doing nothing")
+    void lock_onSmb1_refused() throws Exception {
+        SmbTreeHandleImpl tree = mock(SmbTreeHandleImpl.class);
+        SmbRandomAccessFile raf = newWithTree(tree, false);
+
+        assertThrows(SmbUnsupportedOperationException.class, () -> raf.lock(0, 8, false),
+                "this client has no SMB1 lock request, so the call has to fail rather than appear to have locked something");
+        verify(tree, never()).send(any(Smb2LockRequest.class), eq(RequestParam.NO_RETRY));
     }
 
     @Test

--- a/src/test/java/org/codelibs/jcifs/smb/it/ByteRangeLockIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/ByteRangeLockIT.java
@@ -1,0 +1,102 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Properties;
+
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.impl.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbRandomAccessFile;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Byte range locks, which only say anything when a second open goes for the same range.
+ *
+ * <p>
+ * A lock belongs to the open that took it, so a contending lock taken through the same handle would be granted no
+ * matter what the first one did. Both tests here therefore contend from a separate connection, and
+ * {@code ssnLimit=1} keeps that off the pooled connection the holder is using.
+ * </p>
+ */
+class ByteRangeLockIT extends AbstractSmbIT {
+
+    private SmbFile workDir;
+
+    @AfterEach
+    void removeWorkDir() {
+        deleteQuietly(this.workDir);
+    }
+
+    @Test
+    @DisplayName("an exclusive lock keeps another connection out of the range until it is released")
+    void exclusiveLockKeepsAnotherConnectionOut() throws Exception {
+        final CIFSContext context = server().context();
+        this.workDir = createWorkDir(context, server().share());
+        final SmbFile file = writeFile(this.workDir, "locked.bin", "0123456789");
+
+        try (SmbRandomAccessFile holder = file.openRandomAccess("rw");
+                SmbFile otherFile = otherConnection(file);
+                SmbRandomAccessFile contender = otherFile.openRandomAccess("rw")) {
+
+            holder.lock(0, 4, false);
+
+            // An unheld range is granted, so a refusal here is what shows the lock reached the server and was
+            // recorded, rather than having been built and dropped.
+            assertFalse(contender.tryLock(0, 4, false), "another connection should not be given an exclusive range the holder has locked");
+
+            // And the range has to come free again, which is what tells a real unlock apart from a no-op.
+            holder.unlock(0, 4);
+            assertTrue(contender.tryLock(0, 4, false), "the range should be available once the holder unlocked it");
+            contender.unlock(0, 4);
+        }
+    }
+
+    @Test
+    @DisplayName("a shared lock still allows another shared lock on the same range")
+    void sharedLocksCoexist() throws Exception {
+        final CIFSContext context = server().context();
+        this.workDir = createWorkDir(context, server().share());
+        final SmbFile file = writeFile(this.workDir, "shared.bin", "0123456789");
+
+        try (SmbRandomAccessFile holder = file.openRandomAccess("rw");
+                SmbFile otherFile = otherConnection(file);
+                SmbRandomAccessFile contender = otherFile.openRandomAccess("rw")) {
+
+            holder.lock(0, 4, true);
+
+            // Paired with the test above this pins the flag mapping: were shared and exclusive swapped, one of the
+            // two tests would fail, whereas either one alone would pass with the wrong flag.
+            assertTrue(contender.tryLock(0, 4, true), "a range held by a shared lock should take a second shared lock");
+
+            contender.unlock(0, 4);
+            holder.unlock(0, 4);
+        }
+    }
+
+    /**
+     * Opens the same file over a second, separate connection.
+     */
+    private SmbFile otherConnection(final SmbFile file) throws Exception {
+        final Properties properties = server().defaultProperties();
+        properties.setProperty("jcifs.client.ssnLimit", "1");
+        return new SmbFile(file.getURL().toString(), server().context(properties));
+    }
+}


### PR DESCRIPTION
## What this changes

`SmbRandomAccess` could read, write, seek and truncate, but nothing in this
client could lock a range of a file. `Smb2LockRequest`, `Smb2Lock` and
`Smb2LockResponse` were all complete and correct, but the request had no
production caller and no public API reached it, so a caller had no way to take
a lock.

This adds three methods to `SmbRandomAccess`, which a caller reaches through
`SmbResource.openRandomAccess()`:

- `lock(position, size, shared)` waits for a range another open holds.
- `tryLock(position, size, shared)` sets `SMB2_LOCKFLAG_FAIL_IMMEDIATELY` and
  returns `false` for a range another open holds rather than raising. A server
  refusing such a request answers `STATUS_LOCK_NOT_GRANTED`, which is what
  Samba sends, or `STATUS_FILE_LOCK_CONFLICT`; both are read as the range being
  held.
- `unlock(position, size)` releases a range, which has to be one that was
  locked, since a server matches an unlock against the ranges it recorded
  rather than against whatever bytes overlap.

`tryLock` is what makes the fail-immediately flag reachable. Without it a
caller has only a lock that waits, and a range held elsewhere stops the calling
thread for as long as the holder keeps it.

Locking is SMB2 only. SMB1 has LOCKING_ANDX, but this client builds it solely
to decode an inbound oplock break and has no outbound lock path, so a lock over
SMB1 is refused with `SmbUnsupportedOperationException` rather than appearing
to have locked something.

## A documented claim this falsifies

The reasons durable handles are not planned included that this client takes no
byte-range locks. That stops being true here, and behind it sits a caveat now
written down: a dropped connection is recovered by reopening the path, which
gives a new open, and a lock belongs to the open that took it — so a lock taken
before the drop is gone afterwards and nothing replays it. What rules durable
handles out is unaffected, since the batch oplock or `R|H` lease that a durable
open has to qualify with cannot be requested at all today.

## Verification

- Unit tests: 8810, 0 failures, 0 skipped (6 new; 8804 before).
- Integration tests against Samba: 215, 0 failures, 5 skipped (2 new; 213
  before).
- clirr against 3.0.3: 1 error, unchanged from `main`. Three methods added to a
  public interface produce three breakages, so the count holding at 1 rather
  than rising is what shows all three `<ignored>` entries actually match.
- apache-rat: 0 unapproved.
- The unit tests were written first and watched fail: five against a throwing
  stub, and the SMB1 case on the wrong exception type, which is what shows it
  pins the type rather than merely that something threw.
- The integration case cannot pass vacuously. Had the lock not been recorded,
  the contending `tryLock` would have been granted; had the refusal carried any
  status other than the two treated as "held", it would have raised; had
  `unlock` been a no-op, the follow-up `tryLock` would still have been refused.
  The shared-lock case is paired with it deliberately: either test alone would
  pass with shared and exclusive reversed, and together they do not.

## Compatibility

Three new methods on the public `SmbRandomAccess` interface, so a class
implementing that interface outside the library would have to supply them. The
interface is obtained from `SmbResource.openRandomAccess(...)` and is not meant
to be implemented externally. The three are recorded in the clirr `<ignored>`
list next to the existing 7012 entries.
