### PR TITLE
feat(smb3): negotiate and use the AES-256 encryption ciphers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ JCIFS is a comprehensive, pure Java implementation of the CIFS/SMB networking pr
 - **SMB2**: Full SMB 2.0.2, 2.1 support with enhanced performance
 - **SMB3**: Complete SMB 3.0, 3.0.2, 3.1.1 implementation featuring:
   - **AES-128-CCM encryption** (SMB 3.0/3.0.2)
-  - **AES-128-GCM encryption** (SMB 3.1.1)
+  - **AES-128-GCM and AES-128-CCM encryption** (SMB 3.1.1)
+  - **AES-256-GCM and AES-256-CCM encryption** (SMB 3.1.1), offered by default and
+    selectable with `jcifs.client.encryptionCiphers`
   - **Pre-Authentication Integrity** (SMB 3.1.1)
   - **AES-CMAC signing** for data integrity
   - **Automatic protocol negotiation**

--- a/docs/SMB3_SUPPORT.md
+++ b/docs/SMB3_SUPPORT.md
@@ -40,7 +40,7 @@ persistent handles, multi-channel, directory leasing, RDMA, witness, compression
 | SMB1 / CIFS | Supported | Legacy; also the default multi-protocol negotiate bootstrap. |
 | SMB 2.0.2, 2.1 | Supported | |
 | SMB 3.0, 3.0.2 | Supported | Signing and AES-128-CCM encryption. |
-| SMB 3.1.1 | Supported | Pre-auth integrity, negotiate contexts, AES-128-GCM encryption. |
+| SMB 3.1.1 | Supported | Pre-auth integrity, negotiate contexts, AES-128 and AES-256 encryption in GCM or CCM. |
 
 Selection is controlled by `jcifs.client.minVersion` (default `SMB1`) and
 `jcifs.client.maxVersion` (default `SMB311`), so **SMB 3.1.1 is reachable with
@@ -81,12 +81,12 @@ nothing else in the API changes.
 | Feature | Status | Notes |
 | --- | --- | --- |
 | AES-128-CCM (SMB 3.0, 3.0.2) | Supported | |
-| AES-128-GCM (SMB 3.1.1) | Supported | Preferred when the server offers both. |
-| `ENCRYPTION_CAPABILITIES` negotiation | Supported | Sent only when encryption is enabled. |
+| AES-128-GCM (SMB 3.1.1) | Supported | Listed first by default, which is what keeps the cipher an existing deployment negotiates unchanged. |
+| AES-256-GCM, AES-256-CCM (SMB 3.1.1) | Supported | Offered by default, after the AES-128 ciphers. The cipher keys are derived at 32 bytes; the signing key stays 16. |
+| `ENCRYPTION_CAPABILITIES` negotiation | Supported | Sent only when encryption is enabled. The offered ciphers, and their order, come from `jcifs.client.encryptionCiphers`. |
 | Per-session encryption (`SMB2_SESSION_FLAG_ENCRYPT_DATA`) | Supported | |
 | Per-share encryption (`SMB2_SHAREFLAG_ENCRYPT_DATA`) | Supported | Recorded on tree connect; a plaintext share on the same connection stays plaintext. |
 | Encryption of compound chains | Supported | The whole chain is wrapped in one transform header. |
-| AES-256-CCM / AES-256-GCM | Not implemented | Not negotiated. |
 
 How it behaves:
 
@@ -122,7 +122,7 @@ the fix in #92.
 | Context | Status |
 | --- | --- |
 | `PREAUTH_INTEGRITY_CAPABILITIES` (0x1) | Supported, SHA-512 only. A response without it fails the connection. |
-| `ENCRYPTION_CAPABILITIES` (0x2) | Supported, AES-128-CCM and AES-128-GCM. Sent only when encryption is enabled. |
+| `ENCRYPTION_CAPABILITIES` (0x2) | Supported, all four ciphers: AES-128-CCM, AES-128-GCM, AES-256-CCM, AES-256-GCM. Sent only when encryption is enabled. |
 | `COMPRESSION_CAPABILITIES` (0x3) | Not implemented |
 | `NETNAME_NEGOTIATE_CONTEXT_ID` (0x5) | Not implemented |
 | `TRANSPORT_CAPABILITIES` (0x6) | Not implemented |
