### PR TITLE
feat(smb2): copy server-side between shares on one server

### DIFF
--- a/docs/SMB3_SUPPORT.md
+++ b/docs/SMB3_SUPPORT.md
@@ -25,7 +25,8 @@ support. Where that is the case below, the specific dead end is named.
 
 jcifs is a solid SMB2/SMB3 **file access** client: negotiate, authenticate, sign,
 encrypt, open, read, write, enumerate, query and set metadata, watch for changes,
-resolve DFS, and copy server-side within a share. SMB 3.1.1 is negotiated by
+resolve DFS, and copy server-side between shares on one server. SMB 3.1.1 is
+negotiated by
 default, and SMB3 signing, pre-authentication integrity and transform encryption
 all work against real servers.
 
@@ -305,7 +306,7 @@ file on its first open, as it always has.
 | Feature | Status | Notes |
 | --- | --- | --- |
 | DFS referral resolution | Supported | On by default (`jcifs.client.dfs.disabled=false`). Uses `FSCTL_DFS_GET_REFERRALS`; the `_EX` variant is not used. |
-| Server-side copy (copychunk) | Partial | `SmbFile.copyTo` uses `FSCTL_SRV_COPYCHUNK` **only when source and destination resolve to the same tree connection**. Cross-share and cross-server copies silently fall back to read/write streaming. |
+| Server-side copy (copychunk) | Supported | `SmbFile.copyTo` uses `FSCTL_SRV_COPYCHUNK` whenever both ends of the copy are reached through the same session, which covers **two shares on one server** as well as one share: the resume key taken on the source tree is resolved by the server within the session that asked for it, not within a single tree. A copy between two servers still streams the bytes through the client, as does a copy over SMB1 and a copy a server declines to perform itself — across two trees such a refusal falls back to streaming rather than failing the copy, since streaming is what those copies did before. |
 | Named pipes | Supported | Transceive and peek. |
 | Symbolic links / reparse points | Partial | A path that crosses a symbolic link fails with `SmbSymlinkException`, which carries the target decoded from the `STATUS_STOPPED_ON_SYMLINK` error response: `getSubstituteName()`, `getPrintName()`, `isRelative()` and `getUnparsedPathLength()`. Links are **not followed** — there is no resolution or retry, so a caller that wants to traverse one has to act on the target itself. Which server you are talking to decides whether this comes up at all: Samba resolves a link that stays inside the share and never reports one, so the error surfaces mainly against Windows. |
 | Multi-channel | Not functional | One unused capability constant, an unused `FSCTL_QUERY_NETWORK_INTERFACE_INFO` constant with no response decoder, and `Smb2SessionSetupRequest.setSessionBinding()`, which encodes the binding flag correctly but is called only from unit tests. A session is pinned to one transport. |

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbCopyUtil.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbCopyUtil.java
@@ -85,6 +85,21 @@ public final class SmbCopyUtil {
     }
 
     /**
+     * Decides whether a copy can be handed to the server instead of streamed through the client.
+     *
+     * @param sh the source tree handle
+     * @param dh the destination tree handle
+     * @return whether the copy qualifies for FSCTL_SRV_COPYCHUNK
+     */
+    static boolean canServerSideCopy(final SmbTreeHandleImpl sh, final SmbTreeHandleImpl dh) {
+        // The resume key the source tree hands out is resolved by the server within the session that asked for
+        // it, not within one tree, so two shares on the same server qualify just as one share does. Different
+        // servers do not: there the key means nothing to the destination, and the bytes have to travel through
+        // the client.
+        return sh.isSMB2() && dh.isSMB2() && sh.isSameSession(dh);
+    }
+
+    /**
      * @param dest
      * @param b
      * @param bsize
@@ -98,15 +113,22 @@ public final class SmbCopyUtil {
     static void copyFile(final SmbFile src, final SmbFile dest, final byte[][] b, final int bsize, final WriterThread w,
             final SmbTreeHandleImpl sh, final SmbTreeHandleImpl dh) throws SmbException {
 
-        if (sh.isSMB2() && dh.isSMB2() && sh.isSameTree(dh)) {
+        if (canServerSideCopy(sh, dh)) {
+            final boolean sameTree = sh.isSameTree(dh);
             try {
                 serverSideCopy(src, dest, sh, dh, false);
                 return;
             } catch (final SmbUnsupportedOperationException e) {
                 log.debug("Server side copy not supported, falling back to normal copying", e);
             } catch (final CIFSException e) {
-                log.warn("Server side copy failed", e);
-                throw SmbException.wrap(e);
+                if (sameTree) {
+                    log.warn("Server side copy failed", e);
+                    throw SmbException.wrap(e);
+                }
+                // Across two trees this is newly attempted ground: such a copy always streamed before. A server
+                // that will not resolve a resume key issued on another tree answers with its own status rather
+                // than NOT_SUPPORTED, and that must not turn a copy which used to work into a failure.
+                log.debug("Server side copy across trees failed, falling back to normal copying", e);
             }
         }
 

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbTreeHandleImpl.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbTreeHandleImpl.java
@@ -256,6 +256,30 @@ class SmbTreeHandleImpl implements SmbTreeHandleInternal {
         return this.treeConnection.isSame(((SmbTreeHandleImpl) th).treeConnection);
     }
 
+    /**
+     * Checks whether another handle's tree is served by the same session as this one.
+     *
+     * <p>
+     * Two shares on one server are separate trees that share a session, and a server resolves a copychunk resume
+     * key within the session that issued it - so this, rather than {@link #isSameTree(SmbTreeHandle)}, is what
+     * decides whether an open on one tree may be named by an operation sent on another. Handles reached on
+     * different servers, or with different credentials, have different sessions and are rejected, which is also
+     * the right answer once DFS has resolved two paths to different hosts.
+     * </p>
+     *
+     * @param th the tree handle to compare with
+     * @return whether both trees hang off the same session
+     */
+    boolean isSameSession(final SmbTreeHandleImpl th) {
+        if (th == null) {
+            return false;
+        }
+        // getSession() acquires, so both references have to be released again.
+        try (SmbSessionImpl mine = this.treeConnection.getSession(); SmbSessionImpl theirs = th.treeConnection.getSession()) {
+            return mine != null && mine == theirs;
+        }
+    }
+
     @Override
     public int getSendBufferSize() throws SmbException {
         try (SmbSessionImpl session = this.treeConnection.getSession(); SmbTransportImpl transport = session.getTransport()) {

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbCopyUtilProbe.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbCopyUtilProbe.java
@@ -1,0 +1,56 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.impl;
+
+import org.codelibs.jcifs.smb.CIFSException;
+
+/**
+ * Test-only window onto the route {@code copyTo} will take for a pair of files.
+ *
+ * <p>
+ * A copy produces the same bytes whether the server did it or the client streamed them, so no assertion on the
+ * result can tell the two apart: a change that stopped routing copies to the server would leave every existing
+ * copy test green. This asks the question that is otherwise invisible.
+ * </p>
+ *
+ * <p>
+ * Note precisely what it reports, and what it does not. It evaluates
+ * {@link SmbCopyUtil#canServerSideCopy(SmbTreeHandleImpl, SmbTreeHandleImpl)} - the production predicate itself,
+ * deliberately not a second copy of the same condition, which could agree with this probe while disagreeing with
+ * the code that runs - so it reports the decision the copy will start from. It cannot report that the server
+ * actually carried the copy out; a server free to refuse is then answered by falling back to streaming, and the
+ * bytes are correct either way. What the copy produced is asserted separately.
+ * </p>
+ */
+public final class SmbCopyUtilProbe {
+
+    private SmbCopyUtilProbe() {
+    }
+
+    /**
+     * Returns whether a copy from {@code src} to {@code dest} would be handed to the server.
+     *
+     * @param src  the source file
+     * @param dest the destination file
+     * @return whether the copy qualifies for FSCTL_SRV_COPYCHUNK
+     * @throws CIFSException if either tree cannot be connected
+     */
+    public static boolean wouldCopyServerSide(final SmbFile src, final SmbFile dest) throws CIFSException {
+        try (SmbTreeHandleImpl sh = src.ensureTreeConnected(); SmbTreeHandleImpl dh = dest.ensureTreeConnected()) {
+            return SmbCopyUtil.canServerSideCopy(sh, dh);
+        }
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbCopyUtilTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbCopyUtilTest.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -210,7 +211,7 @@ public class SmbCopyUtilTest {
 
             when(sh.isSMB2()).thenReturn(true);
             when(dh.isSMB2()).thenReturn(true);
-            when(sh.isSameTree(dh)).thenReturn(true);
+            when(sh.isSameSession(dh)).thenReturn(true);
 
             // Set up source file timestamps
             final long testCreateTime = 1000000L;
@@ -278,7 +279,7 @@ public class SmbCopyUtilTest {
 
             when(sh.isSMB2()).thenReturn(true);
             when(dh.isSMB2()).thenReturn(true);
-            when(sh.isSameTree(dh)).thenReturn(true);
+            when(sh.isSameSession(dh)).thenReturn(true);
 
             // Set up source file timestamps
             final long testCreateTime = 1000000L;
@@ -401,7 +402,7 @@ public class SmbCopyUtilTest {
             when(sh.isSMB2()).thenReturn(false);
             when(dh.isSMB2()).thenReturn(false);
             when(dh.hasCapability(SmbConstants.CAP_NT_SMBS)).thenReturn(false);
-            lenient().when(sh.isSameTree(dh)).thenReturn(false); // Different trees
+            lenient().when(sh.isSameSession(dh)).thenReturn(false); // Different trees
 
             // Set up source file timestamps
             final long testModifiedTime = 2000000L;
@@ -453,10 +454,10 @@ public class SmbCopyUtilTest {
             SmbTreeHandleImpl sh = mock(SmbTreeHandleImpl.class, RETURNS_DEEP_STUBS);
             SmbTreeHandleImpl dh = mock(SmbTreeHandleImpl.class, RETURNS_DEEP_STUBS);
 
-            // Force client-side copy (different trees)
+            // Force client-side copy (different sessions, so a different server)
             when(sh.isSMB2()).thenReturn(true);
             when(dh.isSMB2()).thenReturn(true);
-            when(sh.isSameTree(dh)).thenReturn(false);
+            when(sh.isSameSession(dh)).thenReturn(false);
 
             // Set up source file timestamps
             final long testCreateTime = 1000000L;
@@ -552,7 +553,93 @@ public class SmbCopyUtilTest {
         }
     }
 
-    // --- Server-side copy path (SMB2 + same tree) for zero-length files ---
+    // --- Which route a copy takes ---
+
+    @Test
+    @DisplayName("canServerSideCopy asks about the session, not the tree")
+    void canServerSideCopy_asksAboutTheSession() {
+        SmbTreeHandleImpl sh = mock(SmbTreeHandleImpl.class);
+        SmbTreeHandleImpl dh = mock(SmbTreeHandleImpl.class);
+
+        when(sh.isSMB2()).thenReturn(true);
+        when(dh.isSMB2()).thenReturn(true);
+
+        // Two shares on one server: separate trees, one session, and the server can resolve the resume key.
+        when(sh.isSameSession(dh)).thenReturn(true);
+        assertTrue(SmbCopyUtil.canServerSideCopy(sh, dh));
+
+        // A different session is a different server, where the key means nothing to the destination.
+        when(sh.isSameSession(dh)).thenReturn(false);
+        assertFalse(SmbCopyUtil.canServerSideCopy(sh, dh));
+    }
+
+    @Test
+    @DisplayName("canServerSideCopy refuses SMB1 at either end")
+    void canServerSideCopy_refusesSmb1() {
+        SmbTreeHandleImpl sh = mock(SmbTreeHandleImpl.class);
+        SmbTreeHandleImpl dh = mock(SmbTreeHandleImpl.class);
+
+        // SMB1 has no IOCTL path at all, so neither end may be legacy.
+        when(sh.isSMB2()).thenReturn(false);
+        assertFalse(SmbCopyUtil.canServerSideCopy(sh, dh));
+
+        when(sh.isSMB2()).thenReturn(true);
+        when(dh.isSMB2()).thenReturn(false);
+        assertFalse(SmbCopyUtil.canServerSideCopy(sh, dh));
+    }
+
+    @Test
+    @DisplayName("a server-side copy that fails across two trees falls back to streaming")
+    void copyFile_crossTreeServerSideFailure_fallsBackToStreaming() throws Exception {
+        // The case this defends against: a server that will not resolve a resume key issued on another tree
+        // answers with its own status rather than NOT_SUPPORTED, so the generic handler does not turn it into
+        // SmbUnsupportedOperationException. Such a copy streamed before this route existed and has to keep
+        // working, rather than becoming a failure.
+        SmbFile src = mock(SmbFile.class, RETURNS_DEEP_STUBS);
+        SmbFile dest = mock(SmbFile.class, RETURNS_DEEP_STUBS);
+
+        SmbTreeHandleImpl sh = mock(SmbTreeHandleImpl.class, RETURNS_DEEP_STUBS);
+        SmbTreeHandleImpl dh = mock(SmbTreeHandleImpl.class, RETURNS_DEEP_STUBS);
+
+        when(sh.isSMB2()).thenReturn(true);
+        when(dh.isSMB2()).thenReturn(true);
+        when(sh.isSameSession(dh)).thenReturn(true);
+        when(sh.isSameTree(dh)).thenReturn(false);
+
+        SmbFileHandleImpl sfd = mock(SmbFileHandleImpl.class, RETURNS_DEEP_STUBS);
+        when(sfd.getInitialSize()).thenReturn(1024L);
+        when(src.openUnshared(anyInt(), anyInt(), anyInt(), anyInt(), anyInt())).thenReturn(sfd);
+
+        SmbFileHandleImpl dfd = mock(SmbFileHandleImpl.class, RETURNS_DEEP_STUBS);
+        when(dest.openUnshared(anyInt(), anyInt(), anyInt(), anyInt(), anyInt())).thenReturn(dfd);
+
+        // The resume key request is refused with the status a server uses for a key it cannot resolve.
+        when(sh.send(any())).thenThrow(new SmbException(NtStatus.NT_STATUS_OBJECT_NAME_NOT_FOUND, null));
+
+        WriterThread w = mock(WriterThread.class);
+        lenient().when(w.isReady()).thenReturn(true);
+        lenient().doNothing().when(w).write(any(), anyInt(), any());
+        lenient().doNothing().when(w).checkException();
+
+        try {
+            SmbCopyUtil.copyFile(src, dest, new byte[][] { new byte[1024], new byte[1024] }, 1024, w, sh, dh);
+        } catch (Exception e) {
+            // Streaming itself cannot complete against mocks; what matters is which failure comes out.
+            assertFalse(String.valueOf(e.getMessage()).contains("Server side copy failed"),
+                    "the server-side failure must not be what propagates across two trees");
+        }
+
+        // The destination is opened only by the path that streams: the server-side attempt failed at the resume
+        // key, before it ever opened a target. That makes this the positive signal that the fallback was entered
+        // rather than the copy quietly ending.
+        verify(dest, times(1)).openUnshared(anyInt(), anyInt(), anyInt(), anyInt(), anyInt());
+
+        // The source is opened again by the streaming path, and possibly once more by the input stream, which
+        // reopens by path whenever its handle is not valid - so the exact count is deliberately not pinned.
+        verify(src, atLeast(2)).openUnshared(anyInt(), anyInt(), anyInt(), anyInt(), anyInt());
+    }
+
+    // --- Server-side copy path (SMB2 + same session) for zero-length files ---
 
     @Test
     @DisplayName("copyFile uses server-side copy for zero-length and returns")
@@ -565,7 +652,7 @@ public class SmbCopyUtilTest {
         SmbTreeHandleImpl dh = mock(SmbTreeHandleImpl.class);
         when(sh.isSMB2()).thenReturn(true);
         when(dh.isSMB2()).thenReturn(true);
-        when(sh.isSameTree(dh)).thenReturn(true);
+        when(sh.isSameSession(dh)).thenReturn(true);
 
         // Source open returns a handle that reports size 0
         SmbFileHandleImpl sfd = mock(SmbFileHandleImpl.class);

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbNegotiationProbe.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbNegotiationProbe.java
@@ -66,20 +66,6 @@ public final class SmbNegotiationProbe {
     }
 
     /**
-     * Returns the encryption cipher the server selected, or {@code -1} if the response carried no encryption
-     * negotiate context.
-     *
-     * <p>
-     * Without this a test can only assert that encrypted traffic round trips, which passes identically whichever
-     * cipher is in force - so a client that asked for AES-256 and silently got AES-128 would look correct. The
-     * cipher is the only observable that tells those two apart.
-     * </p>
-     *
-     * @param file any connected resource on the tree of interest
-     * @return the selected cipher identifier, or -1 if none was negotiated
-     * @throws CIFSException if the connection cannot be established
-     */
-    /**
      * Returns the signing algorithm the server selected, or {@code -1} if the response carried no
      * SIGNING_CAPABILITIES context.
      *
@@ -104,6 +90,20 @@ public final class SmbNegotiationProbe {
         }
     }
 
+    /**
+     * Returns the encryption cipher the server selected, or {@code -1} if the response carried no encryption
+     * negotiate context.
+     *
+     * <p>
+     * Without this a test can only assert that encrypted traffic round trips, which passes identically whichever
+     * cipher is in force - so a client that asked for AES-256 and silently got AES-128 would look correct. The
+     * cipher is the only observable that tells those two apart.
+     * </p>
+     *
+     * @param file any connected resource on the tree of interest
+     * @return the selected cipher identifier, or -1 if none was negotiated
+     * @throws CIFSException if the connection cannot be established
+     */
     public static int negotiatedCipher(final SmbFile file) throws CIFSException {
         try (SmbTreeHandleImpl tree = (SmbTreeHandleImpl) file.getTreeHandle();
                 SmbSessionImpl session = tree.getSession();

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbTreeHandleImplTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbTreeHandleImplTest.java
@@ -285,6 +285,28 @@ class SmbTreeHandleImplTest {
     }
 
     @Test
+    @DisplayName("isSameSession: null, one shared session, and two different ones")
+    void isSameSessionCoversBranches() {
+        // Two shares on one server are separate trees that share a session, and that is what lets a server
+        // resolve a copychunk resume key taken on one of them, so this asks about the session rather than the
+        // tree. isSameTree would answer false for that pair.
+        assertFalse(handle.isSameSession(null));
+
+        // One session, two trees: the connection hands back the same session the fixture gave this handle.
+        SmbTreeConnection sameSessionConn = mock(SmbTreeConnection.class);
+        when(sameSessionConn.acquire()).thenReturn(sameSessionConn);
+        when(sameSessionConn.getSession()).thenReturn(session);
+        assertTrue(handle.isSameSession(new SmbTreeHandleImpl(resourceLoc, sameSessionConn)));
+
+        // A different session is a different server, where a resume key means nothing.
+        SmbTreeConnection otherSessionConn = mock(SmbTreeConnection.class);
+        SmbSessionImpl otherSession = mock(SmbSessionImpl.class);
+        when(otherSessionConn.acquire()).thenReturn(otherSessionConn);
+        when(otherSessionConn.getSession()).thenReturn(otherSession);
+        assertFalse(handle.isSameSession(new SmbTreeHandleImpl(resourceLoc, otherSessionConn)));
+    }
+
+    @Test
     @DisplayName("Buffer sizes and signing flags from negotiate response")
     void bufferSizesAndSigning() throws Exception {
         // Validate buffer sizes and signing flag are read from negotiate response

--- a/src/test/java/org/codelibs/jcifs/smb/it/CopyFallbackIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/CopyFallbackIT.java
@@ -51,6 +51,12 @@ class CopyFallbackIT extends AbstractSmbIT {
     /** Past the client's 16 MB per-request limit, so the copy loop has to go round twice. */
     private static final int LARGE_SIZE = 20 * 1024 * 1024;
 
+    /**
+     * 2020-09-13, far enough in the past that a target stamped with the time of the copy cannot match it by
+     * coincidence. Whole seconds, so no server's timestamp granularity can round it away.
+     */
+    private static final long STAMP = 1600000000000L;
+
     private SmbFile sourceDir;
     private SmbFile targetDir;
 
@@ -154,5 +160,87 @@ class CopyFallbackIT extends AbstractSmbIT {
             assertArrayEquals("nested level".getBytes(StandardCharsets.UTF_8), in.readAllBytes(),
                     "the nested copy should hold the same bytes");
         }
+    }
+
+    @DialectMatrix
+    @DisplayName("a copy over a longer existing target truncates it, within a share and across two")
+    void copyOverAnExistingTargetTruncatesIt(final DialectVersion dialect) throws Exception {
+        // A copy opens its target with O_TRUNC. A server-side copy writes the bytes itself, chunk by chunk, so a
+        // path that loses the truncation leaves the tail of whatever was there before - and still reports success,
+        // with the right bytes at the front. The length catches that; the byte comparison says the result is not
+        // merely the right size.
+        final CIFSContext context = contextFor(dialect);
+        this.sourceDir = createWorkDir(context, server().share());
+        this.targetDir = createWorkDir(context, "users");
+
+        final String shortContents = "short";
+        final byte[] expected = shortContents.getBytes(StandardCharsets.UTF_8);
+        writeFile(this.sourceDir, "trunc-src.txt", shortContents);
+
+        for (final SmbFile parent : new SmbFile[] { this.sourceDir, this.targetDir }) {
+            final String where = parent == this.sourceDir ? "within a share" : "across two shares";
+            writeFile(parent, "trunc-dst.txt", "a considerably longer body that must not survive being overwritten");
+
+            // A fresh handle for the source each time: the instance a copy was made from has cached its size and
+            // attributes, and the copy reads those to stamp the target.
+            new SmbFile(this.sourceDir, "trunc-src.txt").copyTo(new SmbFile(parent, "trunc-dst.txt"));
+
+            final SmbFile fresh = new SmbFile(parent, "trunc-dst.txt");
+            assertEquals(expected.length, fresh.length(), "the copy should have truncated the existing target " + where);
+            try (InputStream in = fresh.getInputStream()) {
+                assertArrayEquals(expected, in.readAllBytes(), "the copy should hold only the source bytes " + where);
+            }
+        }
+
+        // A copy that resolved the wrong source would be invisible above: both targets would simply hold the same
+        // wrong bytes. This says the source itself was not the thing that changed.
+        final SmbFile freshSource = new SmbFile(this.sourceDir, "trunc-src.txt");
+        assertEquals(expected.length, freshSource.length(), "the copy should have left the source alone on " + dialect);
+        try (InputStream in = freshSource.getInputStream()) {
+            assertArrayEquals(expected, in.readAllBytes(), "the copy should have left the source's bytes alone on " + dialect);
+        }
+    }
+
+    @Test
+    @DisplayName("an empty file copies as an empty file, within a share and across two")
+    void emptyFileCopiesAsEmpty() throws Exception {
+        // Zero length takes its own branch in the server-side path: there is nothing to ask the server to copy, so
+        // it creates the target and sets its metadata instead. Routing a new pair of trees through that path runs
+        // this branch where it has never run before.
+        final CIFSContext context = server().context();
+        this.sourceDir = createWorkDir(context, server().share());
+        this.targetDir = createWorkDir(context, "users");
+
+        new SmbFile(this.sourceDir, "empty-src.txt").createNewFile();
+
+        new SmbFile(this.sourceDir, "empty-src.txt").copyTo(new SmbFile(this.sourceDir, "empty-same.txt"));
+        new SmbFile(this.sourceDir, "empty-src.txt").copyTo(new SmbFile(this.targetDir, "empty-cross.txt"));
+
+        assertTrue(new SmbFile(this.sourceDir, "empty-same.txt").exists(), "an empty copy within a share should exist");
+        assertEquals(0, new SmbFile(this.sourceDir, "empty-same.txt").length(), "an empty copy within a share should be empty");
+        assertTrue(new SmbFile(this.targetDir, "empty-cross.txt").exists(), "an empty copy across shares should exist");
+        assertEquals(0, new SmbFile(this.targetDir, "empty-cross.txt").length(), "an empty copy across shares should be empty");
+    }
+
+    @Test
+    @DisplayName("a copy carries the source's modification time, within a share and across two")
+    void copyPreservesTheModificationTime() throws Exception {
+        // Both paths set the destination's basic information from the source once the bytes are there, which is
+        // what stops a copy from looking freshly written. Asserting against a time set well in the past makes a
+        // failure unambiguous: a path that skips it leaves the target stamped with now.
+        final CIFSContext context = server().context();
+        this.sourceDir = createWorkDir(context, server().share());
+        this.targetDir = createWorkDir(context, "users");
+
+        writeFile(this.sourceDir, "stamped-src.txt", "stamped");
+        new SmbFile(this.sourceDir, "stamped-src.txt").setLastModified(STAMP);
+
+        new SmbFile(this.sourceDir, "stamped-src.txt").copyTo(new SmbFile(this.sourceDir, "stamped-same.txt"));
+        new SmbFile(this.sourceDir, "stamped-src.txt").copyTo(new SmbFile(this.targetDir, "stamped-cross.txt"));
+
+        assertEquals(STAMP, new SmbFile(this.sourceDir, "stamped-same.txt").lastModified(),
+                "a copy within a share should carry the source's modification time");
+        assertEquals(STAMP, new SmbFile(this.targetDir, "stamped-cross.txt").lastModified(),
+                "a copy across shares should carry the source's modification time");
     }
 }

--- a/src/test/java/org/codelibs/jcifs/smb/it/CopyFallbackIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/CopyFallbackIT.java
@@ -27,6 +27,7 @@ import java.util.Random;
 
 import org.codelibs.jcifs.smb.CIFSContext;
 import org.codelibs.jcifs.smb.DialectVersion;
+import org.codelibs.jcifs.smb.impl.SmbCopyUtilProbe;
 import org.codelibs.jcifs.smb.impl.SmbFile;
 import org.codelibs.jcifs.smb.it.env.DialectMatrix;
 import org.junit.jupiter.api.AfterEach;
@@ -38,12 +39,12 @@ import org.junit.jupiter.api.Test;
  *
  * <p>
  * {@code SmbCopyUtil.copyFile} asks the server to do the copy with
- * FSCTL_SRV_COPYCHUNK only when source and destination sit on the same tree;
- * otherwise it streams the bytes through the client. Every copy test in the
- * suite used one share, so the streaming half had never run. The chunk limits
- * the client starts with - a megabyte per chunk and sixteen megabytes per
- * request - also meant that a one-megabyte fixture never exercised more than a
- * single chunk.
+ * FSCTL_SRV_COPYCHUNK when both ends are reached through the same session,
+ * which covers two shares on one server as well as one share; otherwise it
+ * streams the bytes through the client, as it also does over SMB1 and when a
+ * server declines to do the copy itself. The chunk limits the client starts
+ * with - a megabyte per chunk and sixteen megabytes per request - mean that a
+ * one-megabyte fixture never exercises more than a single chunk.
  * </p>
  */
 class CopyFallbackIT extends AbstractSmbIT {
@@ -89,7 +90,7 @@ class CopyFallbackIT extends AbstractSmbIT {
     }
 
     @DialectMatrix
-    @DisplayName("a copy across two shares streams through the client and keeps the bytes")
+    @DisplayName("a copy across two shares keeps the bytes")
     void copyAcrossSharesKeepsTheBytes(final DialectVersion dialect) throws Exception {
         final CIFSContext context = contextFor(dialect);
         this.sourceDir = createWorkDir(context, server().share());
@@ -135,8 +136,8 @@ class CopyFallbackIT extends AbstractSmbIT {
 
         source.copyTo(target);
 
-        assertEquals(LARGE_SIZE, target.length(), "the streamed copy should be the same length");
-        assertArrayEquals(digest(source), digest(target), "the streamed copy should be byte for byte identical");
+        assertEquals(LARGE_SIZE, target.length(), "the cross-share copy should be the same length");
+        assertArrayEquals(digest(source), digest(target), "the cross-share copy should be byte for byte identical");
     }
 
     @Test
@@ -199,6 +200,23 @@ class CopyFallbackIT extends AbstractSmbIT {
         try (InputStream in = freshSource.getInputStream()) {
             assertArrayEquals(expected, in.readAllBytes(), "the copy should have left the source's bytes alone on " + dialect);
         }
+    }
+
+    @Test
+    @DisplayName("a copy across two shares on one server is handed to the server")
+    void crossShareCopyIsHandedToTheServer() throws Exception {
+        // The bytes are the same either way, so the tests above pass whichever route a copy takes. This is the
+        // one assertion that fails if cross-share copies go back to being streamed through the client.
+        final CIFSContext context = server().context();
+        this.sourceDir = createWorkDir(context, server().share());
+        this.targetDir = createWorkDir(context, "users");
+
+        final SmbFile source = writeFile(this.sourceDir, "routed.txt", "routed to the server");
+
+        assertTrue(SmbCopyUtilProbe.wouldCopyServerSide(source, new SmbFile(this.sourceDir, "routed-same.txt")),
+                "a copy within one share should be handed to the server");
+        assertTrue(SmbCopyUtilProbe.wouldCopyServerSide(source, new SmbFile(this.targetDir, "routed-cross.txt")),
+                "a copy across two shares on one server should be handed to the server");
     }
 
     @Test


### PR DESCRIPTION
## What this changes

`FSCTL_SRV_COPYCHUNK` lets a server copy a file without the bytes travelling out
to the client and back. `copyTo` asked for it **only when source and destination
sat on the same tree**, so a copy between two shares on one server — one
connection, one session, often the same disk — streamed every byte through the
client. `docs/SMB3_SUPPORT.md` recorded that as a limitation, in a row and in its
summary line.

The condition was stricter than the protocol. A server resolves a copychunk
resume key **within the session that asked for it**, not within a single tree, and
this code was already sending the resume key on the source tree and the copychunk
on the destination tree. The routing now asks whether both ends are reached
through the same session: two shares on one server qualify; a different server,
different credentials, or a DFS path that resolved to another host do not, because
there the key means nothing to the destination.

## Measured, not assumed

Against Samba 4.21.9, a resume key taken on one share and named in a copychunk
sent on another is honoured and the copy lands byte for byte. The same probe
against a single share was the control — without it, a failure would not
distinguish "the server refuses" from "my probe is wrong".

This **contradicts a frequently cited samba-technical thread from 2015** which
reports that copychunk requires one share and answers otherwise with
`STATUS_OBJECT_NAME_NOT_FOUND`. The same-tcon restriction it describes is not in
the 4.21 source. Worth stating because a web search returns that thread as
current fact.

One thing the probe also caught: reading `length()` straight after a server-side
copy reports **0**, because the instance that performed the copy has cached its
attributes. Every read-back in these tests goes through a fresh handle.

## The fallback, and why it is not optional

Across two trees a server-side failure now falls back to streaming instead of
propagating. A server that will not resolve a key issued on another tree answers
with a status of its own, and `checkStatus2` converts only
`NT_STATUS_NOT_SUPPORTED` and `NT_STATUS_INVALID_DEVICE_REQUEST` into
`SmbUnsupportedOperationException` — the exception the existing fallback catches.
Without this, a cross-share copy that works today would begin to **fail** against
such a server. Within one tree the behaviour is unchanged and the failure is
still raised.

## Regression guard first

Requested explicitly, and it landed in its own commit before the routing was
touched — green on unchanged code, then green after. It pins what both paths have
to keep, and deliberately **not** which path ran:

- **A copy over a longer existing target truncates it**, within a share and
  across two, on every dialect from SMB 2.0.2 to 3.1.1. A server-side copy writes
  the bytes itself, chunk by chunk, so a path that loses the truncation reports
  success with the right bytes at the front and a stale tail behind them.
- **The source is left alone** — a copy that resolved the wrong source would
  otherwise be invisible, since both targets would hold the same wrong bytes.
- **An empty file copies as empty** — zero length takes its own branch, which
  cross-share copies now enter for the first time.
- **The modification time is carried over**, asserted against a time set well in
  the past so a path that skips it fails unambiguously rather than by coincidence.

Falsified rather than trusted: with `O_TRUNC` dropped from the target open the
truncation case fails on all five dialects with `expected: <5> but was: <66>` —
the stale tail. With the streaming path's `SetInfo` suppressed the cross-share
timestamp case fails with the target stamped *now*, while the same-share case
stays green, because that one goes through the server-side path whose own
`SetInfo` was intact. The two paths are covered independently.

## Asserting the route, which bytes cannot

A copy produces the same bytes whichever route it took, so **every existing copy
assertion passes when the routing silently reverts**. One integration test asks
the production predicate itself — not a second copy of the condition, which could
agree with the test while disagreeing with the code that runs. Falsified: with the
condition put back to the tree, that case fails with `expected: <true> but was:
<false>` while the other fifteen executions in the class stay green, which is
exactly the gap it exists to cover.

Unit tests cover the predicate, the session comparison, and the cross-tree
fallback — the last by showing the destination is opened by the streaming path
after the server-side attempt failed.

## What is *not* measured here

**Whether Windows Server 2025 performs a cross-share copy server-side.** The
routing test asserts the client's decision, which passes whatever the server
does, and the behavioural guards pass either way because a refusal falls back to
streaming. So a green Windows job says copies remain correct — it does **not**
say Windows honoured the resume key. The documentation is phrased accordingly and
claims nothing about it.

## Verification

- Unit tests 8851, integration tests 241 against Samba 4.21.9, no failures. The
  nine skips are this host's usual set: four DFS cases needing port 445, three
  Windows-only cases, two symbolic link cases.
- apache-rat `Unapproved: 0, unknown: 0, generated: 0, approved: 401` —
  unchanged, since the new probe is a test source.
- clirr compares against 3.0.3 and has **nothing to record**: both new methods are
  package private on implementation classes, so no public interface moved. Unlike
  the previous few changes, this one adds no `7012` ignore entry.

## Also in here

The status document described copying as server-side within one share, in a row
and in its summary. And a stray javadoc block in a test probe has documented the
wrong method since the AES-256 change, while a second one attached itself to the
new predicate instead of `copyFile` — unrelated to the routing, but mine to fix.
