### PR TITLE
feat(smb3): negotiate and use AES-128-GMAC message signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ JCIFS is a comprehensive, pure Java implementation of the CIFS/SMB networking pr
   - **AES-256-GCM and AES-256-CCM encryption** (SMB 3.1.1), offered by default and
     selectable with `jcifs.client.encryptionCiphers`
   - **Pre-Authentication Integrity** (SMB 3.1.1)
-  - **AES-CMAC signing** for data integrity
+  - **AES-CMAC signing** for data integrity, with **AES-GMAC** negotiable on
+    SMB 3.1.1 via `jcifs.client.signingAlgorithms`
   - **Automatic protocol negotiation**
   - **Transparent encryption** when required by the server, per session or per share (opt-in, see below)
 

--- a/docs/SMB3_SUPPORT.md
+++ b/docs/SMB3_SUPPORT.md
@@ -53,12 +53,12 @@ out-of-range dialect fails the connection.
 | Feature | Status | Notes |
 | --- | --- | --- |
 | Signing, HMAC-SHA256 (SMB 2.x) | Supported | |
-| Signing, AES-128-CMAC (SMB 3.x) | Supported | Via Bouncy Castle. |
+| Signing, AES-128-CMAC (SMB 3.x) | Supported | Via Bouncy Castle. The default on every SMB3 dialect, and the only option below 3.1.1. |
 | Inbound signature verification | Supported | Fail-closed: an unsigned response where a digest is in force also counts as a failure. Skipped for `STATUS_PENDING` interim responses, and for encrypted messages, which the AEAD tag authenticates instead (MS-SMB2 3.1.4.1). |
 | Pre-auth integrity, SHA-512 (SMB 3.1.1) | Supported | Chained over NEGOTIATE and every non-final SESSION_SETUP and fed into signing-key derivation, so tampering surfaces as a signature failure. Skipped for anonymous sessions. |
 | Secure negotiate (`FSCTL_VALIDATE_NEGOTIATE_INFO`) | Supported | Sent on tree connect for signed SMB 2.1–3.0.2 sessions. Security mode, capabilities, dialect and server GUID are compared, and a mismatch disconnects the transport. Not used on 3.1.1, which relies on pre-auth integrity. Knob: `jcifs.client.requireSecureNegotiate`, default `true`. |
 | Authentication: NTLMSSP, Kerberos, SPNEGO | Supported | |
-| AES-128-GMAC signing (SMB 3.1.1, optional) | Not implemented | No `SIGNING_CAPABILITIES` negotiate context either. |
+| AES-128-GMAC signing (SMB 3.1.1) | Supported | Negotiated in a `SIGNING_CAPABILITIES` context, and offered after AES-CMAC by default so the algorithm an existing deployment negotiates does not change — see `jcifs.client.signingAlgorithms`. The nonce is built per message from the MessageId plus a direction bit (MS-SMB2 3.1.4.1), so unlike CMAC the MAC is re-initialised for every message. A server that returns no context signs with AES-CMAC, as before. |
 
 ### `jcifs.client.signingPreferred` does not enable SMB2 signing
 
@@ -127,7 +127,7 @@ the fix in #92.
 | `NETNAME_NEGOTIATE_CONTEXT_ID` (0x5) | Not implemented |
 | `TRANSPORT_CAPABILITIES` (0x6) | Not implemented |
 | `RDMA_TRANSFORM_CAPABILITIES` (0x7) | Not implemented |
-| `SIGNING_CAPABILITIES` (0x8) | Not implemented |
+| `SIGNING_CAPABILITIES` (0x8) | Supported, HMAC-SHA256, AES-CMAC and AES-GMAC. Sent on every SMB 3.1.1 negotiation, whether or not encryption is enabled. A selection the client did not offer fails the connection. |
 
 Unknown context types received from a server are ignored rather than treated as
 errors.