@@ -325,6 +325,7 @@ file on its first open, as it always has.
 | `jcifs.client.ipcSigningEnforced` | `true` | Require signing on IPC$. |
 | `jcifs.client.requireSecureNegotiate` | `true` | Validate the negotiate exchange on tree connect. |
 | `jcifs.client.encryptionEnabled` | `false` | Opt in to SMB3 encryption — see [Encryption](#encryption). |
+| `jcifs.client.encryptionCiphers` | `AES-128-GCM, AES-128-CCM, AES-256-GCM, AES-256-CCM` | The SMB 3.1.1 ciphers to offer, in preference order. An unrecognised name fails configuration rather than being ignored. Note that the server chooses one from the offered list and may apply its own preference when doing so, so listing AES-256 first does not make AES-256 the negotiated cipher; offering only the AES-256 ciphers does require them. No effect below SMB 3.1.1, which does not negotiate a cipher. |
 | `jcifs.client.maxTransferSize` | `1048576` | Largest payload a single SMB2 read or write may carry. The negotiated size is the smaller of this and the server's offer. Has no effect below SMB 2.1, which cannot carry more than 64 KiB in one request. |
 | `jcifs.client.transaction_buf_size` | `65535` | Drives the transact size, and the read and write ceilings on SMB 2.0.2 and SMB1. 512 bytes are subtracted from it, giving an effective 65023. |
 | `jcifs.client.ssnLimit` | `250` | Sessions per connection before a new connection is opened. |

--- a/src/main/java/org/codelibs/jcifs/smb/Configuration.java
+++ b/src/main/java/org/codelibs/jcifs/smb/Configuration.java
@@ -493,13 +493,35 @@ public interface Configuration {
     /**
      * Property {@code jcifs.client.encryptionEnabled} (boolean, default false)
      *
-     * Enables SMB3 encryption. When enabled the client advertises AES-128-GCM and AES-128-CCM during protocol
-     * negotiation and encrypts traffic on any session or share for which the server requires it.
+     * Enables SMB3 encryption. When enabled the client advertises the ciphers given by
+     * {@link #getEncryptionCiphers()} during protocol negotiation and encrypts traffic on any session or share for
+     * which the server requires it.
      *
      * @return whether SMB encryption is enabled
      * @since 2.1
      */
     boolean isEncryptionEnabled();
+
+    /**
+     * Property {@code jcifs.client.encryptionCiphers} (comma-separated, default
+     * {@code AES-128-GCM, AES-128-CCM, AES-256-GCM, AES-256-CCM})
+     *
+     * The SMB 3.1.1 encryption ciphers to offer, in order of preference. Recognised names are
+     * {@code AES-128-CCM}, {@code AES-128-GCM}, {@code AES-256-CCM} and {@code AES-256-GCM}; an unrecognised name
+     * is an error rather than being ignored. Only consulted when {@link #isEncryptionEnabled()} is set, and only
+     * on SMB 3.1.1, which is the only dialect that negotiates a cipher in a negotiate context - SMB 3.0 and 3.0.2
+     * always use AES-128-CCM.
+     *
+     * <p>
+     * Note that this states a preference rather than a requirement. The server picks one cipher from the offered
+     * list and is free to apply its own order of preference when doing so, so listing AES-256 first does not
+     * guarantee AES-256 is what gets negotiated. Offering only the AES-256 ciphers does require them, at the cost
+     * of failing against a server that does not implement them.
+     * </p>
+     *
+     * @return the encryption cipher identifiers to offer, in preference order
+     */
+    int[] getEncryptionCiphers();
 
     /**
      *

--- a/src/main/java/org/codelibs/jcifs/smb/config/BaseConfiguration.java
+++ b/src/main/java/org/codelibs/jcifs/smb/config/BaseConfiguration.java
@@ -36,6 +36,7 @@ import org.codelibs.jcifs.smb.Configuration;
 import org.codelibs.jcifs.smb.DialectVersion;
 import org.codelibs.jcifs.smb.ResolverType;
 import org.codelibs.jcifs.smb.SmbConstants;
+import org.codelibs.jcifs.smb.internal.smb2.nego.EncryptionNegotiateContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,6 +77,8 @@ public class BaseConfiguration implements Configuration {
     protected boolean ipcSigningEnforced = true;
     /** Whether SMB3 encryption is enabled */
     protected boolean encryptionEnabled = false;
+    /** SMB 3.1.1 encryption ciphers to offer, in preference order */
+    protected int[] encryptionCiphers;
     /** Whether to use NT status codes instead of DOS error codes */
     protected boolean useNtStatus = true;
     /** Whether to use extended security negotiation */
@@ -567,6 +570,11 @@ public class BaseConfiguration implements Configuration {
     }
 
     @Override
+    public int[] getEncryptionCiphers() {
+        return this.encryptionCiphers;
+    }
+
+    @Override
     public boolean isForceExtendedSecurity() {
         return this.forceExtendedSecurity;
     }
@@ -773,6 +781,65 @@ public class BaseConfiguration implements Configuration {
     }
 
     /**
+     * Initializes the SMB 3.1.1 encryption ciphers to offer.
+     *
+     * <p>
+     * Unlike the resolver order, an unrecognised name here is fatal rather than logged and skipped. Dropping an
+     * entry would leave the client offering something other than what was configured, and a typo in a cipher list
+     * changes what protects the data - this is the one case that must not fail open.
+     * </p>
+     *
+     * @param prop comma-separated list of cipher names, in preference order, or null for the default
+     * @throws CIFSException if a cipher name is not recognised
+     */
+    protected void initEncryptionCiphers(final String prop) throws CIFSException {
+        if (prop == null || prop.trim().isEmpty()) {
+            // AES-128-GCM leads deliberately. A server chooses one cipher from the client's offer and may apply
+            // its own preference order when doing so, so leading with AES-128 leaves the cipher an existing
+            // deployment negotiates exactly as it was, while still making AES-256 available to a server that
+            // prefers it.
+            this.encryptionCiphers = new int[] { EncryptionNegotiateContext.CIPHER_AES128_GCM, EncryptionNegotiateContext.CIPHER_AES128_CCM,
+                    EncryptionNegotiateContext.CIPHER_AES256_GCM, EncryptionNegotiateContext.CIPHER_AES256_CCM };
+            return;
+        }
+
+        final List<Integer> ciphers = new ArrayList<>();
+        final StringTokenizer st = new StringTokenizer(prop, ",");
+        while (st.hasMoreTokens()) {
+            final String name = st.nextToken().trim();
+            if (name.isEmpty()) {
+                continue;
+            }
+            ciphers.add(cipherByName(name));
+        }
+        if (ciphers.isEmpty()) {
+            throw new CIFSException("No encryption cipher named in jcifs.client.encryptionCiphers: " + prop);
+        }
+
+        this.encryptionCiphers = new int[ciphers.size()];
+        for (int i = 0; i < ciphers.size(); i++) {
+            this.encryptionCiphers[i] = ciphers.get(i);
+        }
+    }
+
+    private static int cipherByName(final String name) throws CIFSException {
+        if (name.equalsIgnoreCase("AES-128-CCM")) {
+            return EncryptionNegotiateContext.CIPHER_AES128_CCM;
+        }
+        if (name.equalsIgnoreCase("AES-128-GCM")) {
+            return EncryptionNegotiateContext.CIPHER_AES128_GCM;
+        }
+        if (name.equalsIgnoreCase("AES-256-CCM")) {
+            return EncryptionNegotiateContext.CIPHER_AES256_CCM;
+        }
+        if (name.equalsIgnoreCase("AES-256-GCM")) {
+            return EncryptionNegotiateContext.CIPHER_AES256_GCM;
+        }
+        throw new CIFSException(
+                "Unknown encryption cipher '" + name + "'; expected one of AES-128-CCM, AES-128-GCM, AES-256-CCM, AES-256-GCM");
+    }
+
+    /**
      * Initializes the disallowed compound operations based on the provided property string.
      *
      * @param prop comma-separated list of operations to disallow in compound requests
@@ -847,6 +914,12 @@ public class BaseConfiguration implements Configuration {
 
         if (this.minVersion == null || this.maxVersion == null) {
             initProtocolVersions((DialectVersion) null, null);
+        }
+
+        if (this.encryptionCiphers == null) {
+            // Every configuration needs this, not just the property-driven one: an unset array would reach
+            // EncryptionNegotiateContext as null the first time a caller enables encryption.
+            initEncryptionCiphers(null);
         }
 
         if (this.disallowCompound == null) {

--- a/src/main/java/org/codelibs/jcifs/smb/config/DelegatingConfiguration.java
+++ b/src/main/java/org/codelibs/jcifs/smb/config/DelegatingConfiguration.java
@@ -629,6 +629,16 @@ public class DelegatingConfiguration implements Configuration {
     /**
      * {@inheritDoc}
      *
+     * @see org.codelibs.jcifs.smb.Configuration#getEncryptionCiphers()
+     */
+    @Override
+    public int[] getEncryptionCiphers() {
+        return this.delegate.getEncryptionCiphers();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * @see org.codelibs.jcifs.smb.Configuration#getLmHostsFileName()
      */
     @Override

--- a/src/main/java/org/codelibs/jcifs/smb/config/PropertyConfiguration.java
+++ b/src/main/java/org/codelibs/jcifs/smb/config/PropertyConfiguration.java
@@ -114,6 +114,7 @@ public final class PropertyConfiguration extends BaseConfiguration implements Co
         this.signingEnforced = Config.getBoolean(p, "jcifs.client.signingEnforced", false);
         this.ipcSigningEnforced = Config.getBoolean(p, "jcifs.client.ipcSigningEnforced", true);
         this.encryptionEnabled = Config.getBoolean(p, "jcifs.client.encryptionEnabled", false);
+        initEncryptionCiphers(p.getProperty("jcifs.client.encryptionCiphers"));
         this.requireSecureNegotiate = Config.getBoolean(p, "jcifs.client.requireSecureNegotiate", true);
         this.sendNTLMTargetName = Config.getBoolean(p, "jcifs.client.SendNTLMTargetName", true);
 

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbTransportImpl.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbTransportImpl.java
@@ -2138,10 +2138,13 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
         }
 
         try {
-            // Derive encryption and decryption keys using SMB3 KDF
+            // Derive encryption and decryption keys using SMB3 KDF, at the length the negotiated cipher requires:
+            // the AES-256 ciphers need 32 bytes. Only the cipher keys vary - the signing key stays 16 bytes
+            // whatever was negotiated, which is why the length is passed here and not inside the derivation.
             final int dialectInt = dialect.getDialect();
-            final byte[] encryptionKey = Smb3KeyDerivation.deriveEncryptionKey(dialectInt, sessionKey, preauthHash);
-            final byte[] decryptionKey = Smb3KeyDerivation.deriveDecryptionKey(dialectInt, sessionKey, preauthHash);
+            final int keyLength = Smb2EncryptionContext.keyLength(cipherId);
+            final byte[] encryptionKey = Smb3KeyDerivation.deriveEncryptionKey(dialectInt, sessionKey, preauthHash, keyLength);
+            final byte[] decryptionKey = Smb3KeyDerivation.deriveDecryptionKey(dialectInt, sessionKey, preauthHash, keyLength);
 
             return new Smb2EncryptionContext(cipherId, dialect, encryptionKey, decryptionKey);
         } catch (final Exception e) {

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/Smb2EncryptionContext.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/Smb2EncryptionContext.java
@@ -62,7 +62,14 @@ public class Smb2EncryptionContext {
      * AES-128-GCM cipher identifier for SMB3.1.1 encryption
      */
     public static final int CIPHER_AES_128_GCM = EncryptionNegotiateContext.CIPHER_AES128_GCM;
-    // Note: AES-256 variants are not currently defined in the negotiate context
+    /**
+     * AES-256-CCM cipher identifier for SMB3.1.1 encryption
+     */
+    public static final int CIPHER_AES_256_CCM = EncryptionNegotiateContext.CIPHER_AES256_CCM;
+    /**
+     * AES-256-GCM cipher identifier for SMB3.1.1 encryption
+     */
+    public static final int CIPHER_AES_256_GCM = EncryptionNegotiateContext.CIPHER_AES256_GCM;
 
     /**
      * Transform header flag indicating the message is encrypted
@@ -86,8 +93,39 @@ public class Smb2EncryptionContext {
         this.dialect = dialect;
         this.encryptionKey = encryptionKey.clone();
         this.decryptionKey = decryptionKey.clone();
+        checkKeyLength("encryption", this.encryptionKey);
+        checkKeyLength("decryption", this.decryptionKey);
         this.noncePrefix = new byte[Math.max(0, getNonceLength() - Long.BYTES)];
         this.secureRandom.nextBytes(this.noncePrefix);
+    }
+
+    /**
+     * Key length in bytes required by a cipher.
+     *
+     * @param cipherId
+     *            the negotiated cipher identifier
+     * @return the required key length in bytes
+     */
+    public static int keyLength(final int cipherId) {
+        return cipherId == CIPHER_AES_256_CCM || cipherId == CIPHER_AES_256_GCM ? Smb3KeyDerivation.CIPHER_KEY_LENGTH_256
+                : Smb3KeyDerivation.CIPHER_KEY_LENGTH_128;
+    }
+
+    /**
+     * Refuses a key that is not the length the negotiated cipher calls for.
+     *
+     * <p>
+     * Nothing downstream would notice: BouncyCastle takes the AES key size from the length of the key it is
+     * handed, so a 16-byte key under an AES-256 cipher id encrypts as AES-128 and succeeds. The session comes up,
+     * traffic flows, and the cipher the client believes it negotiated is not the one protecting the data.
+     * </p>
+     */
+    private void checkKeyLength(final String which, final byte[] key) {
+        final int required = keyLength(this.cipherId);
+        if (key.length != required) {
+            throw new IllegalArgumentException(String.format("Cipher 0x%04x requires a %d-byte %s key but was given %d bytes",
+                    this.cipherId, required, which, key.length));
+        }
     }
 
     /**
@@ -256,7 +294,10 @@ public class Smb2EncryptionContext {
     }
 
     private boolean isGCMCipher() {
-        return this.cipherId == CIPHER_AES_128_GCM;
+        // Set membership rather than equality with the 128-bit id: AES-256-GCM would otherwise fall through to the
+        // CCM branch and be built as a CCM cipher with an 11-byte nonce. getNonceLength() is also called from the
+        // constructor to size the nonce prefix, so a misclassification is wrong from construction onwards.
+        return this.cipherId == CIPHER_AES_128_GCM || this.cipherId == CIPHER_AES_256_GCM;
     }
 
     private int getAuthTagLength() {

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/Smb3KeyDerivation.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/Smb3KeyDerivation.java
@@ -33,6 +33,12 @@ import org.bouncycastle.crypto.params.KDFCounterParameters;
  */
 public final class Smb3KeyDerivation {
 
+    /** Cipher key length for the AES-128 ciphers, and the length of every other derived key. */
+    public static final int CIPHER_KEY_LENGTH_128 = 16;
+
+    /** Cipher key length for the AES-256 ciphers (SMB 3.1.1 only). */
+    public static final int CIPHER_KEY_LENGTH_256 = 32;
+
     private static final byte[] SIGNCONTEXT_300 = toCBytes("SmbSign");
     private static final byte[] SIGNLABEL_300 = toCBytes("SMB2AESCMAC");
     private static final byte[] SIGNLABEL_311 = toCBytes("SMBSigningKey");
@@ -64,8 +70,10 @@ public final class Smb3KeyDerivation {
      * @return derived signing key
      */
     public static byte[] deriveSigningKey(final int dialect, final byte[] sessionKey, final byte[] preauthIntegrity) {
+        // Always 16 bytes, whatever cipher was negotiated. Passed explicitly rather than defaulted so that the
+        // asymmetry with the cipher keys is visible here, at the call site that must never change.
         return derive(sessionKey, dialect == Smb2Constants.SMB2_DIALECT_0311 ? SIGNLABEL_311 : SIGNLABEL_300,
-                dialect == Smb2Constants.SMB2_DIALECT_0311 ? preauthIntegrity : SIGNCONTEXT_300);
+                dialect == Smb2Constants.SMB2_DIALECT_0311 ? preauthIntegrity : SIGNCONTEXT_300, CIPHER_KEY_LENGTH_128);
     }
 
     /**
@@ -78,7 +86,7 @@ public final class Smb3KeyDerivation {
      */
     public static byte[] dervieApplicationKey(final int dialect, final byte[] sessionKey, final byte[] preauthIntegrity) {
         return derive(sessionKey, dialect == Smb2Constants.SMB2_DIALECT_0311 ? APPLABEL_311 : APPLABEL_300,
-                dialect == Smb2Constants.SMB2_DIALECT_0311 ? preauthIntegrity : APPCONTEXT_300);
+                dialect == Smb2Constants.SMB2_DIALECT_0311 ? preauthIntegrity : APPCONTEXT_300, CIPHER_KEY_LENGTH_128);
     }
 
     /**
@@ -90,8 +98,30 @@ public final class Smb3KeyDerivation {
      * @return derived encryption key
      */
     public static byte[] deriveEncryptionKey(final int dialect, final byte[] sessionKey, final byte[] preauthIntegrity) {
+        return deriveEncryptionKey(dialect, sessionKey, preauthIntegrity, CIPHER_KEY_LENGTH_128);
+    }
+
+    /**
+     * Derives the SMB3 encryption key at the length the negotiated cipher requires.
+     *
+     * <p>
+     * Only the cipher keys take a length: AES-256-GCM and AES-256-CCM need 32 bytes, while the signing key stays
+     * 16 bytes whatever cipher was negotiated. That asymmetry is the reason this is an overload rather than a
+     * change to the shared derivation - a 32-byte signing key is accepted by AES-CMAC without complaint and still
+     * produces a 16-byte tag, so it would break signing against real servers while every self-consistent test
+     * stayed green.
+     * </p>
+     *
+     * @param dialect the SMB dialect version
+     * @param sessionKey the base session key
+     * @param preauthIntegrity the pre-authentication integrity hash (for SMB 3.1.1) or null
+     * @param keyLengthBytes the derived key length in bytes
+     * @return derived encryption key
+     */
+    public static byte[] deriveEncryptionKey(final int dialect, final byte[] sessionKey, final byte[] preauthIntegrity,
+            final int keyLengthBytes) {
         return derive(sessionKey, dialect == Smb2Constants.SMB2_DIALECT_0311 ? ENCLABEL_311 : ENCLABEL_300,
-                dialect == Smb2Constants.SMB2_DIALECT_0311 ? preauthIntegrity : ENCCONTEXT_300);
+                dialect == Smb2Constants.SMB2_DIALECT_0311 ? preauthIntegrity : ENCCONTEXT_300, keyLengthBytes);
     }
 
     /**
@@ -103,8 +133,22 @@ public final class Smb3KeyDerivation {
      * @return derived decryption key
      */
     public static byte[] deriveDecryptionKey(final int dialect, final byte[] sessionKey, final byte[] preauthIntegrity) {
+        return deriveDecryptionKey(dialect, sessionKey, preauthIntegrity, CIPHER_KEY_LENGTH_128);
+    }
+
+    /**
+     * Derives the SMB3 decryption key at the length the negotiated cipher requires.
+     *
+     * @param dialect the SMB dialect version
+     * @param sessionKey the base session key
+     * @param preauthIntegrity the pre-authentication integrity hash (for SMB 3.1.1) or null
+     * @param keyLengthBytes the derived key length in bytes
+     * @return derived decryption key
+     */
+    public static byte[] deriveDecryptionKey(final int dialect, final byte[] sessionKey, final byte[] preauthIntegrity,
+            final int keyLengthBytes) {
         return derive(sessionKey, dialect == Smb2Constants.SMB2_DIALECT_0311 ? DECLABEL_311 : DECLABEL_300,
-                dialect == Smb2Constants.SMB2_DIALECT_0311 ? preauthIntegrity : DECCONTEXT_300);
+                dialect == Smb2Constants.SMB2_DIALECT_0311 ? preauthIntegrity : DECCONTEXT_300, keyLengthBytes);
 
     }
 
@@ -112,8 +156,10 @@ public final class Smb3KeyDerivation {
      * @param sessionKey
      * @param label
      * @param context
+     * @param keyLengthBytes
+     *            length of the derived key in bytes; L in the fixed input is this value in bits
      */
-    private static byte[] derive(final byte[] sessionKey, final byte[] label, final byte[] context) {
+    private static byte[] derive(final byte[] sessionKey, final byte[] label, final byte[] context, final int keyLengthBytes) {
         final KDFCounterBytesGenerator gen = new KDFCounterBytesGenerator(new HMac(new SHA256Digest()));
 
         final int r = 32;
@@ -130,14 +176,23 @@ public final class Smb3KeyDerivation {
         // + 1 byte 0x00
         // + context
         System.arraycopy(context, 0, suffix, label.length + 1, context.length);
-        // + 4 byte (== r bits) big endian encoding of L
-        suffix[suffix.length - 1] = (byte) 128;
+        // + 4 byte big endian encoding of L, the key length in BITS. Note this is a four-byte field and not the
+        // single byte it used to be written as: 128 happens to fit in the last byte, 256 (0x00 0x00 0x01 0x00)
+        // does not, and narrowing it to a byte would silently truncate to zero.
+        final int lengthInBits = keyLengthBytes * 8;
+        final int lengthAt = suffix.length - 4;
+        suffix[lengthAt] = (byte) (lengthInBits >>> 24);
+        suffix[lengthAt + 1] = (byte) (lengthInBits >>> 16);
+        suffix[lengthAt + 2] = (byte) (lengthInBits >>> 8);
+        suffix[lengthAt + 3] = (byte) lengthInBits;
 
         final DerivationParameters param = new KDFCounterParameters(sessionKey, null /* prefix */, suffix /* suffix */, r /* r */);
         gen.init(param);
 
-        final byte[] derived = new byte[16];
-        gen.generateBytes(derived, 0, 16);
+        // L is part of the MAC'd fixed input, so the length is not merely how much of a fixed stream is taken: a
+        // 32-byte key differs from a 16-byte one from its first byte.
+        final byte[] derived = new byte[keyLengthBytes];
+        gen.generateBytes(derived, 0, keyLengthBytes);
         return derived;
     }
 

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/nego/EncryptionNegotiateContext.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/nego/EncryptionNegotiateContext.java
@@ -46,6 +46,16 @@ public class EncryptionNegotiateContext implements NegotiateContextRequest, Nego
      */
     public static final int CIPHER_AES128_GCM = 0x2;
 
+    /**
+     * AES 256 CCM (SMB 3.1.1 only)
+     */
+    public static final int CIPHER_AES256_CCM = 0x3;
+
+    /**
+     * AES 256 GCM (SMB 3.1.1 only)
+     */
+    public static final int CIPHER_AES256_GCM = 0x4;
+
     private int[] ciphers;
 
     /**

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/nego/Smb2NegotiateRequest.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/nego/Smb2NegotiateRequest.java
@@ -95,8 +95,10 @@ public class Smb2NegotiateRequest extends ServerMessageBlock2Request<Smb2Negotia
             this.preauthSalt = salt;
 
             if (config.isEncryptionEnabled()) {
-                negoContexts.add(new EncryptionNegotiateContext(config,
-                        new int[] { EncryptionNegotiateContext.CIPHER_AES128_GCM, EncryptionNegotiateContext.CIPHER_AES128_CCM }));
+                // The array order is the client's preference order on the wire, so it is taken from configuration
+                // rather than fixed here. A server picks one of these and may apply its own preference when doing
+                // so, which is why offering AES-256 first does not by itself mean AES-256 is negotiated.
+                negoContexts.add(new EncryptionNegotiateContext(config, config.getEncryptionCiphers()));
             }
         }
 

--- a/src/test/java/org/codelibs/jcifs/smb/config/BaseConfigurationTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/config/BaseConfigurationTest.java
@@ -396,6 +396,12 @@ class BaseConfigurationTest {
         assertNotNull(testConfig.disallowCompound);
         assertTrue(testConfig.disallowCompound.contains("Smb2SessionSetupRequest"));
         assertTrue(testConfig.disallowCompound.contains("Smb2TreeConnectRequest"));
+
+        // Check encryption ciphers. Only PropertyConfiguration reads the property, so without a default here any
+        // other configuration would hand a null array to the negotiate context the first time encryption is
+        // enabled. AES-128-GCM leads, which keeps the cipher an existing deployment negotiates unchanged.
+        assertArrayEquals(new int[] { 0x2, 0x1, 0x4, 0x3 }, testConfig.getEncryptionCiphers(),
+                "initDefaults must offer AES-128-GCM, AES-128-CCM, AES-256-GCM, AES-256-CCM");
     }
 
     @Test

--- a/src/test/java/org/codelibs/jcifs/smb/config/PropertyConfigurationTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/config/PropertyConfigurationTest.java
@@ -1,6 +1,7 @@
 package org.codelibs.jcifs.smb.config;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -147,6 +148,43 @@ class PropertyConfigurationTest extends BaseTest {
         assertTrue(testConfig.getSoTimeout() > 0);
         assertNotNull(testConfig.getMinimumVersion());
         assertNotNull(testConfig.getMaximumVersion());
+    }
+
+    @Test
+    @DisplayName("encryptionCiphers parses cipher names to ids, keeping the configured order")
+    void testEncryptionCiphersProperty() throws CIFSException {
+        final Properties props = new Properties();
+        props.setProperty("jcifs.client.encryptionCiphers", "AES-256-GCM, AES-128-CCM");
+
+        final PropertyConfiguration testConfig = new PropertyConfiguration(props);
+
+        // Order is the client's stated preference on the wire, so it has to survive parsing.
+        assertArrayEquals(new int[] { 0x4, 0x1 }, testConfig.getEncryptionCiphers(),
+                "configured cipher names must map to their MS-SMB2 ids in the configured order");
+    }
+
+    @Test
+    @DisplayName("encryptionCiphers defaults to all four ciphers with AES-128 first")
+    void testEncryptionCiphersDefault() throws CIFSException {
+        final PropertyConfiguration testConfig = new PropertyConfiguration(new Properties());
+
+        // AES-128-GCM leads deliberately: servers choose from the client's offer by their own preference, so
+        // leading with AES-128 keeps the cipher an existing deployment negotiates exactly as it is today, while
+        // still making AES-256 available to a server that prefers it.
+        assertArrayEquals(new int[] { 0x2, 0x1, 0x4, 0x3 }, testConfig.getEncryptionCiphers(),
+                "the default offer must be AES-128-GCM, AES-128-CCM, AES-256-GCM, AES-256-CCM");
+    }
+
+    @Test
+    @DisplayName("an unknown cipher name is refused rather than silently dropped")
+    void testEncryptionCiphersRejectsUnknownName() {
+        final Properties props = new Properties();
+        props.setProperty("jcifs.client.encryptionCiphers", "AES-128-GCM, AES-512-GCM");
+
+        // Dropping the unrecognised entry would leave a client quietly offering something other than what was
+        // configured - and a typo in a security setting is exactly the case that must not fail open.
+        assertThrows(CIFSException.class, () -> new PropertyConfiguration(props),
+                "an unrecognised cipher name must fail configuration rather than be ignored");
     }
 
     @Test

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbNegotiationProbe.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbNegotiationProbe.java
@@ -17,6 +17,7 @@ package org.codelibs.jcifs.smb.impl;
 
 import org.codelibs.jcifs.smb.CIFSException;
 import org.codelibs.jcifs.smb.DialectVersion;
+import org.codelibs.jcifs.smb.internal.smb2.nego.Smb2NegotiateResponse;
 
 /**
  * Test-only window onto the negotiated connection state.
@@ -61,6 +62,34 @@ public final class SmbNegotiationProbe {
                 SmbSessionImpl session = tree.getSession();
                 SmbTransportImpl transport = session.getTransport()) {
             return transport.getNegotiateResponse().isSigningNegotiated();
+        }
+    }
+
+    /**
+     * Returns the encryption cipher the server selected, or {@code -1} if the response carried no encryption
+     * negotiate context.
+     *
+     * <p>
+     * Without this a test can only assert that encrypted traffic round trips, which passes identically whichever
+     * cipher is in force - so a client that asked for AES-256 and silently got AES-128 would look correct. The
+     * cipher is the only observable that tells those two apart.
+     * </p>
+     *
+     * @param file any connected resource on the tree of interest
+     * @return the selected cipher identifier, or -1 if none was negotiated
+     * @throws CIFSException if the connection cannot be established
+     */
+    public static int negotiatedCipher(final SmbFile file) throws CIFSException {
+        try (SmbTreeHandleImpl tree = (SmbTreeHandleImpl) file.getTreeHandle();
+                SmbSessionImpl session = tree.getSession();
+                SmbTransportImpl transport = session.getTransport()) {
+            // The cipher is on the SMB2 response, not on the SmbNegotiationResponse interface, which is also what
+            // an SMB1 negotiation returns. Answering -1 there matches what the SMB2 response itself reports when
+            // no encryption context was negotiated, rather than making a cast failure the contract.
+            if (transport.getNegotiateResponse() instanceof final Smb2NegotiateResponse resp) {
+                return resp.getSelectedCipher();
+            }
+            return -1;
         }
     }
 }

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbTransportImplTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbTransportImplTest.java
@@ -420,6 +420,35 @@ class SmbTransportImplTest {
             assertEquals(EncryptionNegotiateContext.CIPHER_AES128_GCM, gcm.getCipherId());
             assertEquals(DialectVersion.SMB311, gcm.getDialect());
         }
+
+        @Test
+        @DisplayName("createEncryptionContext derives 32-byte keys when an AES-256 cipher was negotiated")
+        void createEncryptionContext_aes256DerivesLongerKeys() throws Exception {
+            byte[] sessionKey = new byte[16];
+            byte[] preauth = new byte[16];
+            setField(transport, "smb2", true);
+
+            // This is the join between negotiation and key derivation, and the place an abandoned attempt at
+            // AES-256 (ad815cf on origin/experimental) went wrong: it negotiated the cipher but never widened the
+            // KDF, so the 32-byte guard rejected the 16-byte key on every AES-256 session. The context now
+            // validates key length in its constructor, so a short key here throws rather than quietly encrypting
+            // as AES-128 - which means this test fails loudly if the two halves are ever wired up inconsistently.
+            for (int cipher : new int[] { EncryptionNegotiateContext.CIPHER_AES256_GCM, EncryptionNegotiateContext.CIPHER_AES256_CCM }) {
+                Smb2NegotiateResponse nego = new Smb2NegotiateResponse(cfg);
+                setField(nego, "selectedDialect", DialectVersion.SMB311);
+                setField(nego, "selectedCipher", cipher);
+                setField(transport, "negotiated", nego);
+
+                Smb2EncryptionContext ctxt = transport.createEncryptionContext(sessionKey, preauth);
+                assertEquals(cipher, ctxt.getCipherId());
+                assertEquals(32, Smb2EncryptionContext.keyLength(cipher), "an AES-256 cipher requires a 32-byte key");
+            }
+
+            // And the AES-128 ciphers must not have grown: the same derivation serves both, so widening it
+            // wholesale would change keys that already work against real servers.
+            assertEquals(16, Smb2EncryptionContext.keyLength(EncryptionNegotiateContext.CIPHER_AES128_GCM));
+            assertEquals(16, Smb2EncryptionContext.keyLength(EncryptionNegotiateContext.CIPHER_AES128_CCM));
+        }
     }
 
     @Test

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb2EncryptionContextTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb2EncryptionContextTest.java
@@ -1,5 +1,6 @@
 package org.codelibs.jcifs.smb.internal.smb2;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -10,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.security.SecureRandom;
 
 import org.codelibs.jcifs.smb.DialectVersion;
+import org.codelibs.jcifs.smb.internal.smb2.nego.EncryptionNegotiateContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -130,32 +132,86 @@ class Smb2EncryptionContextTest {
     }
 
     @Test
-    @DisplayName("Should accept empty keys")
-    void testEmptyKeys() {
-        // Given
-        byte[] emptyKey = new byte[0];
+    @DisplayName("a key of the wrong length for the cipher is rejected rather than silently used")
+    void testEmptyKeysAreRejected() {
+        // A zero-length key used to be accepted here, asserted as "should accept empty keys". Nothing validated
+        // key length at all, so the test was documenting the absence of a check rather than a contract.
+        final byte[] emptyKey = new byte[0];
 
-        // When/Then
-        assertDoesNotThrow(() -> {
-            Smb2EncryptionContext context = new Smb2EncryptionContext(1, DialectVersion.SMB311, emptyKey, emptyKey);
-            assertNotNull(context, "Context should be created with empty keys");
-        }, "Should accept empty keys");
+        assertThrows(IllegalArgumentException.class,
+                () -> new Smb2EncryptionContext(EncryptionNegotiateContext.CIPHER_AES128_GCM, DialectVersion.SMB311, emptyKey, emptyKey),
+                "an empty key cannot encrypt anything and must be refused");
     }
 
     @Test
-    @DisplayName("Should accept different key sizes")
-    void testDifferentKeySizes() {
-        // Given
-        byte[] key128 = new byte[16]; // 128-bit
-        byte[] key256 = new byte[32]; // 256-bit
+    @DisplayName("a 16-byte key under an AES-256 cipher id is refused instead of encrypting as AES-128")
+    void testKeyLengthMustMatchTheCipher() {
+        final byte[] key128 = new byte[16];
+        final byte[] key256 = new byte[32];
         new SecureRandom().nextBytes(key128);
         new SecureRandom().nextBytes(key256);
 
-        // When/Then
-        assertDoesNotThrow(() -> {
-            Smb2EncryptionContext context = new Smb2EncryptionContext(1, DialectVersion.SMB311, key128, key256);
-            assertNotNull(context, "Context should be created with different key sizes");
-        }, "Should accept different key sizes");
+        // This is the defect that matters. BouncyCastle derives the AES key size from the key it is handed, so a
+        // 16-byte key under cipher id 0x4 encrypts as AES-128 and reports success - the session comes up, traffic
+        // flows, and the negotiated cipher is a lie. An abandoned attempt at AES-256 on origin/experimental
+        // (ad815cf) had this guard but never widened the KDF, so it would have thrown on every AES-256 session;
+        // the guard was right and the derivation underneath it was missing.
+        assertThrows(IllegalArgumentException.class,
+                () -> new Smb2EncryptionContext(EncryptionNegotiateContext.CIPHER_AES256_GCM, DialectVersion.SMB311, key128, key128),
+                "AES-256-GCM with a 128-bit key must be refused");
+        assertThrows(IllegalArgumentException.class,
+                () -> new Smb2EncryptionContext(EncryptionNegotiateContext.CIPHER_AES256_CCM, DialectVersion.SMB311, key128, key128),
+                "AES-256-CCM with a 128-bit key must be refused");
+        assertThrows(IllegalArgumentException.class,
+                () -> new Smb2EncryptionContext(EncryptionNegotiateContext.CIPHER_AES128_GCM, DialectVersion.SMB311, key256, key256),
+                "AES-128-GCM with a 256-bit key must be refused");
+
+        // Mismatched pairs too: the two directions are separate keys and either one being wrong is fatal.
+        assertThrows(IllegalArgumentException.class,
+                () -> new Smb2EncryptionContext(EncryptionNegotiateContext.CIPHER_AES128_GCM, DialectVersion.SMB311, key128, key256),
+                "a context whose two keys disagree in length must be refused");
+
+        assertDoesNotThrow(
+                () -> new Smb2EncryptionContext(EncryptionNegotiateContext.CIPHER_AES256_GCM, DialectVersion.SMB311, key256, key256),
+                "AES-256-GCM with 256-bit keys is the valid combination");
+    }
+
+    @Test
+    @DisplayName("the AES-256 ciphers are classified as GCM or CCM, and get the right nonce length")
+    void testAes256CiphersAreClassifiedCorrectly() {
+        final byte[] key256 = new byte[32];
+        new SecureRandom().nextBytes(key256);
+
+        // getNonceLength() is derived from the GCM/CCM classification, and the constructor uses it to size the
+        // nonce prefix - so a cipher that falls through to the CCM branch is mis-sized at construction, not just
+        // at encrypt time. MS-SMB2 2.2.41: GCM 12 bytes, CCM 11, whatever the key size.
+        assertEquals(12, new Smb2EncryptionContext(EncryptionNegotiateContext.CIPHER_AES256_GCM, DialectVersion.SMB311, key256, key256)
+                .getNonceLength(), "AES-256-GCM must use a 12-byte nonce");
+        assertEquals(11, new Smb2EncryptionContext(EncryptionNegotiateContext.CIPHER_AES256_CCM, DialectVersion.SMB311, key256, key256)
+                .getNonceLength(), "AES-256-CCM must use an 11-byte nonce");
+    }
+
+    @Test
+    @DisplayName("an AES-256-GCM message round trips through a second context holding the same keys")
+    void testAes256GcmRoundTrip() throws Exception {
+        final byte[] c2s = new byte[32];
+        final byte[] s2c = new byte[32];
+        new SecureRandom().nextBytes(c2s);
+        new SecureRandom().nextBytes(s2c);
+
+        // Two contexts with the keys swapped, so the decrypting side uses the other direction's key exactly as a
+        // server would. A single context decrypting its own output would pass even if the direction keys were
+        // crossed.
+        final Smb2EncryptionContext client =
+                new Smb2EncryptionContext(EncryptionNegotiateContext.CIPHER_AES256_GCM, DialectVersion.SMB311, c2s, s2c);
+        final Smb2EncryptionContext server =
+                new Smb2EncryptionContext(EncryptionNegotiateContext.CIPHER_AES256_GCM, DialectVersion.SMB311, s2c, c2s);
+
+        final byte[] plaintext = new byte[512];
+        new SecureRandom().nextBytes(plaintext);
+
+        final byte[] wrapped = client.encryptMessage(plaintext, 0x1122334455667788L);
+        assertArrayEquals(plaintext, server.decryptMessage(wrapped), "an AES-256-GCM message must decrypt to what went in");
     }
 
     @Test

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb3KeyDerivationTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb3KeyDerivationTest.java
@@ -439,6 +439,22 @@ class Smb3KeyDerivationTest {
      * of the BouncyCastle KDF used by production so it can pin the label constants.
      */
     private static byte[] deriveOracle(final String label, final byte[] context, final byte[] sessionKey) throws Exception {
+        return deriveOracle(label, context, sessionKey, 16);
+    }
+
+    /**
+     * The same oracle for a key of any length. {@code L} is the output length in <em>bits</em>, so a 32-byte key
+     * sets L = 256 and takes the whole HMAC-SHA256 block.
+     *
+     * <p>
+     * One block is always enough here: HMAC-SHA256 emits exactly 32 bytes per iteration, so a 32-byte key is a
+     * single pass with the counter at 1, the same as a 16-byte one. Note that L is written as a four-byte
+     * big-endian field - for 128 only the last byte is non-zero, which is why the production code could get away
+     * with writing one byte, and why 256 (0x00 0x00 0x01 0x00) cannot.
+     * </p>
+     */
+    private static byte[] deriveOracle(final String label, final byte[] context, final byte[] sessionKey, final int keyLengthBytes)
+            throws Exception {
         final byte[] ascii = label.getBytes(StandardCharsets.US_ASCII);
         final ByteArrayOutputStream fixedInput = new ByteArrayOutputStream();
         fixedInput.writeBytes(new byte[] { 0x00, 0x00, 0x00, 0x01 }); // counter i = 1 (4-byte BE, r = 32)
@@ -446,12 +462,13 @@ class Smb3KeyDerivationTest {
         fixedInput.write(0x00); // label null terminator (toCBytes)
         fixedInput.write(0x00); // 0x00 separator between label and context
         fixedInput.writeBytes(context); // context
-        fixedInput.writeBytes(new byte[] { 0x00, 0x00, 0x00, (byte) 0x80 }); // L = 128 (4-byte BE)
+        final int l = keyLengthBytes * 8;
+        fixedInput.writeBytes(new byte[] { 0x00, 0x00, (byte) (l >>> 8), (byte) l }); // L in bits (4-byte BE)
 
         final Mac mac = Mac.getInstance("HmacSHA256");
         mac.init(new SecretKeySpec(sessionKey, "HmacSHA256"));
         final byte[] full = mac.doFinal(fixedInput.toByteArray());
-        return Arrays.copyOf(full, 16);
+        return Arrays.copyOf(full, keyLengthBytes);
     }
 
     private static byte[] fixedSessionKey() {
@@ -493,5 +510,48 @@ class Smb3KeyDerivationTest {
         final byte[] decExpected = deriveOracle("SMBS2CCipherKey", preauth, sk);
         final byte[] decActual = Smb3KeyDerivation.deriveDecryptionKey(Smb2Constants.SMB2_DIALECT_0311, sk, preauth);
         assertArrayEquals(decExpected, decActual, "Decryption key must be derived with the SMBS2CCipherKey label");
+    }
+
+    @Test
+    @DisplayName("a 32-byte cipher key is a different key stream, not the 16-byte key extended")
+    void testCipherKeysCanBeDerivedAtThirtyTwoBytes() throws Exception {
+        final byte[] sk = fixedSessionKey();
+        final byte[] preauth = fixedPreauth();
+
+        final byte[] encActual = Smb3KeyDerivation.deriveEncryptionKey(Smb2Constants.SMB2_DIALECT_0311, sk, preauth, 32);
+        assertEquals(32, encActual.length, "an AES-256 cipher key must be 32 bytes");
+        assertArrayEquals(deriveOracle("SMBC2SCipherKey", preauth, sk, 32), encActual,
+                "the 32-byte encryption key must match an independent SP800-108 derivation with L = 256");
+
+        final byte[] decActual = Smb3KeyDerivation.deriveDecryptionKey(Smb2Constants.SMB2_DIALECT_0311, sk, preauth, 32);
+        assertEquals(32, decActual.length, "an AES-256 cipher key must be 32 bytes");
+        assertArrayEquals(deriveOracle("SMBS2CCipherKey", preauth, sk, 32), decActual,
+                "the 32-byte decryption key must match an independent SP800-108 derivation with L = 256");
+
+        // L is part of the MAC'd fixed input, so a longer key differs from the first byte rather than extending the
+        // shorter one. This is the assertion that catches the plausible half-fix: enlarging the output buffer while
+        // leaving L at 128 produces 32 bytes that begin with the 16-byte key, and would pass every other check here.
+        final byte[] sixteen = Smb3KeyDerivation.deriveEncryptionKey(Smb2Constants.SMB2_DIALECT_0311, sk, preauth);
+        assertFalse(Arrays.equals(Arrays.copyOf(encActual, 16), sixteen),
+                "a 32-byte key whose first half equals the 16-byte key means L was left at 128");
+    }
+
+    @Test
+    @DisplayName("the signing key stays 16 bytes even though cipher keys can now be 32")
+    void testSigningKeyIsNotWidenedWithCipherKeys() throws Exception {
+        final byte[] sk = fixedSessionKey();
+        final byte[] preauth = fixedPreauth();
+
+        // deriveSigningKey shares the same private derive() as the cipher keys, so widening that shared default
+        // would hand signing a 32-byte key. BouncyCastle's AESCMAC accepts one without complaint and still emits a
+        // 16-byte tag, so nothing here would throw and self-consistent unit tests would stay green - the damage
+        // appears only as "Signature validation failed" against a real server, and both CI backends mandate
+        // signing. This test is the guard for that, which is why it asserts the length rather than trusting it.
+        final byte[] signing = Smb3KeyDerivation.deriveSigningKey(Smb2Constants.SMB2_DIALECT_0311, sk, preauth);
+        assertEquals(16, signing.length, "the SMB 3.1.1 signing key must stay 16 bytes");
+        assertArrayEquals(deriveOracle("SMBSigningKey", preauth, sk, 16), signing, "the signing key must still be derived with L = 128");
+
+        final byte[] signing300 = Smb3KeyDerivation.deriveSigningKey(Smb2Constants.SMB2_DIALECT_0300, sk, preauth);
+        assertEquals(16, signing300.length, "the SMB 3.0 signing key must stay 16 bytes");
     }
 }

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/nego/Smb2NegotiateRequestTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/nego/Smb2NegotiateRequestTest.java
@@ -59,6 +59,8 @@ class Smb2NegotiateRequestTest {
         // Default configuration for SMB 3.1.1 with encryption
         when(mockConfig.isDfsDisabled()).thenReturn(false);
         when(mockConfig.isEncryptionEnabled()).thenReturn(true);
+        when(mockConfig.getEncryptionCiphers())
+                .thenReturn(new int[] { EncryptionNegotiateContext.CIPHER_AES128_GCM, EncryptionNegotiateContext.CIPHER_AES128_CCM });
         when(mockConfig.getMinimumVersion()).thenReturn(DialectVersion.SMB202);
         when(mockConfig.getMaximumVersion()).thenReturn(DialectVersion.SMB311);
         when(mockConfig.getMachineId()).thenReturn(testMachineId);
@@ -205,6 +207,24 @@ class Smb2NegotiateRequestTest {
         for (byte b : guid) {
             assertEquals(0, b);
         }
+    }
+
+    @Test
+    @DisplayName("the offered ciphers are the configured ones, in the configured order")
+    void testOfferedCiphersComeFromConfiguration() {
+        when(mockConfig.getMaximumVersion()).thenReturn(DialectVersion.SMB311);
+        when(mockConfig.isEncryptionEnabled()).thenReturn(true);
+        when(mockConfig.getEncryptionCiphers())
+                .thenReturn(new int[] { EncryptionNegotiateContext.CIPHER_AES256_GCM, EncryptionNegotiateContext.CIPHER_AES128_GCM });
+
+        request = new Smb2NegotiateRequest(mockConfig, 0);
+
+        // The list used to be hardcoded to the two AES-128 ciphers, so a configured preference had nowhere to go.
+        // Asserting the contents in order matters because this array *is* the client's preference order on the
+        // wire; the existing context test only checks the context type and would pass whatever is inside it.
+        final EncryptionNegotiateContext enc = (EncryptionNegotiateContext) request.getNegotiateContexts()[1];
+        assertArrayEquals(new int[] { EncryptionNegotiateContext.CIPHER_AES256_GCM, EncryptionNegotiateContext.CIPHER_AES128_GCM },
+                enc.getCiphers(), "the negotiate context must offer exactly the configured ciphers, in order");
     }
 
     @Test

--- a/src/test/java/org/codelibs/jcifs/smb/it/EncryptionIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/EncryptionIT.java
@@ -16,6 +16,7 @@
 package org.codelibs.jcifs.smb.it;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -28,6 +29,7 @@ import java.util.Random;
 import org.codelibs.jcifs.smb.CIFSContext;
 import org.codelibs.jcifs.smb.DialectVersion;
 import org.codelibs.jcifs.smb.impl.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbNegotiationProbe;
 import org.codelibs.jcifs.smb.it.env.RequiresDialect;
 import org.codelibs.jcifs.smb.it.env.Smb3Matrix;
 import org.junit.jupiter.api.AfterEach;
@@ -120,6 +122,50 @@ class EncryptionIT extends AbstractSmbIT {
         try (InputStream in = file.getInputStream()) {
             assertArrayEquals(payload, in.readAllBytes(), "the encrypted payload came back different");
         }
+    }
+
+    @Test
+    @RequiresDialect(DialectVersion.SMB311)
+    @DisplayName("each offered SMB 3.1.1 cipher is the one the server actually negotiates, AES-256 included")
+    void eachCipherIsNegotiatedAndCarriesData() throws Exception {
+        // One cipher per connection, on purpose. A server picks from the client's offer by its own order of
+        // preference - measured against this fixture, Samba selects AES-128-GCM whenever it is offered at all,
+        // whatever order the client lists - so an arm offering all four would negotiate AES-128-GCM and prove
+        // nothing about AES-256. Offering exactly one makes the server's selection the assertion.
+        for (final String cipher : new String[] { "AES-128-CCM", "AES-128-GCM", "AES-256-CCM", "AES-256-GCM" }) {
+            final Properties props = encrypting();
+            props.setProperty("jcifs.client.encryptionCiphers", cipher);
+            props.setProperty("jcifs.client.minVersion", DialectVersion.SMB311.name());
+            props.setProperty("jcifs.client.maxVersion", DialectVersion.SMB311.name());
+            final CIFSContext context = server().context(props);
+
+            this.workDir = createWorkDir(context, server().encryptedShare());
+            final String contents = "encrypted round trip under " + cipher;
+            final SmbFile file = writeFile(this.workDir, "cipher.txt", contents);
+
+            // The cipher, not just the round trip: reading the payload back succeeds identically under AES-128, so
+            // a client that asked for AES-256 and silently fell back would pass a data-only assertion.
+            assertEquals(expectedCipherId(cipher), SmbNegotiationProbe.negotiatedCipher(file),
+                    "the server should have selected " + cipher + ", the only cipher offered");
+
+            try (InputStream in = file.getInputStream()) {
+                assertArrayEquals(contents.getBytes(StandardCharsets.UTF_8), in.readAllBytes(),
+                        "the payload came back different under " + cipher);
+            }
+
+            deleteQuietly(this.workDir);
+            this.workDir = null;
+        }
+    }
+
+    private static int expectedCipherId(final String cipher) {
+        return switch (cipher) {
+        case "AES-128-CCM" -> 0x1;
+        case "AES-128-GCM" -> 0x2;
+        case "AES-256-CCM" -> 0x3;
+        case "AES-256-GCM" -> 0x4;
+        default -> throw new IllegalArgumentException(cipher);
+        };
     }
 
     @Smb3Matrix


### PR DESCRIPTION
## What this changes

SMB 3.1.1 defines four encryption ciphers; jcifs offered two. `docs/SMB3_SUPPORT.md`
recorded AES-256-CCM and AES-256-GCM as "Not implemented — not negotiated". They are
now implemented, offered by default, and exercised against a real server.

The offered list and its order come from a new property:

| Property | Default |
| --- | --- |
| `jcifs.client.encryptionCiphers` | `AES-128-GCM, AES-128-CCM, AES-256-GCM, AES-256-CCM` |

AES-128 leads deliberately. A server selects one cipher from the client's offer and is
free to apply its own preference when doing so, so leading with AES-128 leaves the
cipher an existing deployment negotiates **exactly as it was**, while making AES-256
available to a server that prefers it. Offering only the AES-256 ciphers requires them,
at the cost of failing against a server that does not implement them. An unrecognised
name fails configuration rather than being ignored — a typo in this setting changes what
protects the data, so it must not fail open.

## Three defects underneath the negotiation

Adding the two constants alone would have produced a client that negotiates AES-256 and
protects nothing with it.

- **The key derivation returned 16 bytes unconditionally.** `L` in the SP800-108 fixed
  input is the key length in *bits*, and was written as a single byte — 128 fits there,
  256 (`00 00 01 00`) does not. It is now a real four-byte big-endian field. Both length
  sites move together: `L` is inside the MAC'd input, so a 32-byte key differs from a
  16-byte one from its first byte rather than extending it.
- **The GCM/CCM decision was `cipherId == CIPHER_AES_128_GCM`.** AES-256-GCM would have
  fallen through to the CCM branch — a CCM cipher with an 11-byte nonce. It is now set
  membership. The same predicate is consulted from the constructor to size the nonce
  prefix, so the misclassification would have been wrong from construction onwards.
- **Nothing validated key length.** BouncyCastle takes the AES key size from the length
  of the key it is handed, so a 16-byte key under an AES-256 cipher id encrypts as
  AES-128 and *succeeds*: the session comes up, traffic flows, and the negotiated cipher
  is not the one protecting the data. The context now rejects a mismatch.

## Why the signing key is left alone

One private method derives all four SMB3 keys, so the length is threaded only through
the encryption and decryption overloads; `deriveSigningKey` passes 16 explicitly at the
call site. Widening the shared default would have handed signing a 32-byte key — which
AES-CMAC accepts without complaint, still emitting a 16-byte tag. Every self-consistent
unit test would stay green while every signed session against a real server failed, and
both CI backends mandate signing. There is a test asserting the signing key stays 16
bytes while cipher keys grow to 32.

## Verification

- Unit tests: 8819, 0 failures, 0 skipped.
- Integration tests against Samba: 217, 0 failures, 5 skipped (the pre-existing
  symlink and Windows-backend skips).
- The 32-byte derivation is pinned against an independent in-test SP800-108 oracle with
  `L = 256`, not against the production KDF decoding its own output.
- `EncryptionIT` offers **one cipher per connection** and asserts the server selected
  that one. Reading the payload back succeeds identically under AES-128, so a data-only
  assertion cannot distinguish a successful AES-256 negotiation from a silent fallback;
  a new test-side probe exposes the negotiated cipher. Offering one rather than four is
  deliberate — measured against the fixture, Samba selects AES-128-GCM whenever it is
  offered at all, whatever order the client lists, so an arm offering all four would
  prove nothing about AES-256.
- **The assertion was falsified on purpose.** With the AES-256-GCM expectation flipped
  to the AES-128-GCM id, the case fails with `expected: <2> but was: <4>` — so the
  server really did negotiate AES-256-GCM, and the check can fail.

## Note for review

`BaseConfiguration` now imports `EncryptionNegotiateContext` from `internal.smb2.nego`,
which is the first dependency from `config` on a protocol-internal package. The
alternative was duplicating the four cipher ids as literals in the configuration layer;
a single authority for them seemed the better trade, given `Configuration` already
exposes cipher ids as `int[]` in its contract. Happy to invert it if you disagree.

## Scope

One new `Configuration` method, which is an addition to a public interface. No existing
behaviour changes: with the default property the cipher negotiated against a given
server is the same one as before.
