### PR TITLE
test(it): assert what five integration tests only looked like they did

### DIFF
--- a/src/test/java/org/codelibs/jcifs/smb/it/ByteRangeLockIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/ByteRangeLockIT.java
@@ -16,13 +16,17 @@
 package org.codelibs.jcifs.smb.it;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.impl.SmbException;
 import org.codelibs.jcifs.smb.impl.SmbFile;
 import org.codelibs.jcifs.smb.impl.SmbRandomAccessFile;
+import org.codelibs.jcifs.smb.it.env.TcpRelay;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,6 +41,11 @@ import org.junit.jupiter.api.Test;
  * </p>
  */
 class ByteRangeLockIT extends AbstractSmbIT {
+
+    /** Generous, because it only bounds a wait that normally ends on the first attempt. */
+    private static final long RELEASE_TIMEOUT_SECONDS = 30;
+
+    private static final long POLL_MILLIS = 50;
 
     private SmbFile workDir;
 
@@ -89,6 +98,60 @@ class ByteRangeLockIT extends AbstractSmbIT {
             contender.unlock(0, 4);
             holder.unlock(0, 4);
         }
+    }
+
+    @Test
+    @DisplayName("a lock is gone once the connection under it drops, and the reopened handle holds no range")
+    void lockDoesNotSurviveAReconnect() throws Exception {
+        final CIFSContext context = server().context();
+        this.workDir = createWorkDir(context, server().share());
+        final SmbFile file = writeFile(this.workDir, "reconnect.bin", "0123456789");
+
+        // The holder goes through the relay so its connection can be cut; the contender goes straight to the server
+        // so it survives the cut. That also puts them on separate transports by construction rather than by
+        // configuration, which is what makes the contention real.
+        try (TcpRelay relay = TcpRelay.to(server().host(), server().port())) {
+            final String viaRelay = "smb://" + relay.host() + ":" + relay.port() + file.getURL().getPath();
+
+            try (SmbFile holderFile = new SmbFile(viaRelay, context);
+                    SmbRandomAccessFile holder = holderFile.openRandomAccess("rw");
+                    SmbFile contenderFile = otherConnection(file);
+                    SmbRandomAccessFile contender = contenderFile.openRandomAccess("rw")) {
+
+                holder.lock(0, 4, false);
+                assertFalse(contender.tryLock(0, 4, false), "the range should be held while the holder's connection is up");
+
+                relay.dropConnections();
+
+                // A lock belongs to the open that took it, and a dropped connection is recovered by reopening the
+                // path, which yields a new open holding nothing. Were the ranges replayed onto the reopened handle -
+                // which is what a durable handle buys and the obvious "fix" to reach for - this would stay refused.
+                assertTrue(awaitGranted(contender, 0, 4), "the lock should not have survived the drop");
+                contender.unlock(0, 4);
+
+                // And the holder's own reopened handle has no record of the range, so releasing it is an error
+                // rather than a no-op. This is the caveat callers have to live with, stated as a test.
+                assertThrows(SmbException.class, () -> holder.unlock(0, 4),
+                        "unlocking a range the reopened handle never locked should fail");
+            }
+        }
+    }
+
+    /**
+     * Waits for the range to become available, which needs the server to have noticed the dropped connection and
+     * torn the holder's open down. Samba does this as soon as it sees the socket close - the relay closes the
+     * server-facing side too - so this normally succeeds on the first attempt; the deadline is only insurance
+     * against a slower server.
+     */
+    private static boolean awaitGranted(final SmbRandomAccessFile contender, final long position, final long size) throws Exception {
+        final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(RELEASE_TIMEOUT_SECONDS);
+        while (System.nanoTime() < deadline) {
+            if (contender.tryLock(position, size, false)) {
+                return true;
+            }
+            Thread.sleep(POLL_MILLIS);
+        }
+        return false;
     }
 
     /**

--- a/src/test/java/org/codelibs/jcifs/smb/it/DfsIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/DfsIT.java
@@ -16,6 +16,7 @@
 package org.codelibs.jcifs.smb.it;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -77,9 +78,26 @@ class DfsIT extends AbstractSmbIT {
     @DisplayName("a link whose name extends another link's name resolves to its own target")
     void linkWithAnOverlappingPrefixIsNotConfusedWithTheShorterOne() throws Exception {
         final CIFSContext context = server().context();
+        final String fileName = "dfs-prefix-" + UUID.randomUUID() + ".txt";
+
+        // The two links point at different shares on purpose, so a file placed in one target is the observable that
+        // says which target a link reached. Checking only that both links resolve cannot see the defect this fixture
+        // exists to catch: a referral that maps the whole "link-extra" component to "link"'s target reaches a real
+        // share, so both links still exist. The narrower form, where "-extra" is left over and appended, was caught
+        // before; this covers the form that was not.
+        final SmbFile direct = new SmbFile(server().url(server().share(), fileName), context);
+        direct.createNewFile();
+        this.workDir = direct;
+
         try (SmbFile shorter = new SmbFile(dfsPath("link"), context); SmbFile longer = new SmbFile(dfsPath("link-extra"), context)) {
             assertTrue(shorter.exists(), "link should resolve");
             assertTrue(longer.exists(), "link-extra should resolve");
+        }
+
+        try (SmbFile viaShorter = new SmbFile(dfsPath("link") + fileName, context);
+                SmbFile viaLonger = new SmbFile(dfsPath("link-extra") + fileName, context)) {
+            assertTrue(viaShorter.exists(), "the file should be reachable through the link pointing at its share");
+            assertFalse(viaLonger.exists(), "link-extra points at a different share, so the file must not be reachable through it");
         }
     }
 

--- a/src/test/java/org/codelibs/jcifs/smb/it/SmbFileIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/SmbFileIT.java
@@ -30,8 +30,11 @@ import java.util.Properties;
 
 import org.codelibs.jcifs.smb.CIFSContext;
 import org.codelibs.jcifs.smb.CIFSException;
+import org.codelibs.jcifs.smb.SmbConstants;
 import org.codelibs.jcifs.smb.SmbResource;
+import org.codelibs.jcifs.smb.impl.NtStatus;
 import org.codelibs.jcifs.smb.impl.NtlmPasswordAuthenticator;
+import org.codelibs.jcifs.smb.impl.SmbException;
 import org.codelibs.jcifs.smb.impl.SmbFile;
 import org.codelibs.jcifs.smb.impl.SmbRandomAccessFile;
 import org.codelibs.jcifs.smb.it.env.RequiresBackend;
@@ -297,15 +300,12 @@ class SmbFileIT extends AbstractSmbIT {
 
             assertFalse(file.exists(), "File should not exist initially");
 
-            // Deleting a non-existent file may throw exception depending on implementation
-            try {
-                file.delete();
-            } catch (final Exception e) {
-                // Expected behavior - deleting non-existent file may throw
-                log.debug("Delete non-existent file threw exception (expected): {}", e.getMessage());
-            }
-
-            assertFalse(file.exists(), "File should still not exist after delete attempt");
+            // delete() decides this itself rather than leaving it to the server: it checks existence first and
+            // raises OBJECT_NAME_NOT_FOUND. Swallowing that hid a guaranteed failure and left the test passing for
+            // any behaviour at all, including a delete that removed some other path.
+            final SmbException e = assertThrows(SmbException.class, file::delete, "deleting a file that does not exist must fail");
+            assertEquals(NtStatus.NT_STATUS_OBJECT_NAME_NOT_FOUND, e.getNtStatus(),
+                    "unexpected status: 0x" + Integer.toHexString(e.getNtStatus()));
         }
     }
 
@@ -369,19 +369,22 @@ class SmbFileIT extends AbstractSmbIT {
             dir.mkdir();
 
             // Create a file inside
-            new SmbFile(createSmbUrl("users", "nonempty/file.txt"), context).createNewFile();
+            final SmbFile child = new SmbFile(createSmbUrl("users", "nonempty/file.txt"), context);
+            child.createNewFile();
 
-            // Attempting to delete non-empty directory should fail or require recursive deletion
-            // The behavior may vary, but the directory should still exist if simple delete is used
-            try {
-                dir.delete();
-            } catch (final Exception e) {
-                // Expected if the implementation doesn't allow deleting non-empty directories
+            // delete() recurses into the directory itself, so it is the API under test here and not a step to be
+            // stood in for. Deleting the contents from the test first, as this used to, meant a delete() whose own
+            // recursion was broken still left an empty directory to remove, and the test passed either way.
+            dir.delete();
+
+            // Asked again through fresh handles, because exists() serves a cached answer for up to
+            // jcifs.client.attrExpirationPeriod (5 s by default) and only the instance that performed the delete
+            // clears its own cache, so a sibling handle can still report a deleted file as present.
+            try (SmbFile childAgain = new SmbFile(createSmbUrl("users", "nonempty/file.txt"), context);
+                    SmbFile dirAgain = new SmbFile(createSmbUrl("users", "nonempty/"), context)) {
+                assertFalse(childAgain.exists(), "delete() should have removed the directory's contents");
+                assertFalse(dirAgain.exists(), "delete() should have removed the directory itself");
             }
-
-            // Verify we can delete recursively
-            deleteRecursively(dir);
-            assertFalse(dir.exists(), "Directory should be deleted after recursive deletion");
         }
     }
 
@@ -654,6 +657,8 @@ class SmbFileIT extends AbstractSmbIT {
             // Set read-only
             file.setReadOnly();
             assertTrue(file.canRead(), "File should still be readable");
+            // Without this the read-only state itself went unchecked, so setReadOnly() doing nothing would pass
+            assertFalse(file.canWrite(), "File should not be writable while read-only");
 
             // Set back to read-write
             file.setReadWrite();
@@ -668,17 +673,18 @@ class SmbFileIT extends AbstractSmbIT {
 
             file.createNewFile();
 
-            // Get current attributes
             final int attrs = file.getAttributes();
-            assertNotNull(attrs, "Attributes should not be null");
 
-            // Note: Setting specific attributes depends on SMB server support
-            // Just verify the methods don't throw exceptions
-            try {
-                file.setAttributes(attrs);
-            } catch (final Exception e) {
-                log.debug("setAttributes threw exception (may not be fully supported): {}", e.getMessage());
-            }
+            // assertNotNull on an int is unfalsifiable once it is boxed, so this asserted nothing whatsoever: a
+            // getAttributes() returning garbage, and a setAttributes() throwing every time, both passed. What can
+            // be checked is that a bit written comes back, since ATTR_READONLY (0x01) survives both ATTR_SET_MASK
+            // and ATTR_GET_MASK, and setPathInformation expires the attribute cache so the read reaches the server.
+            file.setAttributes(attrs | SmbConstants.ATTR_READONLY);
+            assertEquals(SmbConstants.ATTR_READONLY, file.getAttributes() & SmbConstants.ATTR_READONLY,
+                    "the read-only bit should survive a round trip through the server");
+
+            file.setAttributes(attrs & ~SmbConstants.ATTR_READONLY);
+            assertEquals(0, file.getAttributes() & SmbConstants.ATTR_READONLY, "the read-only bit should have been cleared again");
         }
 
         @Test


### PR DESCRIPTION
## What this changes

Five integration tests asserted less than their names claimed. Four of
them could not fail at all, or could not fail for the reason they gave.

| Test | What it asserted | What it missed |
| --- | --- | --- |
| `SmbFileIT.testGetAndSetAttributes` | `assertNotNull` on an `int` | Boxing makes this unfalsifiable, so the test had no failure mode whatsoever |
| `SmbFileIT.testDeleteNonEmptyDirectory` | that the test's own recursive helper worked | `delete()` recurses itself, so a broken recursion still passed |
| `SmbFileIT.testDeleteNonExistentFile` | that a file never created does not exist | the guaranteed `OBJECT_NAME_NOT_FOUND` was swallowed |
| `SmbFileIT.testSetReadOnlyAndReadWrite` | `canRead()` after `setReadOnly()` | a `setReadOnly()` that did nothing passed |
| `DfsIT.linkWithAnOverlappingPrefix…` | that both DFS links resolve | never checked *which* target each link reached |

Each now asserts a server-observable fact, grounded in the implementation
rather than guessed at:

- Attributes: writes `ATTR_READONLY` and reads it back. That bit survives
  both `ATTR_SET_MASK` and `ATTR_GET_MASK`, and `setPathInformation`
  expires the attribute cache, so the read reaches the server.
- Non-empty directory: calls `delete()` alone and asserts the contents and
  the directory are both gone, because `delete()` is the recursion under
  test.
- Missing path: asserts the specific NT status, which `delete()` raises
  itself rather than leaving to the server.
- DFS: the fixture points `link` and `link-extra` at different shares
  deliberately, since unbounded prefix matching has been a recurring
  defect. A file placed in one target must be reachable through the link
  pointing there and not through the other. A referral that maps the whole
  `link-extra` component to `link`'s target reaches a real share, which is
  why an `exists()`-only check cannot see it.

## A documented claim that nothing verified

`docs/SMB3_SUPPORT.md` states that a byte range lock does not survive a
reconnect, and that this is a caveat for callers rather than an argument
for durable handles. No test covered it. `ByteRangeLockIT` now does: the
holder locks through a `TcpRelay` while the contender contends from a
direct connection, so the two are on separate transports by construction
rather than by configuration. After the connection drops, the contending
`tryLock` must be granted and the holder's own `unlock` must fail, since
the reconnect reopens by path and the new open recorded no range.

## Verification

- Unit tests: 8810, 0 failures, 0 skipped.
- Integration tests against Samba: 216, 0 failures, 5 skipped.
- clirr against 3.0.3: 1 error, 1 warning, unchanged — no production code
  is touched by this change.
- apache-rat: 0 unapproved.
- The lock test was measured before it was written. A throwaway probe
  showed the range is released as soon as the server sees the socket
  close, because the relay closes the server-facing side too rather than
  leaving the server to time out. The whole class runs in under a tenth of
  a second, so the bounded wait is insurance against a slower server, not
  a tolerance for flakiness.
- Two assertions were corrected during the work rather than forced
  through. The non-empty-directory case was first written to assert that
  `delete()` refuses, which is wrong because it recurses. The existence
  checks first used the same handles that performed the mutation, which
  reported a deleted file as present, because `exists()` serves a cached
  answer for five seconds and only the instance that performed the delete
  clears its own cache; they now go through fresh handles, as
  `OutputStreamReconnectIT` already does for the same reason.

## Scope

Tests only. No production code, no public API, no configuration.
