### PR TITLE
test(it): move the Samba fixture from 4.21.9 to 4.22.10

### DIFF
--- a/build_helpers/samba/Dockerfile
+++ b/build_helpers/samba/Dockerfile
@@ -3,7 +3,7 @@
 # Pinned to an Alpine release rather than a floating tag so the Samba version
 # only moves when this file moves. Multi-arch, so the same image builds on the
 # amd64 CI runners and on arm64 development machines.
-FROM alpine:3.22
+FROM alpine:3.23
 
 RUN apk add --no-cache samba-server samba-client samba-common-tools
 

--- a/docs/SMB3_SUPPORT.md
+++ b/docs/SMB3_SUPPORT.md
@@ -167,7 +167,7 @@ break anyway.
 | Oplock break notification | Supported | Decoded and resolved to the open it names. Since the notification carries TreeId 0 and, on several servers, SessionId 0, the open is found by file id in the session open tables rather than from the header. A break naming an open the client does not have is ignored, as MS-SMB2 3.2.5.19.1 requires. jcifs caches nothing, so there is no cached data to discard. |
 | Oplock break acknowledgement | Supported | `Smb2OplockBreakAcknowledgment` is sent on the broken open's own tree, which is what gives it the session and tree id the server requires. A break from level II to none is not answered at all (MS-SMB2 2.2.24.1). The acknowledgement is sent off the receive thread, because it draws a reply and waiting for one there would stop the loop that reads it. |
 | SMB3 leases | Not implemented | Two unused constants; no lease is ever requested, and there is no lease create context to request one with. A lease break is now decoded rather than fatal: before 3.0.4 its 44-byte body failed a decode that demanded 24, and that failure closed the socket, logged off every session and failed every request in flight on the connection. Such a break is logged and otherwise ignored, since no lease was ever held — there is no lease break acknowledgement message either. A lease holding `SMB2_LEASE_HANDLE_CACHING` is one of the two ways to qualify for a durable handle; see [Why durable handles are not planned](#why-durable-handles-are-not-planned). |
-| Directory leasing | Not implemented | Unused capability constant; depends on leases. Worth knowing before planning anything on it: a directory lease may only be `R` or `R|H` (MS-SMB2 3.3.5.9.11 strips write caching for directories), and Samba 4.21 does not implement directory leases at all, so nothing is granted there whatever the client asks for. |
+| Directory leasing | Not implemented | Unused capability constant; depends on leases. Worth knowing before planning anything on it: a directory lease may only be `R` or `R|H`, because a request's write bit is cleared for a directory rather than refused (MS-FSA 2.1.5.18 asks for STATUS_INVALID_PARAMETER; Windows and Samba both just drop the bit). Samba 4.21 does not implement directory leases at all, so nothing is granted there whatever the client asks for; Samba 4.22 does, behind a `smb3 directory leases` global that defaults to `auto` - on unless the server is clustered, and only while `smb2 leases` and `oplocks` are on and `kernel oplocks` is off. The server advertises the capability only to a client that advertised it first. |
 | Durable / persistent handles | Not implemented, and not planned | No DHnQ/DH2Q/DHnC/DH2C contexts, no app instance id, no handle reconnect path. See [Why durable handles are not planned](#why-durable-handles-are-not-planned) for what it would take and why it is not worth it here. |
 | Create contexts (the framework itself) | Not functional | The request side encodes correctly: `Smb2CreateRequest.setCreateContexts()` lays contexts out as MS-SMB2 2.2.13.2 requires, and `CreateContextIT` checks that a real server answers each one. But nothing outside the tests calls it, and `Smb2CreateResponse.createContext()` is `return null`, so a context in a response is skipped. Before 3.0.4 no context could be sent at all — `size()` left out each context's header and name, so the request failed before it was sent — and the encoder also zeroed every `Next` and undercounted `CreateContextsLength`. |
 
@@ -206,10 +206,12 @@ because only a lease carries a client-chosen key that exempts its holder. `R` is
 required: a lease asking for handle caching alone is reduced to none.
 
 **Directories cannot have one.** MS-SMB2 3.3.5.9.10 skips durability when the
-open is a directory, and Samba 4.21 blocks it twice over — its durable cookie is
-refused for directories, and it has no directory leases to qualify with. Since
-directory enumeration is much of what this library does, the feature would not
-apply to it.
+open is a directory, and Samba refuses it as well. On 4.21 it is blocked twice
+over — the durable cookie is refused for directories, and there are no directory
+leases to qualify with. On 4.22 only the first block remains: a directory lease
+can now satisfy the handle-caching test, but the durable cookie still answers
+STATUS_NOT_SUPPORTED for a directory, so the result is the same. Since directory
+enumeration is much of what this library does, the feature would not apply to it.
 
 **What it buys is mostly not what this client uses.** A durable handle preserves
 byte-range locks across the reconnect — the reason the Linux client implemented


### PR DESCRIPTION
## What this changes

The integration fixture's Samba moves from **4.21.9** (Alpine 3.22) to **4.22.10**
(Alpine 3.23). No client code changes. Two statements in the status document that
named 4.21 as the reference server are corrected, because the move makes them
untrue.

## Why 4.22

4.22 is the first release where `smbd` answers an ordinary SMB2 client with
`STATUS_STOPPED_ON_SYMLINK` — telling the client where a symbolic link points —
instead of either resolving the link itself or reporting the name as absent.

On 4.21 that status is **unreachable for any SMB2 client, whatever the share is
configured with**. `source3/smbd/filename.c` converts it into
`OBJECT_NAME_NOT_FOUND` when `follow symlinks` is off, and Samba's own test suite
lists its four SMB2 symlink tests as known failures. In 4.22 the create path
gained a symbolic link error context builder, `follow symlinks = no` became the
switch that reaches it, and that known-failure list was deleted.

This matters because `SymlinkIT` records that jcifs does not resolve reparse
points, and until now the only server that could exercise a client-side resolver
was Windows. With this bump, Samba can too — which is four of the seven checks a
pull request runs, across the whole dialect matrix, rather than the two Windows
jobs alone.

## Measured, not assumed

Before the bump, a share with `follow symlinks = no` and `wide links = no` on
4.21.9 was built and probed: every kind of link — relative, absolute,
directory, broken, and one pointing outside the share — answered `0xC0000034` and
`exists()` was false, while an ordinary file in the same share read back
normally. That control matters, because without it "no symlink error" could
equally have meant "the probe is wrong".

After the bump, the same share on 4.22.10 reports every one of them as a
symbolic link, with the target attached.

## The existing suite is the guard

Nothing in the client changes, so the regression evidence is the suite itself,
green before and after:

- **8851 unit tests, 241 integration tests, no failures** against 4.22.10.
- **The same nine cases skip as before**, and the same classes: four DFS cases
  that need port 445, three that are Windows only, and the two symbolic link
  cases. A different skip set would have been the thing to worry about — it can
  hide a behaviour change as easily as a failure can.
- apache-rat `Unapproved: 0, unknown: 0, generated: 0, approved: 401`, clirr
  against 3.0.3 with nothing to record, and no formatter or import-order churn.

One trap worth naming, because it would have produced a false green: the harness
builds the fixture under a **fixed image tag**, so a bumped Dockerfile can be
"proved" against the image it is replacing. The run behind these numbers deleted
that tag first, and the container's own log names the server that answered —
`smbd version 4.22.10`.

## The document corrections

Both are consequences of moving the reference server, not of anything in the
client:

- **Directory leasing.** 4.21 does not implement directory leases, so "nothing is
  granted there whatever the client asks for" held. 4.22 implements them, behind
  a `smb3 directory leases` global defaulting to `auto` — on unless the server is
  clustered — and advertised only to a client that advertised the capability
  first. The `R` or `R|H` limit still holds, but for a more precise reason than
  the document gave: a directory request has its write bit **cleared** rather
  than refused.
- **Durable handles on a directory.** Still refused, but now blocked once rather
  than twice: a directory lease can satisfy the handle-caching test, while the
  durable cookie still answers `STATUS_NOT_SUPPORTED` for a directory. The
  outcome is unchanged; the stated reasoning no longer is.

The 8 MiB read, write and transact offer was checked at the same time and is
unchanged, including that it still does not depend on the client asking for
multi-credit.

## What this does not do

It does not make jcifs follow symbolic links, and it does **not** enable the two
`@Disabled` cases in `SymlinkIT`. Those name links whose targets are absolute
paths in the Windows server's own object namespace, which no client can map back
to a share path — enabling them is a fixture question, not a resolver one.