@@ -325,6 +325,7 @@ file on its first open, as it always has.
 | `jcifs.client.ipcSigningEnforced` | `true` | Require signing on IPC$. |
 | `jcifs.client.requireSecureNegotiate` | `true` | Validate the negotiate exchange on tree connect. |
 | `jcifs.client.encryptionEnabled` | `false` | Opt in to SMB3 encryption — see [Encryption](#encryption). |
+| `jcifs.client.signingAlgorithms` | `AES-CMAC, AES-GMAC, HMAC-SHA256` | The SMB 3.1.1 signing algorithms to offer, in preference order. An unrecognised name fails configuration rather than being ignored. AES-CMAC leads because it is what this client has always signed with, and the server chooses from the offered list by its own preference — so the negotiated algorithm is unchanged unless this property is. Offering only `AES-GMAC` requires it. No effect below SMB 3.1.1, which does not negotiate a signing algorithm. |
 | `jcifs.client.encryptionCiphers` | `AES-128-GCM, AES-128-CCM, AES-256-GCM, AES-256-CCM` | The SMB 3.1.1 ciphers to offer, in preference order. An unrecognised name fails configuration rather than being ignored. Note that the server chooses one from the offered list and may apply its own preference when doing so, so listing AES-256 first does not make AES-256 the negotiated cipher; offering only the AES-256 ciphers does require them. No effect below SMB 3.1.1, which does not negotiate a cipher. |
 | `jcifs.client.maxTransferSize` | `1048576` | Largest payload a single SMB2 read or write may carry. The negotiated size is the smaller of this and the server's offer. Has no effect below SMB 2.1, which cannot carry more than 64 KiB in one request. |
 | `jcifs.client.transaction_buf_size` | `65535` | Drives the transact size, and the read and write ceilings on SMB 2.0.2 and SMB1. 512 bytes are subtracted from it, giving an effective 65023. |

--- a/src/main/java/org/codelibs/jcifs/smb/Configuration.java
+++ b/src/main/java/org/codelibs/jcifs/smb/Configuration.java
@@ -524,6 +524,26 @@ public interface Configuration {
     int[] getEncryptionCiphers();
 
     /**
+     * Property {@code jcifs.client.signingAlgorithms} (comma-separated, default
+     * {@code AES-CMAC, AES-GMAC, HMAC-SHA256})
+     *
+     * The SMB 3.1.1 signing algorithms to offer, in order of preference. Recognised names are
+     * {@code HMAC-SHA256}, {@code AES-CMAC} and {@code AES-GMAC}; an unrecognised name is an error rather than
+     * being ignored. Only consulted on SMB 3.1.1, which is the only dialect that negotiates a signing algorithm
+     * in a negotiate context - SMB 3.0 and 3.0.2 always sign with AES-128-CMAC and SMB 2.x with HMAC-SHA256.
+     *
+     * <p>
+     * As with the encryption ciphers, this states a preference rather than a requirement: the server picks one
+     * algorithm from the offered list and may apply its own order when doing so. The default leads with AES-CMAC,
+     * which is what the client has always used, so the algorithm negotiated against a given server does not
+     * change unless this property does.
+     * </p>
+     *
+     * @return the signing algorithm identifiers to offer, in preference order
+     */
+    int[] getSigningAlgorithms();
+
+    /**
      *
      * Property {@code jcifs.client.forceExtendedSecurity} (boolean, default false)
      *

--- a/src/main/java/org/codelibs/jcifs/smb/config/BaseConfiguration.java
+++ b/src/main/java/org/codelibs/jcifs/smb/config/BaseConfiguration.java
@@ -37,6 +37,7 @@ import org.codelibs.jcifs.smb.DialectVersion;
 import org.codelibs.jcifs.smb.ResolverType;
 import org.codelibs.jcifs.smb.SmbConstants;
 import org.codelibs.jcifs.smb.internal.smb2.nego.EncryptionNegotiateContext;
+import org.codelibs.jcifs.smb.internal.smb2.nego.SigningNegotiateContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,6 +80,8 @@ public class BaseConfiguration implements Configuration {
     protected boolean encryptionEnabled = false;
     /** SMB 3.1.1 encryption ciphers to offer, in preference order */
     protected int[] encryptionCiphers;
+    /** SMB 3.1.1 signing algorithms to offer, in preference order */
+    protected int[] signingAlgorithms;
     /** Whether to use NT status codes instead of DOS error codes */
     protected boolean useNtStatus = true;
     /** Whether to use extended security negotiation */
@@ -575,6 +578,11 @@ public class BaseConfiguration implements Configuration {
     }
 
     @Override
+    public int[] getSigningAlgorithms() {
+        return this.signingAlgorithms;
+    }
+
+    @Override
     public boolean isForceExtendedSecurity() {
         return this.forceExtendedSecurity;
     }
@@ -822,6 +830,60 @@ public class BaseConfiguration implements Configuration {
         }
     }
 
+    /**
+     * Initializes the SMB 3.1.1 signing algorithms to offer.
+     *
+     * <p>
+     * An unrecognised name is fatal here for the same reason it is for the ciphers: dropping an entry would leave
+     * the client offering something other than what was configured, and this setting decides what protects
+     * message integrity.
+     * </p>
+     *
+     * @param prop comma-separated list of algorithm names, in preference order, or null for the default
+     * @throws CIFSException if an algorithm name is not recognised
+     */
+    protected void initSigningAlgorithms(final String prop) throws CIFSException {
+        if (prop == null || prop.trim().isEmpty()) {
+            // AES-CMAC leads deliberately: it is what this client has always signed with, and a server chooses
+            // from the offer by its own preference, so leading with it keeps the negotiated algorithm unchanged
+            // for every existing deployment while making GMAC available to anyone who asks for it.
+            this.signingAlgorithms = new int[] { SigningNegotiateContext.SIGNING_ALGO_AES128_CMAC,
+                    SigningNegotiateContext.SIGNING_ALGO_AES128_GMAC, SigningNegotiateContext.SIGNING_ALGO_HMAC_SHA256 };
+            return;
+        }
+
+        final List<Integer> algos = new ArrayList<>();
+        final StringTokenizer st = new StringTokenizer(prop, ",");
+        while (st.hasMoreTokens()) {
+            final String name = st.nextToken().trim();
+            if (name.isEmpty()) {
+                continue;
+            }
+            algos.add(signingAlgorithmByName(name));
+        }
+        if (algos.isEmpty()) {
+            throw new CIFSException("No signing algorithm named in jcifs.client.signingAlgorithms: " + prop);
+        }
+
+        this.signingAlgorithms = new int[algos.size()];
+        for (int i = 0; i < algos.size(); i++) {
+            this.signingAlgorithms[i] = algos.get(i);
+        }
+    }
+
+    private static int signingAlgorithmByName(final String name) throws CIFSException {
+        if (name.equalsIgnoreCase("HMAC-SHA256")) {
+            return SigningNegotiateContext.SIGNING_ALGO_HMAC_SHA256;
+        }
+        if (name.equalsIgnoreCase("AES-CMAC")) {
+            return SigningNegotiateContext.SIGNING_ALGO_AES128_CMAC;
+        }
+        if (name.equalsIgnoreCase("AES-GMAC")) {
+            return SigningNegotiateContext.SIGNING_ALGO_AES128_GMAC;
+        }
+        throw new CIFSException("Unknown signing algorithm '" + name + "'; expected one of HMAC-SHA256, AES-CMAC, AES-GMAC");
+    }
+
     private static int cipherByName(final String name) throws CIFSException {
         if (name.equalsIgnoreCase("AES-128-CCM")) {
             return EncryptionNegotiateContext.CIPHER_AES128_CCM;
@@ -920,6 +982,10 @@ public class BaseConfiguration implements Configuration {
             // Every configuration needs this, not just the property-driven one: an unset array would reach
             // EncryptionNegotiateContext as null the first time a caller enables encryption.
             initEncryptionCiphers(null);
+        }
+
+        if (this.signingAlgorithms == null) {
+            initSigningAlgorithms(null);
         }
 
         if (this.disallowCompound == null) {

--- a/src/main/java/org/codelibs/jcifs/smb/config/DelegatingConfiguration.java
+++ b/src/main/java/org/codelibs/jcifs/smb/config/DelegatingConfiguration.java
@@ -639,6 +639,16 @@ public class DelegatingConfiguration implements Configuration {
     /**
      * {@inheritDoc}
      *
+     * @see org.codelibs.jcifs.smb.Configuration#getSigningAlgorithms()
+     */
+    @Override
+    public int[] getSigningAlgorithms() {
+        return this.delegate.getSigningAlgorithms();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * @see org.codelibs.jcifs.smb.Configuration#getLmHostsFileName()
      */
     @Override

--- a/src/main/java/org/codelibs/jcifs/smb/config/PropertyConfiguration.java
+++ b/src/main/java/org/codelibs/jcifs/smb/config/PropertyConfiguration.java
@@ -115,6 +115,7 @@ public final class PropertyConfiguration extends BaseConfiguration implements Co
         this.ipcSigningEnforced = Config.getBoolean(p, "jcifs.client.ipcSigningEnforced", true);
         this.encryptionEnabled = Config.getBoolean(p, "jcifs.client.encryptionEnabled", false);
         initEncryptionCiphers(p.getProperty("jcifs.client.encryptionCiphers"));
+        initSigningAlgorithms(p.getProperty("jcifs.client.signingAlgorithms"));
         this.requireSecureNegotiate = Config.getBoolean(p, "jcifs.client.requireSecureNegotiate", true);
         this.sendNTLMTargetName = Config.getBoolean(p, "jcifs.client.SendNTLMTargetName", true);
 

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbSessionImpl.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbSessionImpl.java
@@ -619,8 +619,10 @@ final class SmbSessionImpl implements SmbSessionInternal {
                         if (this.preauthIntegrityHash != null && log.isDebugEnabled()) {
                             log.debug("Final preauth integrity hash " + Hexdump.toHexString(this.preauthIntegrityHash));
                         }
-                        Smb2SigningDigest dgst =
-                                new Smb2SigningDigest(this.sessionKey, negoResp.getDialectRevision(), this.preauthIntegrityHash);
+                        // The signing algorithm comes from the SIGNING_CAPABILITIES context the server echoed, or
+                        // is unset when it returned none - in which case AES-128-CMAC applies, exactly as before.
+                        Smb2SigningDigest dgst = new Smb2SigningDigest(this.sessionKey, negoResp.getDialectRevision(),
+                                this.preauthIntegrityHash, negoResp.getSelectedSigningAlgorithm());
                         // verify the server signature here, this is not done automatically as we don't set the
                         // request digest
                         // Ignore a missing signature for SMB < 3.0, as

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/Smb2SigningDigest.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/Smb2SigningDigest.java
@@ -18,13 +18,18 @@
 package org.codelibs.jcifs.smb.internal.smb2;
 
 import java.security.GeneralSecurityException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 import javax.crypto.Mac;
+import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
 import org.codelibs.jcifs.smb.internal.CommonServerMessageBlock;
 import org.codelibs.jcifs.smb.internal.SMBSigningDigest;
+import org.codelibs.jcifs.smb.internal.smb2.nego.SigningNegotiateContext;
 import org.codelibs.jcifs.smb.internal.util.SMBUtil;
 import org.codelibs.jcifs.smb.util.Crypto;
 import org.slf4j.Logger;
@@ -48,7 +53,31 @@ public class Smb2SigningDigest implements SMBSigningDigest {
      */
     private static final int SIGNATURE_OFFSET = 48;
     private static final int SIGNATURE_LENGTH = 16;
+
+    /** Offsets within the SMB2 header, matching ServerMessageBlock2.writeHeaderWireFormat. */
+    private static final int COMMAND_OFFSET = 12;
+    private static final int FLAGS_OFFSET = 16;
+    private static final int MID_OFFSET = 24;
+
+    /** AES-GMAC takes a 12-byte nonce (MS-SMB2 3.1.4.1, [RFC4543]). */
+    private static final int GMAC_NONCE_LENGTH = 12;
+
+    /** No SIGNING_CAPABILITIES context was negotiated, so AES-128-CMAC applies. */
+    public static final int SIGNING_ALGO_UNSET = -1;
+
+    /** Set in the nonce when the message was sent by the server rather than the client. */
+    private static final int NONCE_FLAG_RESPONSE = 0x01;
+
+    /** Set in the nonce when the message is an SMB2 CANCEL request. */
+    private static final int NONCE_FLAG_CANCEL = 0x02;
+
     private final Mac digest;
+
+    /**
+     * The signing key, kept because a GMAC Mac has to be re-initialised for every message and initialising needs
+     * the key again. Null unless GMAC was negotiated.
+     */
+    private final byte[] gmacKey;
 
     /**
      * Constructs a SMB2 signing digest with the specified session key and dialect
@@ -65,8 +94,29 @@ public class Smb2SigningDigest implements SMBSigningDigest {
      */
     public Smb2SigningDigest(final byte[] sessionKey, final int dialect, final byte[] preauthIntegrityHash)
             throws GeneralSecurityException {
+        this(sessionKey, dialect, preauthIntegrityHash, SIGNING_ALGO_UNSET);
+    }
+
+    /**
+     * Constructs a SMB2 signing digest for a negotiated signing algorithm.
+     *
+     * @param sessionKey
+     *            the session key for signing
+     * @param dialect
+     *            the SMB2 dialect version
+     * @param preauthIntegrityHash
+     *            the pre-authentication integrity hash (for SMB 3.1.1)
+     * @param signingAlgorithm
+     *            the algorithm from the SIGNING_CAPABILITIES negotiate context, or {@code -1} when the server
+     *            returned none - which means AES-128-CMAC (MS-SMB2 3.3.5.4)
+     * @throws GeneralSecurityException
+     *             if the signing algorithm cannot be initialized
+     */
+    public Smb2SigningDigest(final byte[] sessionKey, final int dialect, final byte[] preauthIntegrityHash, final int signingAlgorithm)
+            throws GeneralSecurityException {
         Mac m;
         byte[] signingKey;
+        boolean gmac = false;
         switch (dialect) {
         case Smb2Constants.SMB2_DIALECT_0202:
         case Smb2Constants.SMB2_DIALECT_0210:
@@ -83,14 +133,104 @@ public class Smb2SigningDigest implements SMBSigningDigest {
                 throw new IllegalArgumentException("Missing preauthIntegrityHash for SMB 3.1");
             }
             signingKey = Smb3KeyDerivation.deriveSigningKey(dialect, sessionKey, preauthIntegrityHash);
-            m = Mac.getInstance("AESCMAC", Crypto.getProvider());
+            // Only 3.1.1 negotiates the algorithm. Anything else, including an unset selection, is AES-CMAC -
+            // which is what this client used before the context was offered, so the default is unchanged.
+            if (signingAlgorithm == SigningNegotiateContext.SIGNING_ALGO_AES128_GMAC) {
+                m = Mac.getInstance("AES-GMAC", Crypto.getProvider());
+                gmac = true;
+            } else {
+                m = Mac.getInstance("AESCMAC", Crypto.getProvider());
+            }
             break;
         default:
             throw new IllegalArgumentException("Unknown dialect");
         }
 
-        m.init(new SecretKeySpec(signingKey, "HMAC"));
+        if (gmac) {
+            // Deliberately not initialised here. GMAC needs a per-message nonce, and BouncyCastle refuses to
+            // reuse an initialised GCM cipher - a second doFinal throws "GCM cipher cannot be reused for
+            // encryption" - so the key is kept and init happens per message instead.
+            this.gmacKey = signingKey;
+        } else {
+            m.init(new SecretKeySpec(signingKey, "HMAC"));
+            this.gmacKey = null;
+        }
         this.digest = m;
+    }
+
+    /**
+     * Returns the MAC to use for one message, initialised for it.
+     *
+     * <p>
+     * For CMAC and HMAC this is the single instance built in the constructor, reset. For GMAC it is a <em>new</em>
+     * instance every time, because the nonce is per message and BouncyCastle tracks key/nonce pairs on the
+     * instance: re-initialising one with a nonce it has already seen fails with "cannot reuse nonce for GCM
+     * encryption". That guard is right for encryption and wrong for a MAC, where recomputing the same tag over
+     * the same message is exactly what verifying does - so one digest would refuse to verify a response it had
+     * just signed, and any retried or replayed message would fail on the second look. A fresh instance costs a
+     * cipher construction, which is nothing beside the round trip that carried the message.
+     * </p>
+     *
+     * <p>
+     * Called with the monitor already held by {@link #sign} or {@link #verify}, so the initialisation and the
+     * update that follows are one atomic step even when a digest is shared between threads.
+     * </p>
+     */
+    private Mac prepare(final byte[] data, final int offset) {
+        if (this.gmacKey == null) {
+            this.digest.reset();
+            return this.digest;
+        }
+        try {
+            final Mac gmac = Mac.getInstance("AES-GMAC", Crypto.getProvider());
+            gmac.init(new SecretKeySpec(this.gmacKey, "AES"), new IvParameterSpec(gmacNonce(data, offset)));
+            return gmac;
+        } catch (final NoSuchAlgorithmException | InvalidKeyException | InvalidAlgorithmParameterException e) {
+            throw new IllegalStateException("Failed to initialise GMAC for signing", e);
+        }
+    }
+
+    /**
+     * Builds the AES-GMAC nonce for the message whose header starts at {@code offset}.
+     *
+     * <p>
+     * MS-SMB2 3.1.4.1: 12 bytes, the first 8 set to the MessageId, then four bytes whose least significant bit is
+     * zero if the sender is a client and one otherwise, whose penultimate bit is set for an SMB2 CANCEL request,
+     * and whose remaining 30 bits are zero. Section 3.1.5.1 has verification use the same syntax.
+     * </p>
+     *
+     * <p>
+     * Everything comes out of the message itself, which is what lets one construction serve both directions: the
+     * direction bit is the header's own SMB2_FLAGS_SERVER_TO_REDIR, clear on a request this client signs and set
+     * on a response it verifies. Only those two bits are taken - copying the flags word wholesale would drag in
+     * SMB2_FLAGS_SIGNED, which is set on every signed message, and corrupt the nonce for ordinary traffic.
+     * </p>
+     *
+     * @param data
+     *            buffer holding the message
+     * @param offset
+     *            offset of the SMB2 header within {@code data}
+     * @return the 12-byte nonce
+     */
+    static byte[] gmacNonce(final byte[] data, final int offset) {
+        final byte[] nonce = new byte[GMAC_NONCE_LENGTH];
+
+        // The MessageId is already little-endian in the header, and the nonce wants it in that same order, so it
+        // is copied rather than re-encoded.
+        System.arraycopy(data, offset + MID_OFFSET, nonce, 0, 8);
+
+        final int flags = SMBUtil.readInt4(data, offset + FLAGS_OFFSET);
+        final int command = SMBUtil.readInt2(data, offset + COMMAND_OFFSET);
+
+        int trailing = 0;
+        if ((flags & ServerMessageBlock2.SMB2_FLAGS_SERVER_TO_REDIR) != 0) {
+            trailing |= NONCE_FLAG_RESPONSE;
+        }
+        if (command == ServerMessageBlock2.SMB2_CANCEL) {
+            trailing |= NONCE_FLAG_CANCEL;
+        }
+        nonce[8] = (byte) trailing;
+        return nonce;
     }
 
     /**
@@ -102,8 +242,6 @@ public class Smb2SigningDigest implements SMBSigningDigest {
     @Override
     public synchronized void sign(final byte[] data, final int offset, final int length, final CommonServerMessageBlock request,
             final CommonServerMessageBlock response) {
-        this.digest.reset();
-
         // zero out signature field
         final int index = offset + SIGNATURE_OFFSET;
         for (int i = 0; i < SIGNATURE_LENGTH; i++) {
@@ -111,13 +249,18 @@ public class Smb2SigningDigest implements SMBSigningDigest {
         }
 
         // set signed flag
-        final int oldFlags = SMBUtil.readInt4(data, offset + 16);
+        final int oldFlags = SMBUtil.readInt4(data, offset + FLAGS_OFFSET);
         final int flags = oldFlags | ServerMessageBlock2.SMB2_FLAGS_SIGNED;
-        SMBUtil.writeInt4(flags, data, offset + 16);
+        SMBUtil.writeInt4(flags, data, offset + FLAGS_OFFSET);
 
-        this.digest.update(data, offset, length);
+        // After the header is in its final state, so the nonce is derived from the same bytes the peer will
+        // authenticate. Setting SMB2_FLAGS_SIGNED cannot change it - the nonce takes only the direction bit and
+        // the command - but deriving it from a header still being edited would be fragile for no reason.
+        final Mac mac = prepare(data, offset);
 
-        final byte[] sig = this.digest.doFinal();
+        mac.update(data, offset, length);
+
+        final byte[] sig = mac.doFinal();
         System.arraycopy(sig, 0, data, offset + SIGNATURE_OFFSET, SIGNATURE_LENGTH);
     }
 
@@ -130,9 +273,7 @@ public class Smb2SigningDigest implements SMBSigningDigest {
     @Override
     public synchronized boolean verify(final byte[] data, final int offset, final int length, final int extraPad,
             final CommonServerMessageBlock msg) {
-        this.digest.reset();
-
-        final int flags = SMBUtil.readInt4(data, offset + 16);
+        final int flags = SMBUtil.readInt4(data, offset + FLAGS_OFFSET);
         if ((flags & ServerMessageBlock2.SMB2_FLAGS_SIGNED) == 0) {
             log.error("The server did not sign a message we expected to be signed");
             return true;
@@ -146,10 +287,14 @@ public class Smb2SigningDigest implements SMBSigningDigest {
             data[index + i] = 0;
         }
 
-        this.digest.update(data, offset, length);
+        // The nonce comes out of the received header, so the direction bit is the server's - which is what makes
+        // one construction serve both signing a request and verifying a response.
+        final Mac mac = prepare(data, offset);
+
+        mac.update(data, offset, length);
 
         final byte[] cmp = new byte[SIGNATURE_LENGTH];
-        System.arraycopy(this.digest.doFinal(), 0, cmp, 0, SIGNATURE_LENGTH);
+        System.arraycopy(mac.doFinal(), 0, cmp, 0, SIGNATURE_LENGTH);
         if (!MessageDigest.isEqual(sig, cmp)) {
             return true;
         }

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/nego/SigningNegotiateContext.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/nego/SigningNegotiateContext.java
@@ -1,0 +1,147 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.internal.smb2.nego;
+
+import org.codelibs.jcifs.smb.Configuration;
+import org.codelibs.jcifs.smb.internal.SMBProtocolDecodingException;
+import org.codelibs.jcifs.smb.internal.util.SMBUtil;
+
+/**
+ * SMB2 Signing Capabilities Negotiate Context.
+ *
+ * <p>
+ * Used in SMB 3.1.1 to negotiate which algorithm signs messages (MS-SMB2 2.2.3.1.7). The data is a count followed
+ * by that many 16-bit algorithm ids, ordered with the client's most preferred first. Only SMB 3.1.1 negotiates
+ * this: SMB 3.0 and 3.0.2 always sign with AES-128-CMAC, and SMB 2.x with HMAC-SHA256.
+ * </p>
+ */
+public class SigningNegotiateContext implements NegotiateContextRequest, NegotiateContextResponse {
+
+    /**
+     * Context type
+     */
+    public static final int NEGO_CTX_SIGNING_TYPE = 0x8;
+
+    /**
+     * HMAC-SHA256, the SMB 2.x signing algorithm
+     */
+    public static final int SIGNING_ALGO_HMAC_SHA256 = 0x0;
+
+    /**
+     * AES-128-CMAC, the SMB 3.x default
+     */
+    public static final int SIGNING_ALGO_AES128_CMAC = 0x1;
+
+    /**
+     * AES-128-GMAC (SMB 3.1.1 only)
+     */
+    public static final int SIGNING_ALGO_AES128_GMAC = 0x2;
+
+    private int[] signingAlgos;
+
+    /**
+     * Constructs a signing capabilities negotiate context.
+     *
+     * @param config the configuration (currently unused)
+     * @param signingAlgos the signing algorithm ids to negotiate, most preferred first
+     */
+    public SigningNegotiateContext(final Configuration config, final int[] signingAlgos) {
+        this.signingAlgos = signingAlgos;
+    }
+
+    /**
+     * Default constructor for decoding.
+     */
+    public SigningNegotiateContext() {
+    }
+
+    /**
+     * Gets the signing algorithms.
+     *
+     * @return array of signing algorithm ids
+     */
+    public int[] getSigningAlgos() {
+        return this.signingAlgos;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.codelibs.jcifs.smb.internal.smb2.nego.NegotiateContextRequest#getContextType()
+     */
+    @Override
+    public int getContextType() {
+        return NEGO_CTX_SIGNING_TYPE;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.codelibs.jcifs.smb.Encodable#encode(byte[], int)
+     */
+    @Override
+    public int encode(final byte[] dst, int dstIndex) {
+        final int start = dstIndex;
+        SMBUtil.writeInt2(this.signingAlgos != null ? this.signingAlgos.length : 0, dst, dstIndex);
+        dstIndex += 2;
+
+        if (this.signingAlgos != null) {
+            for (final int algo : this.signingAlgos) {
+                SMBUtil.writeInt2(algo, dst, dstIndex);
+                dstIndex += 2;
+            }
+        }
+        return dstIndex - start;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.codelibs.jcifs.smb.Decodable#decode(byte[], int, int)
+     */
+    @Override
+    public int decode(final byte[] buffer, int bufferIndex, final int len) throws SMBProtocolDecodingException {
+        final int start = bufferIndex;
+        final int nalgos = SMBUtil.readInt2(buffer, bufferIndex);
+        bufferIndex += 2;
+
+        if ((long) bufferIndex + 2L * nalgos > buffer.length) {
+            throw new SMBProtocolDecodingException("Invalid signing negotiate context");
+        }
+
+        this.signingAlgos = new int[nalgos];
+        for (int i = 0; i < nalgos; i++) {
+            this.signingAlgos[i] = SMBUtil.readInt2(buffer, bufferIndex);
+            bufferIndex += 2;
+        }
+
+        return bufferIndex - start;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.codelibs.jcifs.smb.Encodable#size()
+     */
+    @Override
+    public int size() {
+        // Deliberately the number of bytes encode() writes, and no more. EncryptionNegotiateContext reports two
+        // bytes more than it writes, which is harmless there only because the wire length comes from encode's
+        // return value rather than from size().
+        return 2 + (this.signingAlgos != null ? 2 * this.signingAlgos.length : 0);
+    }
+
+}

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/nego/Smb2NegotiateRequest.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/nego/Smb2NegotiateRequest.java
@@ -100,6 +100,11 @@ public class Smb2NegotiateRequest extends ServerMessageBlock2Request<Smb2Negotia
                 // so, which is why offering AES-256 first does not by itself mean AES-256 is negotiated.
                 negoContexts.add(new EncryptionNegotiateContext(config, config.getEncryptionCiphers()));
             }
+
+            // Unconditionally, unlike the encryption context: signing is negotiated whether or not encryption is
+            // in use, and a signed but unencrypted session is the ordinary case. Without this context a 3.1.1
+            // server signs with AES-128-CMAC (MS-SMB2 3.3.5.4), which is what the client did before.
+            negoContexts.add(new SigningNegotiateContext(config, config.getSigningAlgorithms()));
         }
 
         this.negotiateContexts = negoContexts.toArray(new NegotiateContextRequest[negoContexts.size()]);

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/nego/Smb2NegotiateResponse.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/nego/Smb2NegotiateResponse.java
@@ -66,6 +66,7 @@ public class Smb2NegotiateResponse extends ServerMessageBlock2Response implement
     private boolean supportsEncryption;
     private int selectedCipher = -1;
     private int selectedPreauthHash = -1;
+    private int selectedSigningAlgorithm = -1;
 
     /**
      * Constructs an SMB2 negotiate response with the given configuration.
@@ -128,6 +129,20 @@ public class Smb2NegotiateResponse extends ServerMessageBlock2Response implement
      */
     public int getSelectedPreauthHash() {
         return this.selectedPreauthHash;
+    }
+
+    /**
+     * Gets the signing algorithm selected for SMB 3.1.1.
+     *
+     * <p>
+     * {@code -1} when the server returned no SIGNING_CAPABILITIES context, which a 3.1.1 server is free to do and
+     * which means AES-128-CMAC (MS-SMB2 3.3.5.4) - the algorithm this client used before the context was offered.
+     * </p>
+     *
+     * @return the selectedSigningAlgorithm, or -1 if none was negotiated
+     */
+    public int getSelectedSigningAlgorithm() {
+        return this.selectedSigningAlgorithm;
     }
 
     /**
@@ -321,10 +336,23 @@ public class Smb2NegotiateResponse extends ServerMessageBlock2Response implement
             return false;
         }
 
-        boolean foundPreauth = false, foundEnc = false;
+        boolean foundPreauth = false, foundEnc = false, foundSigning = false;
         for (final NegotiateContextResponse ncr : this.negotiateContexts) {
             if (ncr == null) {
                 continue;
+            }
+            if (!foundSigning && ncr.getContextType() == SigningNegotiateContext.NEGO_CTX_SIGNING_TYPE) {
+                foundSigning = true;
+                final SigningNegotiateContext sign = (SigningNegotiateContext) ncr;
+                if (!checkSigningContext(req, sign)) {
+                    return false;
+                }
+                this.selectedSigningAlgorithm = sign.getSigningAlgos()[0];
+                continue;
+            }
+            if (ncr.getContextType() == SigningNegotiateContext.NEGO_CTX_SIGNING_TYPE) {
+                log.error("Multiple signing negotiate contexts");
+                return false;
             }
             if (!foundEnc && ncr.getContextType() == EncryptionNegotiateContext.NEGO_CTX_ENC_TYPE) {
                 foundEnc = true;
@@ -388,6 +416,44 @@ public class Smb2NegotiateResponse extends ServerMessageBlock2Response implement
         }
         if (!valid) {
             log.error("Server returned invalid hash selection");
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Validates a SIGNING_CAPABILITIES context in the response.
+     *
+     * <p>
+     * An absent context is not an error - a 3.1.1 server may ignore it, and AES-128-CMAC then applies - but a
+     * context naming an algorithm the client did not offer is, for the same reason the cipher selection is checked
+     * against the request: otherwise a server could steer the client onto an algorithm it deliberately excluded.
+     * </p>
+     */
+    private static boolean checkSigningContext(final Smb2NegotiateRequest req, final SigningNegotiateContext sc) {
+        if (sc.getSigningAlgos() == null || sc.getSigningAlgos().length != 1) {
+            log.error("Server returned no signing algorithm selection");
+            return false;
+        }
+
+        SigningNegotiateContext rsc = null;
+        for (final NegotiateContextRequest rnc : req.getNegotiateContexts()) {
+            if (rnc instanceof SigningNegotiateContext) {
+                rsc = (SigningNegotiateContext) rnc;
+            }
+        }
+        if (rsc == null) {
+            return false;
+        }
+
+        boolean valid = false;
+        for (final int algo : rsc.getSigningAlgos()) {
+            if (algo == sc.getSigningAlgos()[0]) {
+                valid = true;
+            }
+        }
+        if (!valid) {
+            log.error("Server returned invalid signing algorithm selection");
             return false;
         }
         return true;
@@ -592,6 +658,8 @@ public class Smb2NegotiateResponse extends ServerMessageBlock2Response implement
             return new EncryptionNegotiateContext();
         case PreauthIntegrityNegotiateContext.NEGO_CTX_PREAUTH_TYPE:
             return new PreauthIntegrityNegotiateContext();
+        case SigningNegotiateContext.NEGO_CTX_SIGNING_TYPE:
+            return new SigningNegotiateContext();
         }
         return null;
     }

--- a/src/test/java/org/codelibs/jcifs/smb/config/PropertyConfigurationTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/config/PropertyConfigurationTest.java
@@ -151,6 +151,40 @@ class PropertyConfigurationTest extends BaseTest {
     }
 
     @Test
+    @DisplayName("signingAlgorithms parses algorithm names to ids, keeping the configured order")
+    void testSigningAlgorithmsProperty() throws CIFSException {
+        final Properties props = new Properties();
+        props.setProperty("jcifs.client.signingAlgorithms", "AES-GMAC, HMAC-SHA256");
+
+        final PropertyConfiguration testConfig = new PropertyConfiguration(props);
+
+        assertArrayEquals(new int[] { 0x2, 0x0 }, testConfig.getSigningAlgorithms(),
+                "configured algorithm names must map to their MS-SMB2 ids in the configured order");
+    }
+
+    @Test
+    @DisplayName("signingAlgorithms defaults to AES-CMAC first, leaving existing behaviour unchanged")
+    void testSigningAlgorithmsDefault() throws CIFSException {
+        final PropertyConfiguration testConfig = new PropertyConfiguration(new Properties());
+
+        // AES-CMAC leads deliberately. A server picks from the client's offer by its own preference - the Samba
+        // fixture lists AES-128-GMAC first - so leading with CMAC keeps the algorithm an existing deployment
+        // negotiates exactly as it is today, while making GMAC reachable for anyone who asks for it.
+        assertArrayEquals(new int[] { 0x1, 0x2, 0x0 }, testConfig.getSigningAlgorithms(),
+                "the default offer must be AES-CMAC, AES-GMAC, HMAC-SHA256");
+    }
+
+    @Test
+    @DisplayName("an unknown signing algorithm name is refused rather than silently dropped")
+    void testSigningAlgorithmsRejectsUnknownName() {
+        final Properties props = new Properties();
+        props.setProperty("jcifs.client.signingAlgorithms", "AES-CMAC, AES-512-GMAC");
+
+        assertThrows(CIFSException.class, () -> new PropertyConfiguration(props),
+                "an unrecognised signing algorithm name must fail configuration rather than be ignored");
+    }
+
+    @Test
     @DisplayName("encryptionCiphers parses cipher names to ids, keeping the configured order")
     void testEncryptionCiphersProperty() throws CIFSException {
         final Properties props = new Properties();

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbNegotiationProbe.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbNegotiationProbe.java
@@ -79,6 +79,31 @@ public final class SmbNegotiationProbe {
      * @return the selected cipher identifier, or -1 if none was negotiated
      * @throws CIFSException if the connection cannot be established
      */
+    /**
+     * Returns the signing algorithm the server selected, or {@code -1} if the response carried no
+     * SIGNING_CAPABILITIES context.
+     *
+     * <p>
+     * As with the cipher, this is the only observable that distinguishes a successful negotiation from a silent
+     * fallback: a signed session works identically under AES-CMAC and AES-GMAC, so asserting that traffic flows
+     * says nothing about which algorithm protected it.
+     * </p>
+     *
+     * @param file any connected resource on the tree of interest
+     * @return the selected signing algorithm identifier, or -1 if none was negotiated
+     * @throws CIFSException if the connection cannot be established
+     */
+    public static int negotiatedSigningAlgorithm(final SmbFile file) throws CIFSException {
+        try (SmbTreeHandleImpl tree = (SmbTreeHandleImpl) file.getTreeHandle();
+                SmbSessionImpl session = tree.getSession();
+                SmbTransportImpl transport = session.getTransport()) {
+            if (transport.getNegotiateResponse() instanceof final Smb2NegotiateResponse resp) {
+                return resp.getSelectedSigningAlgorithm();
+            }
+            return -1;
+        }
+    }
+
     public static int negotiatedCipher(final SmbFile file) throws CIFSException {
         try (SmbTreeHandleImpl tree = (SmbTreeHandleImpl) file.getTreeHandle();
                 SmbSessionImpl session = tree.getSession();

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb2GmacNonceTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb2GmacNonceTest.java
@@ -1,0 +1,142 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.internal.smb2;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.codelibs.jcifs.smb.internal.util.SMBUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The AES-GMAC nonce, which is derived entirely from the message being signed.
+ *
+ * <p>
+ * MS-SMB2 3.1.4.1 states it as: 12 bytes, the "first 8 bytes are set to MessageId", then "if the sender is a
+ * client, least significant bit is set to zero, otherwise set to 1. If the message is SMB2 CANCEL request, the
+ * penultimate bit is set to 1, otherwise set to zero. Remaining 30 bits are set to zero." Section 3.1.5.1 says
+ * verification uses the same syntax, and since the direction bit is read from each message's own header, one
+ * construction serves signing a request and verifying a response.
+ * </p>
+ *
+ * <p>
+ * Samba computes the same thing - {@code SBVAL(iv, 0, msg_id)}, then {@code high_bits = flags &
+ * SMB2_HDR_FLAG_REDIRECT} with {@code SMB2_HDR_FLAG_ASYNC} added for {@code SMB2_OP_CANCEL}, written at offset 8 -
+ * where REDIRECT is 0x01 and ASYNC 0x02, so the two agree bit for bit. That agreement is why this is asserted
+ * against literal expected bytes rather than against a second implementation of the same arithmetic: a test that
+ * recomputed the layout would pass whatever the layout was.
+ * </p>
+ */
+class Smb2GmacNonceTest {
+
+    /** Offsets within the SMB2 header, as written by ServerMessageBlock2.writeHeaderWireFormat. */
+    private static final int COMMAND_OFFSET = 12;
+    private static final int FLAGS_OFFSET = 16;
+    private static final int MID_OFFSET = 24;
+
+    private static byte[] header(final long mid, final int flags, final int command) {
+        final byte[] buf = new byte[Smb2Constants.SMB2_HEADER_LENGTH];
+        SMBUtil.writeInt2(command, buf, COMMAND_OFFSET);
+        SMBUtil.writeInt4(flags, buf, FLAGS_OFFSET);
+        SMBUtil.writeInt8(mid, buf, MID_OFFSET);
+        return buf;
+    }
+
+    @Test
+    @DisplayName("a request nonce carries the message id and a zero direction bit")
+    void requestNonce() {
+        final byte[] buf = header(0x0102030405060708L, 0, ServerMessageBlock2.SMB2_QUERY_DIRECTORY);
+
+        final byte[] nonce = Smb2SigningDigest.gmacNonce(buf, 0);
+
+        assertEquals(12, nonce.length, "the GMAC nonce is 12 bytes");
+        // MessageId little-endian, exactly as it sits in the header, then four bytes that are all zero for a
+        // client-sent message that is not a CANCEL.
+        assertArrayEquals(new byte[] { 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00, 0x00, 0x00, 0x00 }, nonce,
+                "a client request nonce is the message id followed by four zero bytes");
+    }
+
+    @Test
+    @DisplayName("a response nonce sets the least significant bit of the trailing four bytes")
+    void responseNonce() {
+        final byte[] buf =
+                header(0x0102030405060708L, ServerMessageBlock2.SMB2_FLAGS_SERVER_TO_REDIR, ServerMessageBlock2.SMB2_QUERY_DIRECTORY);
+
+        final byte[] nonce = Smb2SigningDigest.gmacNonce(buf, 0);
+
+        // "If the sender is a client, least significant bit is set to zero, otherwise set to 1." The bit is read
+        // from the message's own flags, which is what lets the same code verify an incoming response.
+        assertArrayEquals(new byte[] { 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x01, 0x00, 0x00, 0x00 }, nonce,
+                "a response nonce sets bit 0 of the byte at offset 8");
+    }
+
+    @Test
+    @DisplayName("a CANCEL request sets the penultimate bit, and only for CANCEL")
+    void cancelNonce() {
+        final byte[] cancel = header(0x1122334455667788L, 0, ServerMessageBlock2.SMB2_CANCEL);
+
+        assertArrayEquals(new byte[] { (byte) 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x02, 0x00, 0x00, 0x00 },
+                Smb2SigningDigest.gmacNonce(cancel, 0), "a CANCEL request sets bit 1 of the byte at offset 8");
+
+        // Every other command must leave that bit clear, or the nonce for ordinary traffic is wrong.
+        final byte[] echo = header(0x1122334455667788L, 0, ServerMessageBlock2.SMB2_ECHO);
+        assertEquals(0, Smb2SigningDigest.gmacNonce(echo, 0)[8], "a non-CANCEL client request has no bits set at offset 8");
+    }
+
+    @Test
+    @DisplayName("a CANCEL response sets both bits")
+    void cancelResponseNonce() {
+        final byte[] buf = header(0x00000000000000FFL, ServerMessageBlock2.SMB2_FLAGS_SERVER_TO_REDIR, ServerMessageBlock2.SMB2_CANCEL);
+
+        // The two bits are independent, so the combination has to be checked as well: taking one as implying the
+        // absence of the other would pass with an implementation that treated them as a single enum.
+        assertEquals(0x03, Smb2SigningDigest.gmacNonce(buf, 0)[8], "a CANCEL response sets both bit 0 and bit 1");
+    }
+
+    @Test
+    @DisplayName("the nonce is read from the message's own header, at whatever offset it sits")
+    void nonceHonoursTheBufferOffset() {
+        // Messages are signed in place inside a larger send buffer - ServerMessageBlock2 passes headerStart - so
+        // reading the header from index zero would produce the wrong nonce for every compounded message after the
+        // first, while the first one still verified.
+        final byte[] framed = new byte[Smb2Constants.SMB2_HEADER_LENGTH + 96];
+        final int off = 80;
+        SMBUtil.writeInt2(ServerMessageBlock2.SMB2_READ, framed, off + COMMAND_OFFSET);
+        SMBUtil.writeInt4(0, framed, off + FLAGS_OFFSET);
+        SMBUtil.writeInt8(0x7766554433221100L, framed, off + MID_OFFSET);
+
+        assertArrayEquals(new byte[] { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x00, 0x00, 0x00, 0x00 },
+                Smb2SigningDigest.gmacNonce(framed, off), "the nonce must come from the header at the given offset");
+    }
+
+    @Test
+    @DisplayName("the remaining 30 bits are zero even when the header carries other flags")
+    void unrelatedFlagsDoNotLeakIntoTheNonce() {
+        // Only the direction bit and the CANCEL marker belong in the nonce. SIGNED is set on every signed message
+        // and RELATED_OPERATIONS on every chained one, so leaking the flags word wholesale would corrupt the nonce
+        // for ordinary traffic - and would do it in a way that still round trips against another jcifs client.
+        final int noisy = ServerMessageBlock2.SMB2_FLAGS_SIGNED | ServerMessageBlock2.SMB2_FLAGS_RELATED_OPERATIONS
+                | ServerMessageBlock2.SMB2_FLAGS_DFS_OPERATIONS | ServerMessageBlock2.SMB2_FLAGS_ASYNC_COMMAND;
+        final byte[] buf = header(1L, noisy, ServerMessageBlock2.SMB2_CREATE);
+
+        final byte[] nonce = Smb2SigningDigest.gmacNonce(buf, 0);
+        assertEquals(0, nonce[8], "no unrelated flag may appear at offset 8");
+        assertEquals(0, nonce[9], "byte 9 is reserved and must be zero");
+        assertEquals(0, nonce[10], "byte 10 is reserved and must be zero");
+        assertEquals(0, nonce[11], "byte 11 is reserved and must be zero");
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb2GmacSigningTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/Smb2GmacSigningTest.java
@@ -1,0 +1,177 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.internal.smb2;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.security.GeneralSecurityException;
+import java.security.Security;
+import java.util.Arrays;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.codelibs.jcifs.smb.internal.CommonServerMessageBlock;
+import org.codelibs.jcifs.smb.internal.smb2.nego.SigningNegotiateContext;
+import org.codelibs.jcifs.smb.internal.util.SMBUtil;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * AES-128-GMAC signing, which SMB 3.1.1 negotiates in a SIGNING_CAPABILITIES context.
+ *
+ * <p>
+ * GMAC differs from CMAC in a way that matters structurally: its MAC object cannot be reset and reused, because
+ * every message needs a fresh nonce. BouncyCastle enforces that - a second doFinal on a GMAC Mac without
+ * re-initialising throws {@code IllegalStateException: GCM cipher cannot be reused for encryption} - so signing
+ * two messages in a row is the case that would break a digest written the way the CMAC one is.
+ * </p>
+ */
+class Smb2GmacSigningTest {
+
+    private static final int SIGNATURE_OFFSET = 48;
+    private static final int SIGNATURE_LENGTH = 16;
+    private static final int FLAGS_OFFSET = 16;
+    private static final int MID_OFFSET = 24;
+
+    private byte[] sessionKey;
+    private byte[] preauthIntegrityHash;
+    private CommonServerMessageBlock request;
+    private CommonServerMessageBlock response;
+
+    @BeforeAll
+    static void registerProvider() {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
+    @BeforeEach
+    void setup() {
+        this.sessionKey = new byte[16];
+        Arrays.fill(this.sessionKey, (byte) 0xAA);
+        this.preauthIntegrityHash = new byte[64];
+        Arrays.fill(this.preauthIntegrityHash, (byte) 0xBB);
+        this.request = mock(CommonServerMessageBlock.class);
+        this.response = mock(CommonServerMessageBlock.class);
+    }
+
+    private static byte[] message(final long mid) {
+        final byte[] data = new byte[128];
+        SMBUtil.writeInt8(mid, data, MID_OFFSET);
+        return data;
+    }
+
+    private static byte[] signatureOf(final byte[] data) {
+        return Arrays.copyOfRange(data, SIGNATURE_OFFSET, SIGNATURE_OFFSET + SIGNATURE_LENGTH);
+    }
+
+    @Test
+    @DisplayName("a GMAC digest signs, and signs a second message without being re-created")
+    void gmacSignsRepeatedly() throws GeneralSecurityException {
+        final Smb2SigningDigest digest = new Smb2SigningDigest(this.sessionKey, Smb2Constants.SMB2_DIALECT_0311, this.preauthIntegrityHash,
+                SigningNegotiateContext.SIGNING_ALGO_AES128_GMAC);
+
+        final byte[] first = message(1L);
+        digest.sign(first, 0, first.length, this.request, this.response);
+        assertFalse(Arrays.equals(new byte[SIGNATURE_LENGTH], signatureOf(first)), "the first message must be signed");
+
+        // The point of this test. A Mac initialised once and merely reset cannot do this - BouncyCastle throws
+        // rather than producing a wrong tag - so a digest that signs one message proves nothing about the second.
+        final byte[] second = message(2L);
+        assertDoesNotThrow(() -> digest.sign(second, 0, second.length, this.request, this.response),
+                "signing a second message must not require a new digest");
+        assertFalse(Arrays.equals(new byte[SIGNATURE_LENGTH], signatureOf(second)), "the second message must be signed");
+    }
+
+    @Test
+    @DisplayName("the signature depends on the message id, because the nonce does")
+    void signatureDependsOnMessageId() throws GeneralSecurityException {
+        final Smb2SigningDigest digest = new Smb2SigningDigest(this.sessionKey, Smb2Constants.SMB2_DIALECT_0311, this.preauthIntegrityHash,
+                SigningNegotiateContext.SIGNING_ALGO_AES128_GMAC);
+
+        final byte[] one = message(1L);
+        final byte[] two = message(2L);
+        digest.sign(one, 0, one.length, this.request, this.response);
+        digest.sign(two, 0, two.length, this.request, this.response);
+
+        // Two messages identical but for the id must get different tags. Were the nonce fixed - or derived from
+        // something constant - they would match, and every message on the connection would reuse one nonce, which
+        // is the failure GMAC is least forgiving of.
+        assertFalse(Arrays.equals(signatureOf(one), signatureOf(two)), "different message ids must produce different signatures");
+    }
+
+    @Test
+    @DisplayName("GMAC and CMAC produce different signatures over the same bytes")
+    void gmacDiffersFromCmac() throws GeneralSecurityException {
+        final Smb2SigningDigest gmac = new Smb2SigningDigest(this.sessionKey, Smb2Constants.SMB2_DIALECT_0311, this.preauthIntegrityHash,
+                SigningNegotiateContext.SIGNING_ALGO_AES128_GMAC);
+        final Smb2SigningDigest cmac = new Smb2SigningDigest(this.sessionKey, Smb2Constants.SMB2_DIALECT_0311, this.preauthIntegrityHash,
+                SigningNegotiateContext.SIGNING_ALGO_AES128_CMAC);
+
+        final byte[] viaGmac = message(7L);
+        final byte[] viaCmac = message(7L);
+        gmac.sign(viaGmac, 0, viaGmac.length, this.request, this.response);
+        cmac.sign(viaCmac, 0, viaCmac.length, this.request, this.response);
+
+        // If the algorithm argument were ignored, both would be CMAC and these would match - so this is what
+        // catches the negotiated algorithm never actually reaching the Mac.
+        assertFalse(Arrays.equals(signatureOf(viaGmac), signatureOf(viaCmac)), "GMAC and CMAC must not agree on a signature");
+    }
+
+    @Test
+    @DisplayName("an unset algorithm still signs with AES-CMAC, exactly as before")
+    void unsetAlgorithmFallsBackToCmac() throws GeneralSecurityException {
+        // A 3.1.1 server may return no SIGNING_CAPABILITIES context, in which case MS-SMB2 3.3.5.4 says AES-CMAC.
+        // The three-argument constructor is the pre-existing behaviour and must stay byte-identical to passing the
+        // CMAC id explicitly, or every existing deployment's signatures change.
+        final Smb2SigningDigest legacy = new Smb2SigningDigest(this.sessionKey, Smb2Constants.SMB2_DIALECT_0311, this.preauthIntegrityHash);
+        final Smb2SigningDigest explicitCmac = new Smb2SigningDigest(this.sessionKey, Smb2Constants.SMB2_DIALECT_0311,
+                this.preauthIntegrityHash, SigningNegotiateContext.SIGNING_ALGO_AES128_CMAC);
+
+        final byte[] viaLegacy = message(11L);
+        final byte[] viaExplicit = message(11L);
+        legacy.sign(viaLegacy, 0, viaLegacy.length, this.request, this.response);
+        explicitCmac.sign(viaExplicit, 0, viaExplicit.length, this.request, this.response);
+
+        assertArrayEquals(signatureOf(viaLegacy), signatureOf(viaExplicit), "the default must remain AES-CMAC, bit for bit");
+    }
+
+    @Test
+    @DisplayName("a GMAC signature verifies, and a tampered one does not")
+    void gmacVerifies() throws GeneralSecurityException {
+        final Smb2SigningDigest signer = new Smb2SigningDigest(this.sessionKey, Smb2Constants.SMB2_DIALECT_0311, this.preauthIntegrityHash,
+                SigningNegotiateContext.SIGNING_ALGO_AES128_GMAC);
+        final Smb2SigningDigest verifier = new Smb2SigningDigest(this.sessionKey, Smb2Constants.SMB2_DIALECT_0311,
+                this.preauthIntegrityHash, SigningNegotiateContext.SIGNING_ALGO_AES128_GMAC);
+
+        // Signed as a response, because that is the direction a client verifies, and the nonce's direction bit is
+        // read from the message itself - so a verifier that rebuilt the nonce as if it were a request would fail.
+        final byte[] data = message(21L);
+        SMBUtil.writeInt4(ServerMessageBlock2.SMB2_FLAGS_SERVER_TO_REDIR, data, FLAGS_OFFSET);
+        signer.sign(data, 0, data.length, this.request, this.response);
+
+        // verify() reports trouble by returning true, which reads backwards but is the existing contract.
+        assertFalse(verifier.verify(data, 0, data.length, 0, this.response), "a correctly signed message must verify");
+
+        data[100] ^= 0x01;
+        assertTrue(verifier.verify(data, 0, data.length, 0, this.response), "a tampered message must not verify");
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/nego/SigningNegotiateContextTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/nego/SigningNegotiateContextTest.java
@@ -1,0 +1,144 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.internal.smb2.nego;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.codelibs.jcifs.smb.Configuration;
+import org.codelibs.jcifs.smb.internal.SMBProtocolDecodingException;
+import org.codelibs.jcifs.smb.internal.util.SMBUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * The SMB2_SIGNING_CAPABILITIES negotiate context (MS-SMB2 2.2.3.1.7).
+ *
+ * <p>
+ * The data is a 2-byte SigningAlgorithmCount followed by that many 16-bit ids, ordered with the most preferred
+ * first. The defined ids are 0x0000 HMAC-SHA256, 0x0001 AES-CMAC and 0x0002 AES-GMAC, which is also what Samba's
+ * smb2_constants.h carries, so the two agree.
+ * </p>
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SigningNegotiateContext Tests")
+class SigningNegotiateContextTest {
+
+    @Mock
+    private Configuration mockConfig;
+
+    @Test
+    @DisplayName("the context type is 0x0008")
+    void testContextType() {
+        assertEquals(0x0008, SigningNegotiateContext.NEGO_CTX_SIGNING_TYPE, "MS-SMB2 2.2.3.1.7 assigns type 0x0008");
+        assertEquals(0x0008,
+                new SigningNegotiateContext(mockConfig, new int[] { SigningNegotiateContext.SIGNING_ALGO_AES128_GMAC }).getContextType());
+    }
+
+    @Test
+    @DisplayName("the algorithm ids match the specification")
+    void testAlgorithmIds() {
+        // Pinned as literals rather than referred through another constant: these are wire values, and the point
+        // of the assertion is that they are these numbers and not some other numbering.
+        assertEquals(0x0000, SigningNegotiateContext.SIGNING_ALGO_HMAC_SHA256, "HMAC-SHA256 is 0x0000");
+        assertEquals(0x0001, SigningNegotiateContext.SIGNING_ALGO_AES128_CMAC, "AES-CMAC is 0x0001");
+        assertEquals(0x0002, SigningNegotiateContext.SIGNING_ALGO_AES128_GMAC, "AES-GMAC is 0x0002");
+    }
+
+    @Test
+    @DisplayName("encode writes the count then the ids, in the order given")
+    void testEncode() {
+        final int[] algos = { SigningNegotiateContext.SIGNING_ALGO_AES128_GMAC, SigningNegotiateContext.SIGNING_ALGO_AES128_CMAC };
+        final SigningNegotiateContext ctx = new SigningNegotiateContext(mockConfig, algos);
+
+        final byte[] buffer = new byte[64];
+        final int written = ctx.encode(buffer, 0);
+
+        assertEquals(2, SMBUtil.readInt2(buffer, 0), "SigningAlgorithmCount must be the number of ids");
+        assertEquals(SigningNegotiateContext.SIGNING_ALGO_AES128_GMAC, SMBUtil.readInt2(buffer, 2), "the first id is the preferred one");
+        assertEquals(SigningNegotiateContext.SIGNING_ALGO_AES128_CMAC, SMBUtil.readInt2(buffer, 4), "the second id follows it");
+        assertEquals(6, written, "two bytes of count plus two ids of two bytes each");
+    }
+
+    @Test
+    @DisplayName("decode reads back what encode wrote")
+    void testDecodeRoundTrip() throws SMBProtocolDecodingException {
+        final int[] algos = { SigningNegotiateContext.SIGNING_ALGO_HMAC_SHA256, SigningNegotiateContext.SIGNING_ALGO_AES128_GMAC,
+                SigningNegotiateContext.SIGNING_ALGO_AES128_CMAC };
+        final byte[] buffer = new byte[64];
+        final int written = new SigningNegotiateContext(mockConfig, algos).encode(buffer, 0);
+
+        final SigningNegotiateContext decoded = new SigningNegotiateContext();
+        final int read = decoded.decode(buffer, 0, written);
+
+        assertArrayEquals(algos, decoded.getSigningAlgos(), "the ids must survive a round trip in order");
+        assertEquals(written, read, "decode must consume exactly what encode produced");
+    }
+
+    @Test
+    @DisplayName("a server response naming one algorithm decodes to that algorithm")
+    void testDecodeServerSelection() throws SMBProtocolDecodingException {
+        // What a server actually sends back: the single algorithm it chose.
+        final byte[] buffer = new byte[8];
+        SMBUtil.writeInt2(1, buffer, 0);
+        SMBUtil.writeInt2(SigningNegotiateContext.SIGNING_ALGO_AES128_GMAC, buffer, 2);
+
+        final SigningNegotiateContext decoded = new SigningNegotiateContext();
+        decoded.decode(buffer, 0, 4);
+
+        assertArrayEquals(new int[] { SigningNegotiateContext.SIGNING_ALGO_AES128_GMAC }, decoded.getSigningAlgos());
+    }
+
+    @Test
+    @DisplayName("size matches what encode writes")
+    void testSize() {
+        final SigningNegotiateContext ctx = new SigningNegotiateContext(mockConfig,
+                new int[] { SigningNegotiateContext.SIGNING_ALGO_AES128_CMAC, SigningNegotiateContext.SIGNING_ALGO_AES128_GMAC });
+
+        final byte[] buffer = new byte[64];
+        final int written = ctx.encode(buffer, 0);
+
+        // The encryption context reports a size two bytes larger than it writes, which is harmless only because
+        // the wire length comes from encode's return value. Not repeating that here.
+        assertEquals(written, ctx.size(), "size must agree with the number of bytes encode writes");
+    }
+
+    @Test
+    @DisplayName("a count that runs past the buffer is rejected rather than read out of bounds")
+    void testDecodeRejectsOverlongCount() {
+        final byte[] buffer = new byte[8];
+        SMBUtil.writeInt2(1000, buffer, 0);
+
+        assertThrows(SMBProtocolDecodingException.class, () -> new SigningNegotiateContext().decode(buffer, 0, buffer.length),
+                "a declared count larger than the buffer must fail decoding");
+    }
+
+    @Test
+    @DisplayName("an empty algorithm array encodes a zero count without error")
+    void testEncodeEmpty() {
+        // The specification requires a count greater than zero, so the client never sends this; encoding it must
+        // still not write past the count field, because a malformed response must not be able to steer the encoder.
+        final byte[] buffer = new byte[64];
+        final int written = new SigningNegotiateContext(mockConfig, new int[0]).encode(buffer, 0);
+
+        assertEquals(0, SMBUtil.readInt2(buffer, 0), "an empty array encodes a zero count");
+        assertEquals(2, written, "only the count field is written");
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/nego/Smb2NegotiateRequestTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/nego/Smb2NegotiateRequestTest.java
@@ -61,6 +61,10 @@ class Smb2NegotiateRequestTest {
         when(mockConfig.isEncryptionEnabled()).thenReturn(true);
         when(mockConfig.getEncryptionCiphers())
                 .thenReturn(new int[] { EncryptionNegotiateContext.CIPHER_AES128_GCM, EncryptionNegotiateContext.CIPHER_AES128_CCM });
+        // A real configuration can never return null here - initDefaults fills it in - so leaving the mock
+        // unstubbed would have these tests exercising a state production cannot reach.
+        when(mockConfig.getSigningAlgorithms()).thenReturn(new int[] { SigningNegotiateContext.SIGNING_ALGO_AES128_CMAC,
+                SigningNegotiateContext.SIGNING_ALGO_AES128_GMAC, SigningNegotiateContext.SIGNING_ALGO_HMAC_SHA256 });
         when(mockConfig.getMinimumVersion()).thenReturn(DialectVersion.SMB202);
         when(mockConfig.getMaximumVersion()).thenReturn(DialectVersion.SMB311);
         when(mockConfig.getMachineId()).thenReturn(testMachineId);
@@ -210,6 +214,42 @@ class Smb2NegotiateRequestTest {
     }
 
     @Test
+    @DisplayName("the offered signing algorithms are the configured ones, in the configured order")
+    void testOfferedSigningAlgorithmsComeFromConfiguration() {
+        when(mockConfig.getMaximumVersion()).thenReturn(DialectVersion.SMB311);
+        when(mockConfig.getSigningAlgorithms()).thenReturn(
+                new int[] { SigningNegotiateContext.SIGNING_ALGO_AES128_GMAC, SigningNegotiateContext.SIGNING_ALGO_AES128_CMAC });
+
+        request = new Smb2NegotiateRequest(mockConfig, 0);
+
+        // The SIGNING_CAPABILITIES context is sent on 3.1.1 whether or not encryption is enabled - signing and
+        // encryption are separate concerns, and a signed but unencrypted session is the common case.
+        SigningNegotiateContext signing = null;
+        for (final NegotiateContextRequest ctx : request.getNegotiateContexts()) {
+            if (ctx instanceof SigningNegotiateContext) {
+                signing = (SigningNegotiateContext) ctx;
+            }
+        }
+        assertNotNull(signing, "a SIGNING_CAPABILITIES context must be offered on SMB 3.1.1");
+        assertArrayEquals(new int[] { SigningNegotiateContext.SIGNING_ALGO_AES128_GMAC, SigningNegotiateContext.SIGNING_ALGO_AES128_CMAC },
+                signing.getSigningAlgos(), "the context must offer exactly the configured algorithms, in order");
+    }
+
+    @Test
+    @DisplayName("no signing context is offered below SMB 3.1.1")
+    void testNoSigningContextBelowSmb311() {
+        // Only 3.1.1 negotiates a signing algorithm in a context; 3.0 and 3.0.2 always use AES-CMAC and 2.x
+        // HMAC-SHA256, so offering the context there would be sending a context the dialect has no place for.
+        when(mockConfig.getMaximumVersion()).thenReturn(DialectVersion.SMB302);
+
+        request = new Smb2NegotiateRequest(mockConfig, 0);
+
+        for (final NegotiateContextRequest ctx : request.getNegotiateContexts()) {
+            assertFalse(ctx instanceof SigningNegotiateContext, "no signing context below SMB 3.1.1");
+        }
+    }
+
+    @Test
     @DisplayName("the offered ciphers are the configured ones, in the configured order")
     void testOfferedCiphersComeFromConfiguration() {
         when(mockConfig.getMaximumVersion()).thenReturn(DialectVersion.SMB311);
@@ -240,7 +280,7 @@ class Smb2NegotiateRequestTest {
         // Then
         NegotiateContextRequest[] contexts = request.getNegotiateContexts();
         assertNotNull(contexts);
-        assertEquals(2, contexts.length);
+        assertEquals(3, contexts.length);
 
         // Verify preauth context
         assertTrue(contexts[0] instanceof PreauthIntegrityNegotiateContext);
@@ -250,12 +290,16 @@ class Smb2NegotiateRequestTest {
         assertTrue(contexts[1] instanceof EncryptionNegotiateContext);
         assertEquals(EncryptionNegotiateContext.NEGO_CTX_ENC_TYPE, contexts[1].getContextType());
 
+        // Verify signing context
+        assertTrue(contexts[2] instanceof SigningNegotiateContext);
+        assertEquals(SigningNegotiateContext.NEGO_CTX_SIGNING_TYPE, contexts[2].getContextType());
+
         // Verify salt was generated
         assertArrayEquals(testSalt, request.getPreauthSalt());
     }
 
     @Test
-    @DisplayName("Should add only preauth context when encryption disabled for SMB 3.1.1")
+    @DisplayName("Should omit only the encryption context when encryption disabled for SMB 3.1.1")
     void testNegotiateContextsSmb311NoEncryption() {
         // Given
         when(mockConfig.getMaximumVersion()).thenReturn(DialectVersion.SMB311);
@@ -267,10 +311,21 @@ class Smb2NegotiateRequestTest {
         // Then
         NegotiateContextRequest[] contexts = request.getNegotiateContexts();
         assertNotNull(contexts);
-        assertEquals(1, contexts.length);
 
-        // Only preauth context
-        assertTrue(contexts[0] instanceof PreauthIntegrityNegotiateContext);
+        // Asserted by type rather than by count. The point of this test is that disabling encryption drops the
+        // encryption context and nothing else - signing is negotiated independently, and a signed but unencrypted
+        // session is the ordinary case - and a bare length never actually checked which context was missing.
+        boolean preauth = false, encryption = false, signing = false;
+        for (final NegotiateContextRequest ctx : contexts) {
+            preauth |= ctx instanceof PreauthIntegrityNegotiateContext;
+            encryption |= ctx instanceof EncryptionNegotiateContext;
+            signing |= ctx instanceof SigningNegotiateContext;
+        }
+        assertTrue(preauth, "the preauth integrity context is required on SMB 3.1.1");
+        assertFalse(encryption, "no encryption context when encryption is disabled");
+        assertTrue(signing, "the signing context is offered whether or not encryption is enabled");
+        assertEquals(2, contexts.length, "preauth and signing, and nothing else");
+
         assertArrayEquals(testSalt, request.getPreauthSalt());
     }
 
@@ -412,8 +467,8 @@ class Smb2NegotiateRequestTest {
         // Then
         assertTrue(bytesWritten > 36);
 
-        // Verify negotiate context count
-        assertEquals(2, SMBUtil.readInt2(buffer, 32));
+        // Verify negotiate context count: preauth, encryption and signing
+        assertEquals(3, SMBUtil.readInt2(buffer, 32));
 
         // Verify negotiate context offset is set
         int contextOffset = SMBUtil.readInt4(buffer, 28);
@@ -532,7 +587,7 @@ class Smb2NegotiateRequestTest {
         assertEquals(16, request.getClientGuid().length);
         assertEquals(32, request.getPreauthSalt().length);
         assertTrue(request.getDialects().length > 0);
-        assertEquals(2, request.getNegotiateContexts().length);
+        assertEquals(3, request.getNegotiateContexts().length);
     }
 
     @Test

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/nego/Smb2NegotiateResponseTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/nego/Smb2NegotiateResponseTest.java
@@ -678,6 +678,78 @@ class Smb2NegotiateResponseTest {
     }
 
     @Test
+    @DisplayName("a signing context in the response is parsed rather than skipped")
+    void testSigningContextIsCreated() {
+        // Without a case for 0x0008 here, createContext returns null, the decode loop leaves the slot null and
+        // checkNegotiateContexts skips it - so the client would offer algorithms and never learn which one the
+        // server chose. The negotiation would be one-way and silently so.
+        NegotiateContextResponse ctx = Smb2NegotiateResponse.createContext(SigningNegotiateContext.NEGO_CTX_SIGNING_TYPE);
+
+        assertNotNull(ctx, "a SIGNING_CAPABILITIES context must be recognised");
+        assertTrue(ctx instanceof SigningNegotiateContext);
+        assertEquals(SigningNegotiateContext.NEGO_CTX_SIGNING_TYPE, ctx.getContextType());
+    }
+
+    @Test
+    @DisplayName("the server's chosen signing algorithm is recorded")
+    void testSelectedSigningAlgorithmIsRecorded() throws Exception {
+        setResponseAsReceived(response);
+        setPrivateField(response, "dialectRevision", 0x0311);
+        setPrivateField(response, "capabilities", 0);
+
+        when(mockRequest.getCapabilities()).thenReturn(0);
+        when(mockRequest.getNegotiateContexts())
+                .thenReturn(new NegotiateContextRequest[] { createMockPreauthContext(), createMockSigningContext() });
+
+        NegotiateContextResponse[] contexts = new NegotiateContextResponse[] { createValidPreauthResponse(),
+                createValidSigningResponse(SigningNegotiateContext.SIGNING_ALGO_AES128_GMAC) };
+        setPrivateField(response, "negotiateContexts", contexts);
+
+        assertTrue(response.isValid(mockContext, mockRequest), "a response selecting an offered algorithm is valid");
+        assertEquals(SigningNegotiateContext.SIGNING_ALGO_AES128_GMAC, response.getSelectedSigningAlgorithm(),
+                "the algorithm the server chose must be recorded, so signing can use it");
+    }
+
+    @Test
+    @DisplayName("a signing algorithm the client never offered is refused")
+    void testUnofferedSigningAlgorithmIsRefused() throws Exception {
+        setResponseAsReceived(response);
+        setPrivateField(response, "dialectRevision", 0x0311);
+        setPrivateField(response, "capabilities", 0);
+
+        when(mockRequest.getCapabilities()).thenReturn(0);
+        // The client offered CMAC and GMAC only.
+        when(mockRequest.getNegotiateContexts())
+                .thenReturn(new NegotiateContextRequest[] { createMockPreauthContext(), createMockSigningContext() });
+
+        // The server answers with HMAC-SHA256, which was not offered. Accepting that would let a server steer the
+        // client onto an algorithm it deliberately did not ask for - the same reason the cipher selection is
+        // validated against the request rather than taken on trust.
+        NegotiateContextResponse[] contexts = new NegotiateContextResponse[] { createValidPreauthResponse(),
+                createValidSigningResponse(SigningNegotiateContext.SIGNING_ALGO_HMAC_SHA256) };
+        setPrivateField(response, "negotiateContexts", contexts);
+
+        assertFalse(response.isValid(mockContext, mockRequest), "an algorithm outside the offered set must fail validation");
+    }
+
+    @Test
+    @DisplayName("a response with no signing context leaves the algorithm unset")
+    void testAbsentSigningContextLeavesAlgorithmUnset() throws Exception {
+        // A 3.1.1 server that ignores the context signs with AES-128-CMAC (MS-SMB2 3.3.5.4), which is what the
+        // client did before this existed. The unset marker is what lets the digest fall back to it.
+        setResponseAsReceived(response);
+        setPrivateField(response, "dialectRevision", 0x0311);
+        setPrivateField(response, "capabilities", 0);
+
+        when(mockRequest.getCapabilities()).thenReturn(0);
+        when(mockRequest.getNegotiateContexts()).thenReturn(new NegotiateContextRequest[] { createMockPreauthContext() });
+        setPrivateField(response, "negotiateContexts", new NegotiateContextResponse[] { createValidPreauthResponse() });
+
+        assertTrue(response.isValid(mockContext, mockRequest), "a response without a signing context is still valid");
+        assertEquals(-1, response.getSelectedSigningAlgorithm(), "no signing context means no negotiated algorithm");
+    }
+
+    @Test
     @DisplayName("Should fail validation with missing negotiate contexts for SMB 3.1.1")
     void testMissingNegotiateContexts() throws Exception {
         // Given
@@ -1049,6 +1121,27 @@ class Smb2NegotiateResponseTest {
         EncryptionNegotiateContext ctx = new EncryptionNegotiateContext();
         try {
             setPrivateField(ctx, "ciphers", new int[] { EncryptionNegotiateContext.CIPHER_AES128_GCM });
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return ctx;
+    }
+
+    private NegotiateContextRequest createMockSigningContext() {
+        SigningNegotiateContext ctx = new SigningNegotiateContext();
+        try {
+            setPrivateField(ctx, "signingAlgos",
+                    new int[] { SigningNegotiateContext.SIGNING_ALGO_AES128_CMAC, SigningNegotiateContext.SIGNING_ALGO_AES128_GMAC });
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return ctx;
+    }
+
+    private SigningNegotiateContext createValidSigningResponse(final int algo) {
+        SigningNegotiateContext ctx = new SigningNegotiateContext();
+        try {
+            setPrivateField(ctx, "signingAlgos", new int[] { algo });
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/org/codelibs/jcifs/smb/it/SigningIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/SigningIT.java
@@ -16,15 +16,22 @@
 package org.codelibs.jcifs.smb.it;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Properties;
+import java.util.Random;
 
 import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.DialectVersion;
 import org.codelibs.jcifs.smb.impl.SmbFile;
 import org.codelibs.jcifs.smb.impl.SmbNegotiationProbe;
+import org.codelibs.jcifs.smb.it.env.DialectMatrix;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -88,6 +95,91 @@ class SigningIT extends AbstractSmbIT {
 
         try (InputStream in = file.getInputStream()) {
             assertArrayEquals(contents.getBytes(StandardCharsets.UTF_8), in.readAllBytes());
+        }
+    }
+
+    @DialectMatrix
+    @DisplayName("signing holds across a whole sequence of requests, on every dialect")
+    void signingHoldsAcrossASequenceOfRequests(final DialectVersion dialect) throws Exception {
+        // One signing implementation serves every dialect - HMAC-SHA256 below SMB3, AES-128-CMAC at SMB3 and
+        // above - so a change to it can break a dialect the suite never pins. Before this, every signing test ran
+        // on whatever the suite negotiated, which is 3.1.1: SMB 2.0.2 and 3.0.2 signing were not exercised at all.
+        final Properties props = new Properties();
+        props.setProperty("jcifs.client.minVersion", dialect.name());
+        props.setProperty("jcifs.client.maxVersion", dialect.name());
+        props.setProperty("jcifs.client.signingEnforced", "true");
+        final CIFSContext context = server().context(props);
+
+        this.workDir = createWorkDir(context, server().share());
+        assertEquals(dialect, SmbNegotiationProbe.negotiatedDialect(this.workDir), "the run should have pinned " + dialect);
+
+        // A sequence, not a single exchange. The signature of each message is computed over its own header, and a
+        // per-message input that a signing change could get wrong - the message id, say - only shows up once
+        // several messages with different ids have gone by. A lone round trip is a weak probe for that.
+        final String contents = "signed sequence on " + dialect;
+        for (int i = 0; i < 5; i++) {
+            final SmbFile file = writeFile(this.workDir, "seq-" + i + ".txt", contents + " #" + i);
+            try (InputStream in = file.getInputStream()) {
+                assertArrayEquals((contents + " #" + i).getBytes(StandardCharsets.UTF_8), in.readAllBytes(),
+                        "signed payload " + i + " came back different on " + dialect);
+            }
+        }
+
+        // Enumeration issues its own signed requests and is the one operation whose open handle is the iteration,
+        // so a signature failure part way through surfaces here rather than on the first message.
+        final String[] names = this.workDir.list();
+        assertEquals(5, names.length, "every signed file should be listed on " + dialect + ", got " + Arrays.toString(names));
+    }
+
+    @DialectMatrix
+    @DisplayName("a compounded request chain verifies on every dialect")
+    void compoundedChainIsSignedCorrectly(final DialectVersion dialect) throws Exception {
+        // exists()/length() on a missing path go out as a compound (related) open+query+close chain, which is
+        // signed as one message from the first header. MS-SMB2 3.1.4.1 requires any trailing padding in a chain to
+        // be part of the hash, so a chain is the case where a signing change can get the authenticated extent
+        // wrong while single messages still verify.
+        final Properties props = new Properties();
+        props.setProperty("jcifs.client.minVersion", dialect.name());
+        props.setProperty("jcifs.client.maxVersion", dialect.name());
+        props.setProperty("jcifs.client.signingEnforced", "true");
+        final CIFSContext context = server().context(props);
+
+        this.workDir = createWorkDir(context, server().share());
+        final SmbFile present = writeFile(this.workDir, "compound.txt", "compound chain");
+        assertTrue(present.exists(), "a file just written must be reported as present on " + dialect);
+        assertEquals(14, present.length(), "the compounded query should report the written length on " + dialect);
+
+        // And the error path. Verification of an error response is skipped unless requireSecureNegotiate is set
+        // (ServerMessageBlock2Response.verifySignature), so a signing fault can hide there while every successful
+        // response still verifies. Asking for a path that does not exist is the cheapest way through it.
+        try (SmbFile missing = new SmbFile(this.workDir, "no-such-file.txt")) {
+            assertFalse(missing.exists(), "a path that was never created must not be reported as present on " + dialect);
+        }
+    }
+
+    @DialectMatrix
+    @DisplayName("a payload spanning many messages stays signed end to end")
+    void largePayloadStaysSigned(final DialectVersion dialect) throws Exception {
+        // Large transfers are split into many requests, each signed with its own message id, and above SMB 2.1
+        // each one spends several credits. This is the broadest sweep over per-message signing state that can be
+        // arranged without reaching into the transport.
+        final Properties props = new Properties();
+        props.setProperty("jcifs.client.minVersion", dialect.name());
+        props.setProperty("jcifs.client.maxVersion", dialect.name());
+        props.setProperty("jcifs.client.signingEnforced", "true");
+        final CIFSContext context = server().context(props);
+
+        this.workDir = createWorkDir(context, server().share());
+
+        final byte[] payload = new byte[3 * 1024 * 1024];
+        new Random(20260912L).nextBytes(payload);
+
+        final SmbFile file = new SmbFile(this.workDir, "large-signed.bin");
+        try (OutputStream out = file.getOutputStream()) {
+            out.write(payload);
+        }
+        try (InputStream in = file.getInputStream()) {
+            assertArrayEquals(payload, in.readAllBytes(), "the signed payload came back different on " + dialect);
         }
     }
 }

--- a/src/test/java/org/codelibs/jcifs/smb/it/SigningIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/SigningIT.java
@@ -32,6 +32,7 @@ import org.codelibs.jcifs.smb.DialectVersion;
 import org.codelibs.jcifs.smb.impl.SmbFile;
 import org.codelibs.jcifs.smb.impl.SmbNegotiationProbe;
 import org.codelibs.jcifs.smb.it.env.DialectMatrix;
+import org.codelibs.jcifs.smb.it.env.RequiresDialect;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -96,6 +97,55 @@ class SigningIT extends AbstractSmbIT {
         try (InputStream in = file.getInputStream()) {
             assertArrayEquals(contents.getBytes(StandardCharsets.UTF_8), in.readAllBytes());
         }
+    }
+
+    @Test
+    @RequiresDialect(DialectVersion.SMB311)
+    @DisplayName("each offered SMB 3.1.1 signing algorithm is the one the server negotiates, GMAC included")
+    void eachSigningAlgorithmIsNegotiatedAndCarriesData() throws Exception {
+        // One algorithm per connection, for the same reason the cipher arms do it: a server chooses from the
+        // client's offer by its own preference - this fixture lists AES-128-GMAC first - so an arm offering
+        // several would say nothing about which one the client can actually drive. Offering exactly one makes the
+        // server's selection the assertion.
+        for (final String algorithm : new String[] { "AES-CMAC", "AES-GMAC" }) {
+            final Properties props = new Properties();
+            props.setProperty("jcifs.client.signingAlgorithms", algorithm);
+            props.setProperty("jcifs.client.signingEnforced", "true");
+            props.setProperty("jcifs.client.minVersion", DialectVersion.SMB311.name());
+            props.setProperty("jcifs.client.maxVersion", DialectVersion.SMB311.name());
+            final CIFSContext context = server().context(props);
+
+            this.workDir = createWorkDir(context, server().share());
+
+            assertEquals(expectedSigningAlgorithmId(algorithm), SmbNegotiationProbe.negotiatedSigningAlgorithm(this.workDir),
+                    "the server should have selected " + algorithm + ", the only algorithm offered");
+
+            // Several messages, because the GMAC nonce is derived per message from the message id: signing one
+            // message proves the algorithm was accepted, but not that a session can keep using it.
+            final String contents = "signed with " + algorithm;
+            for (int i = 0; i < 3; i++) {
+                final SmbFile file = writeFile(this.workDir, "algo-" + i + ".txt", contents + " #" + i);
+                try (InputStream in = file.getInputStream()) {
+                    assertArrayEquals((contents + " #" + i).getBytes(StandardCharsets.UTF_8), in.readAllBytes(),
+                            "payload " + i + " came back different under " + algorithm);
+                }
+            }
+
+            // Enumeration, which keeps issuing signed requests against one handle.
+            assertEquals(3, this.workDir.list().length, "every signed file should be listed under " + algorithm);
+
+            deleteQuietly(this.workDir);
+            this.workDir = null;
+        }
+    }
+
+    private static int expectedSigningAlgorithmId(final String algorithm) {
+        return switch (algorithm) {
+        case "HMAC-SHA256" -> 0x0;
+        case "AES-CMAC" -> 0x1;
+        case "AES-GMAC" -> 0x2;
+        default -> throw new IllegalArgumentException(algorithm);
+        };
     }
 
     @DialectMatrix


### PR DESCRIPTION
## What this changes

SMB 3.1.1 lets the two ends agree a signing algorithm in a `SIGNING_CAPABILITIES`
negotiate context. jcifs sent none, so every session signed with AES-128-CMAC no
matter what the server preferred — and both Samba 4.21 and Windows Server 2022+
prefer AES-128-GMAC. `docs/SMB3_SUPPORT.md` recorded this as "Not implemented — no
`SIGNING_CAPABILITIES` negotiate context either".

| Property | Default |
| --- | --- |
| `jcifs.client.signingAlgorithms` | `AES-CMAC, AES-GMAC, HMAC-SHA256` |

**AES-CMAC leads deliberately.** A server picks from the offered list by its own
preference, so leading with the algorithm this client has always used leaves the
negotiated algorithm **unchanged for every existing deployment**, while making GMAC
reachable for anyone who asks. Offering only `AES-GMAC` requires it. An unrecognised
name fails configuration rather than being ignored — this setting decides what
protects message integrity, so it must not fail open.

The response side is validated like the cipher selection: an algorithm the client did
not offer fails the connection, and a server returning no context means AES-CMAC.

## The nonce, pinned against two sources

MS-SMB2 3.1.4.1 gives 12 bytes — MessageId in the first eight, then four bytes whose
least significant bit is 0 for a client and 1 for a server, penultimate bit set for an
SMB2 CANCEL request, remaining 30 bits zero. Samba's `smb2_signing.c` computes exactly
the same value. Two independent sources agreeing is why this was safe to implement at
all; the unit tests assert **literal expected bytes** rather than re-deriving the
layout, since a test that recomputed it would pass whatever the layout was.

Every input comes from the message being signed, so one construction serves both
directions — the direction bit is the header's own `SERVER_TO_REDIR`, clear on a
request we sign and set on a response we verify.

## Two structural consequences

- **The Mac can no longer be initialised once and reset.** It now prepares per message,
  inside the existing `synchronized` blocks, so a digest shared between threads still
  cannot interleave one message's nonce with another's bytes.
- **A GMAC Mac cannot be re-initialised with a key/nonce pair it has already seen** —
  BouncyCastle refuses with `cannot reuse nonce for GCM encryption`. That guard is
  correct for encryption and wrong for a MAC, where recomputing a tag over the same
  message is precisely what verification does. Without a fresh Mac per GMAC operation,
  one digest would **refuse to verify a response it had just signed**. A test caught
  this; it is not a hypothetical.

CMAC and HMAC-SHA256 keep the single reused Mac, and a test asserts the three-argument
constructor stays byte-identical to passing the CMAC id explicitly.

## Verification

Regression first, as requested: signing was pinned across the whole dialect matrix in
**a separate commit before the signing path was touched** — message sequences,
compounded chains, error responses (whose verification is otherwise skipped unless
`requireSecureNegotiate` is set), and 3 MiB payloads, on SMB 2.0.2 through 3.1.1. The
2.0.2 and 3.0.2 signing paths had never been exercised by this suite. That guard was
green before the change and is green after.

- Unit tests: 8847, 0 failures.
- Integration tests against Samba: 233, 0 failures, 5 skipped (pre-existing symlink
  and Windows-backend skips).
- The guard itself was falsified: with one byte of the derived signing key flipped, the
  run fails with `Signature validation failed`. Worth recording *how* — the failure
  lands on the class fixture, because the preflight check opens a connection before any
  test runs, so a signing fault is immediate and fatal at connection setup rather than
  a silent corruption. That property is what made changing this path tolerable.
- The new integration case offers **one algorithm per connection** and asserts the
  server selected it. Flipping the AES-GMAC expectation to the CMAC id fails with
  `expected: <1> but was: <2>` — so Samba really negotiated AES-128-GMAC, and the
  assertion can fail.

## Scope

One new `Configuration` method, an addition to a public interface — the same case
`pom.xml` already ignores for four existing additions. No behaviour changes with the
default property: the algorithm negotiated against a given server is the same as before.
