### PR TITLE
feat(smb2): report the access a server grants on a file

### DIFF
--- a/build_helpers/samba/entrypoint.sh
+++ b/build_helpers/samba/entrypoint.sh
@@ -40,6 +40,25 @@ ln -sfn missing.txt               /srv/share/link-broken
 ln -sfn /srv/outside/outside.txt  /srv/share/link-outside
 ln -sfn ./target.txt              /srv/share/link-relative
 
+# Files the connecting account is granted less than the share is. The share
+# itself is writable by both accounts, so anything that reports access from the
+# share alone reports the same answer for all three of these - only the access
+# the server computes for the file itself tells them apart. Created after the
+# blanket chmod above so it does not undo them, and owned by root, which is the
+# account none of the tests authenticate as.
+mkdir -p /srv/share/access
+printf 'readable contents\n'  > /srv/share/access/readable.txt
+printf 'read-only contents\n' > /srv/share/access/readonly.txt
+printf 'secret contents\n'    > /srv/share/access/noaccess.txt
+chmod 0777 /srv/share/access
+chmod 0666 /srv/share/access/readable.txt
+# Readable by everyone, writable only by root.
+chmod 0444 /srv/share/access/readonly.txt
+# Unreadable by anyone but root. The directory stays searchable, so the account
+# can still stat the file: that is what keeps it reporting that it exists while
+# its contents stay unreachable.
+chmod 0600 /srv/share/access/noaccess.txt
+
 # The same shapes again in the share that reports links rather than resolving
 # them. Every in-share target is relative, which is the only form a client can
 # resolve: an absolute target names a path in the server's own namespace.

--- a/build_helpers/win-setup.ps1
+++ b/build_helpers/win-setup.ps1
@@ -108,6 +108,27 @@ try {
     Pop-Location
 }
 
+Write-Host 'Creating the fixtures for the access-reporting tests'
+# Files the connecting account is granted less than the share is. The share
+# grants both accounts Full, and these files inherit that, so only the explicit
+# deny below tells them apart - and only the access the server computes for the
+# file itself reports it.
+$accessPath = Join-Path $sharePath 'access'
+New-Item -Path $accessPath -ItemType Directory -Force | Out-Null
+[IO.File]::WriteAllText((Join-Path $accessPath 'readable.txt'), "readable contents`n")
+[IO.File]::WriteAllText((Join-Path $accessPath 'readonly.txt'), "read-only contents`n")
+[IO.File]::WriteAllText((Join-Path $accessPath 'noaccess.txt'), "secret contents`n")
+
+# Deny the one specific right, never the generic set. A deny of (R) would also
+# deny ReadAttributes, and the attributes-only open that a client makes to stat
+# a file would then fail - the file would stop reporting that it exists at all,
+# which is a different thing from being unreadable. (RD) leaves attributes
+# visible; (WD,AD) leaves reading alone.
+foreach ($user in $testUsers) {
+    icacls (Join-Path $accessPath 'readonly.txt') /deny "${user}:(WD,AD)" /Q | Out-Null
+    icacls (Join-Path $accessPath 'noaccess.txt') /deny "${user}:(RD)" /Q | Out-Null
+}
+
 Write-Host 'Creating the fixtures for the link-reporting share'
 $symlinkPath = Join-Path $Root 'symlinks'
 [IO.File]::WriteAllText((Join-Path $symlinkPath 'target.txt'), "target file contents`n")

--- a/docs/SMB3_SUPPORT.md
+++ b/docs/SMB3_SUPPORT.md
@@ -169,16 +169,37 @@ break anyway.
 | SMB3 leases | Not implemented | Two unused constants; no lease is ever requested, and there is no lease create context to request one with. A lease break is now decoded rather than fatal: before 3.0.4 its 44-byte body failed a decode that demanded 24, and that failure closed the socket, logged off every session and failed every request in flight on the connection. Such a break is logged and otherwise ignored, since no lease was ever held — there is no lease break acknowledgement message either. A lease holding `SMB2_LEASE_HANDLE_CACHING` is one of the two ways to qualify for a durable handle; see [Why durable handles are not planned](#why-durable-handles-are-not-planned). |
 | Directory leasing | Not implemented | Unused capability constant; depends on leases. Worth knowing before planning anything on it: a directory lease may only be `R` or `R|H`, because a request's write bit is cleared for a directory rather than refused (MS-FSA 2.1.5.18 asks for STATUS_INVALID_PARAMETER; Windows and Samba both just drop the bit). Samba 4.21 does not implement directory leases at all, so nothing is granted there whatever the client asks for; Samba 4.22 does, behind a `smb3 directory leases` global that defaults to `auto` - on unless the server is clustered, and only while `smb2 leases` and `oplocks` are on and `kernel oplocks` is off. The server advertises the capability only to a client that advertised it first. |
 | Durable / persistent handles | Not implemented, and not planned | No DHnQ/DH2Q/DHnC/DH2C contexts, no app instance id, no handle reconnect path. See [Why durable handles are not planned](#why-durable-handles-are-not-planned) for what it would take and why it is not worth it here. |
-| Create contexts (the framework itself) | Not functional | The request side encodes correctly: `Smb2CreateRequest.setCreateContexts()` lays contexts out as MS-SMB2 2.2.13.2 requires, and `CreateContextIT` checks that a real server answers each one. But nothing outside the tests calls it, and `Smb2CreateResponse.createContext()` is `return null`, so a context in a response is skipped. Before 3.0.4 no context could be sent at all — `size()` left out each context's header and name, so the request failed before it was sent — and the encoder also zeroed every `Next` and undercounted `CreateContextsLength`. |
+| Create contexts (the framework itself) | Partial | Both directions work, for the one context type this client uses. `Smb2CreateRequest.setCreateContexts()` lays contexts out as MS-SMB2 2.2.13.2 requires, and `Smb2CreateResponse` walks the response chain and hands each entry to a factory that resolves it by name. Only `MxAc` resolves to anything today; every other context in a response is still skipped rather than decoded. Before 3.0.4 no context could be sent at all — `size()` left out each context's header and name, so the request failed before it was sent — and the encoder also zeroed every `Next` and undercounted `CreateContextsLength`. |
+| Maximal access (`MxAc`) | Supported | Sent on the open that reads a file's attributes, which costs no extra round trip, and the reported access is what `canRead()` and `canWrite()` answer from. See [What a caller may do with a file](#what-a-caller-may-do-with-a-file). |
 
-The last row is the blocker for the three above it: leases, durable handles and
-persistent handles all ride on create contexts. Contexts can now be sent, but a
-context in a response is still dropped. Note how little is missing there: the
-walker in `Smb2CreateResponse` is complete — it follows the `Next` chain,
-bounds-checks each entry and collects them — and only the factory that turns a
-context name into a response object is `return null`. Recognising a lease or
-durable handle response means adding those response types and a dispatch on the
-name, not writing a decoder.
+Leases, durable handles and persistent handles all ride on create contexts, and
+what is missing for them is no longer the framework: the walker follows the
+`Next` chain, bounds-checks each entry and collects them, and the factory that
+turns a context name into a response object now dispatches on the name.
+Recognising a lease or durable handle response means adding those response types
+and another branch there, not writing a decoder.
+
+### What a caller may do with a file
+
+`canRead()` and `canWrite()` used to answer from the file attributes alone, and
+the attributes do not carry permissions: `canRead()` was documented as "simply
+calls the `exists` method", so a file the server would refuse to open reported
+that it could be read, and a file protected by an ACL rather than by the
+read-only attribute reported that it could be written. For a caller that walks a
+share deciding what to fetch — which is most of them — that turns a permission
+into a failure discovered one open too late.
+
+Since 3.0.4 the open that reads the attributes also carries
+`SMB2_CREATE_QUERY_MAXIMAL_ACCESS`, and the access the server reports is what
+those two methods answer from. Both are still gated on `exists()` first, and
+`canWrite()` still requires the read-only attribute to be clear as well.
+
+Where the server reports no access — SMB1, which cannot be asked, or a server
+that declines to work it out — both fall back to exactly what they answered
+before. That is deliberate: not knowing what is granted is not the same as
+knowing nothing is, and treating the two alike would hide files that are in fact
+readable. A handle opened for a specific access reports nothing about the rest,
+so an open made that way clears the recorded access rather than narrowing it.
 
 ### Why durable handles are not planned
 

--- a/src/main/java/org/codelibs/jcifs/smb/SmbResource.java
+++ b/src/main/java/org/codelibs/jcifs/smb/SmbResource.java
@@ -152,24 +152,45 @@ public interface SmbResource extends AutoCloseable {
     boolean isDirectory() throws CIFSException;
 
     /**
-     * Tests to see if the file this <code>SmbResource</code> represents
-     * exists and is not marked read-only. By default, resources are
-     * considered to be read-only and therefore for <code>smb://</code>,
-     * <code>smb://workgroup/</code>, and <code>smb://server/</code> resources
-     * will be read-only.
+     * Tests to see if the file this <code>SmbResource</code> represents can be
+     * written.
      *
-     * @return <code>true</code> if the resource exists is not marked
-     *         read-only
+     * <p>
+     * The resource has to exist and not be marked read-only. On SMB2 the server
+     * is also asked what access it grants this caller, on the same open that
+     * reads the attributes, and a file it will not let the caller write reports
+     * <code>false</code> even when no read-only attribute is set: a permission
+     * that denies writing does not show up in the attributes at all. Where the
+     * server reports no such access - SMB1, or a server that declines to work it
+     * out - only the attribute is consulted, as before.
+     * </p>
+     *
+     * <p>
+     * By default, resources are considered to be read-only and therefore for
+     * <code>smb://</code>, <code>smb://workgroup/</code>, and
+     * <code>smb://server/</code> resources will be read-only.
+     * </p>
+     *
+     * @return <code>true</code> if the resource exists, is not marked read-only,
+     *         and is not one the server says this caller may not write
      * @throws CIFSException if an error occurs accessing the resource
      */
     boolean canWrite() throws CIFSException;
 
     /**
      * Tests to see if the file this <code>SmbResource</code> represents can be
-     * read. Because any file, directory, or other resource can be read if it
-     * exists, this method simply calls the <code>exists</code> method.
+     * read.
      *
-     * @return <code>true</code> if the file is read-only
+     * <p>
+     * On SMB2 the server is asked what access it grants this caller, on the same
+     * open that reads the attributes, and a file whose contents it will not hand
+     * over reports <code>false</code>. Where the server reports no such access -
+     * SMB1, or a server that declines to work it out - this falls back to whether
+     * the resource exists, which is all this method used to answer.
+     * </p>
+     *
+     * @return <code>true</code> if the resource exists and the server does not
+     *         say this caller may not read it
      * @throws CIFSException if an error occurs accessing the resource
      */
     boolean canRead() throws CIFSException;

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbFile.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbFile.java
@@ -81,6 +81,7 @@ import org.codelibs.jcifs.smb.internal.smb1.trans2.Trans2SetFileInformationRespo
 import org.codelibs.jcifs.smb.internal.smb2.ServerMessageBlock2Request;
 import org.codelibs.jcifs.smb.internal.smb2.ServerMessageBlock2Response;
 import org.codelibs.jcifs.smb.internal.smb2.Smb2Constants;
+import org.codelibs.jcifs.smb.internal.smb2.create.QueryMaximalAccessRequest;
 import org.codelibs.jcifs.smb.internal.smb2.create.Smb2CloseRequest;
 import org.codelibs.jcifs.smb.internal.smb2.create.Smb2CloseResponse;
 import org.codelibs.jcifs.smb.internal.smb2.create.Smb2CreateRequest;
@@ -377,6 +378,16 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
     private long size;
     private long sizeExpiration;
     private boolean isExists;
+
+    /**
+     * The access the server reported on the open that last read the attributes.
+     * Only meaningful while {@code grantedAccessKnown} is set: not knowing what
+     * access is granted is a different thing from being granted nothing, so the
+     * two are kept apart rather than folded into a zero mask. Both are governed
+     * by {@code attrExpiration}, the way the attributes themselves are.
+     */
+    private int grantedAccess;
+    private boolean grantedAccessKnown;
 
     private final CIFSContext transportContext;
     private SmbTreeConnection treeConnection;
@@ -771,6 +782,9 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
                 this.lastAccess = info.getLastAccessTime();
                 this.attributes = info.getAttributes() & ATTR_GET_MASK;
                 this.attrExpiration = attrTimeout;
+                // This open asked for a particular access rather than for a report of
+                // one, so what the server granted here says nothing about the rest.
+                recordGrantedAccess(null);
             }
 
             this.isExists = true;
@@ -826,6 +840,8 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
             }
             final BasicFileInformation info = response.getInfo(BasicFileInformation.class);
             this.isExists = true;
+            // SMB1 has no way to ask what access is granted.
+            recordGrantedAccess(null);
             if (info instanceof FileBasicInfo) {
                 this.attributes = info.getAttributes() & ATTR_GET_MASK;
                 this.createTime = info.getCreateTime();
@@ -849,6 +865,7 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
         }
 
         this.isExists = true;
+        recordGrantedAccess(null);
         this.attributes = response.getAttributes() & ATTR_GET_MASK;
         this.lastModified = response.getLastWriteTime();
         this.attrExpiration = System.currentTimeMillis() + th.getConfig().getAttributeCacheTimeout();
@@ -871,6 +888,7 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
         this.lastModified = 0L;
         this.lastAccess = 0L;
         this.isExists = false;
+        recordGrantedAccess(null);
 
         try {
             if (this.url.getHost().length() == 0) {} else if (this.fileLocator.getShare() == null) {
@@ -1064,7 +1082,10 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
         if (getType() == TYPE_NAMED_PIPE) { // try opening the pipe for reading?
             return true;
         }
-        return exists(); // try opening and catch sharing violation?
+        // exists() first, and not only because a file that is not there cannot be
+        // read: it is what fetches the access the server grants, so the check below
+        // has nothing to consult until it has run.
+        return exists() && grants(FILE_READ_DATA | GENERIC_READ | GENERIC_ALL);
     }
 
     @Override
@@ -1072,7 +1093,38 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
         if (getType() == TYPE_NAMED_PIPE) { // try opening the pipe for writing?
             return true;
         }
-        return exists() && (this.attributes & ATTR_READONLY) == 0;
+        return exists() && (this.attributes & ATTR_READONLY) == 0
+                && grants(FILE_WRITE_DATA | FILE_APPEND_DATA | GENERIC_WRITE | GENERIC_ALL);
+    }
+
+    /**
+     * Whether the access the server last reported includes any of the given rights.
+     *
+     * <p>
+     * A server that reported no access at all is answered {@code true}: not knowing
+     * what is granted is not the same as knowing nothing is, and reporting a file
+     * unreadable on that basis would hide files this client can in fact read. The
+     * generic rights are accepted alongside the specific ones because a server is
+     * free to answer in either form, and both servers this is tested against answer
+     * in the specific form.
+     * </p>
+     *
+     * @param access the rights to look for
+     * @return true unless the server said this caller has none of them
+     */
+    private boolean grants(final int access) {
+        return !this.grantedAccessKnown || (this.grantedAccess & access) != 0;
+    }
+
+    /**
+     * Records what the server reported about this caller's access, alongside the
+     * attributes from the same open.
+     *
+     * @param granted the reported access, or null if the server reported none
+     */
+    private void recordGrantedAccess(final Integer granted) {
+        this.grantedAccessKnown = granted != null;
+        this.grantedAccess = granted != null ? granted.intValue() : 0;
     }
 
     @Override
@@ -1733,6 +1785,11 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
             cr.setFileAttributes(fileAttributes);
             cr.setDesiredAccess(desiredAccess);
             cr.setShareAccess(shareAccess);
+            // Asked for on the open that reads the attributes, because the attributes
+            // do not carry it: a file the caller may not read looks exactly like one
+            // it may, and only the server can say which it is. It costs no round trip
+            // and a server that will not answer simply leaves it out.
+            cr.setCreateContexts(new QueryMaximalAccessRequest());
 
             ServerMessageBlock2Request<?> cur = cr;
 
@@ -1767,6 +1824,7 @@ public class SmbFile extends URLConnection implements SmbResource, SmbConstants 
             this.lastAccess = info.getLastAccessTime();
             this.attributes = info.getAttributes() & ATTR_GET_MASK;
             this.attrExpiration = System.currentTimeMillis() + th.getConfig().getAttributeCacheTimeout();
+            recordGrantedAccess(createResp.getMaximalAccess());
 
             this.size = info.getSize();
             this.sizeExpiration = System.currentTimeMillis() + th.getConfig().getAttributeCacheTimeout();

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/create/QueryMaximalAccessRequest.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/create/QueryMaximalAccessRequest.java
@@ -1,0 +1,75 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package org.codelibs.jcifs.smb.internal.smb2.create;
+
+import java.util.Arrays;
+
+/**
+ * SMB2_CREATE_QUERY_MAXIMAL_ACCESS_REQUEST, MS-SMB2 2.2.13.2.5.
+ *
+ * <p>
+ * Asks the server to report, in the create response, the access it would grant
+ * this caller on the file being opened. That answer accounts for the share and
+ * for the file's own permissions, neither of which the file attributes carry.
+ * </p>
+ *
+ * <p>
+ * The Timestamp the structure may carry is sent as zero. A server is allowed to
+ * skip the response when the file has not changed since the timestamp given, and
+ * zero is never a file's last write time, so a zero timestamp is the form that is
+ * always answered.
+ * </p>
+ */
+public class QueryMaximalAccessRequest implements CreateContextRequest {
+
+    static final byte[] NAME = { 'M', 'x', 'A', 'c' };
+
+    private static final int TIMESTAMP_SIZE = 8;
+
+    /**
+     * Constructs a request for the caller's maximal access on the file.
+     */
+    public QueryMaximalAccessRequest() {
+    }
+
+    @Override
+    public byte[] getName() {
+        return NAME.clone();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.codelibs.jcifs.smb.Encodable#encode(byte[], int)
+     */
+    @Override
+    public int encode(final byte[] dst, final int dstIndex) {
+        // Written rather than assumed: the transport buffer is reused, so what is
+        // already at this offset is whatever the previous message left there.
+        Arrays.fill(dst, dstIndex, dstIndex + TIMESTAMP_SIZE, (byte) 0);
+        return TIMESTAMP_SIZE;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.codelibs.jcifs.smb.Encodable#size()
+     */
+    @Override
+    public int size() {
+        return TIMESTAMP_SIZE;
+    }
+}

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/create/QueryMaximalAccessResponse.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/create/QueryMaximalAccessResponse.java
@@ -1,0 +1,86 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package org.codelibs.jcifs.smb.internal.smb2.create;
+
+import org.codelibs.jcifs.smb.internal.SMBProtocolDecodingException;
+import org.codelibs.jcifs.smb.internal.util.SMBUtil;
+
+/**
+ * SMB2_CREATE_QUERY_MAXIMAL_ACCESS_RESPONSE, MS-SMB2 2.2.14.2.5.
+ *
+ * <p>
+ * Carries the access the server grants this caller on the file it just opened.
+ * QueryStatus is the result of computing it: a server that could not work the
+ * access out reports the failure there and leaves MaximalAccess meaningless, so
+ * both have to be read before the mask is used.
+ * </p>
+ */
+public class QueryMaximalAccessResponse implements CreateContextResponse {
+
+    static final byte[] NAME = { 'M', 'x', 'A', 'c' };
+
+    private static final int RESPONSE_SIZE = 8;
+
+    private int queryStatus;
+    private int maximalAccess;
+
+    /**
+     * Constructs an empty response, to be filled in by decoding.
+     */
+    public QueryMaximalAccessResponse() {
+    }
+
+    @Override
+    public byte[] getName() {
+        return NAME.clone();
+    }
+
+    /**
+     * Gets the status of the server's attempt to compute the access.
+     *
+     * @return NT_STATUS_SUCCESS when the mask is meaningful
+     */
+    public int getQueryStatus() {
+        return this.queryStatus;
+    }
+
+    /**
+     * Gets the access the server grants the caller on this file.
+     *
+     * @return an access mask, meaningful only when {@link #getQueryStatus()} is success
+     */
+    public int getMaximalAccess() {
+        return this.maximalAccess;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.codelibs.jcifs.smb.Decodable#decode(byte[], int, int)
+     */
+    @Override
+    public int decode(final byte[] buffer, int bufferIndex, final int len) throws SMBProtocolDecodingException {
+        if (len < RESPONSE_SIZE) {
+            throw new SMBProtocolDecodingException("Invalid maximal access response length " + len);
+        }
+        final int start = bufferIndex;
+        this.queryStatus = SMBUtil.readInt4(buffer, bufferIndex);
+        bufferIndex += 4;
+        this.maximalAccess = SMBUtil.readInt4(buffer, bufferIndex);
+        bufferIndex += 4;
+        return bufferIndex - start;
+    }
+}

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/create/Smb2CreateResponse.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/create/Smb2CreateResponse.java
@@ -17,10 +17,12 @@
  */
 package org.codelibs.jcifs.smb.internal.smb2.create;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
 import org.codelibs.jcifs.smb.Configuration;
+import org.codelibs.jcifs.smb.impl.NtStatus;
 import org.codelibs.jcifs.smb.internal.CommonServerMessageBlockRequest;
 import org.codelibs.jcifs.smb.internal.SMBProtocolDecodingException;
 import org.codelibs.jcifs.smb.internal.SmbBasicFileInfo;
@@ -326,10 +328,39 @@ public class Smb2CreateResponse extends ServerMessageBlock2Response implements S
     }
 
     /**
-     * @param nameBytes
-     * @return
+     * The access the server reports this caller has on the file.
+     *
+     * <p>
+     * Present only when the create asked for it and the server worked it out. A
+     * server that declines, or reports a failure computing it, is indistinguishable
+     * here from one that was never asked - in each case the caller knows nothing
+     * about its access rather than knowing it has none.
+     * </p>
+     *
+     * @return the granted access mask, or {@code null} if the server reported none
+     */
+    public Integer getMaximalAccess() {
+        if (this.createContexts == null) {
+            return null;
+        }
+        for (final CreateContextResponse cc : this.createContexts) {
+            if (cc instanceof final QueryMaximalAccessResponse mxac && mxac.getQueryStatus() == NtStatus.NT_STATUS_SUCCESS) {
+                return mxac.getMaximalAccess();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Resolves a create context in a response to the type that decodes it.
+     *
+     * @param nameBytes the context name as it arrived
+     * @return a response object for it, or {@code null} for a context this client does not read
      */
     private static CreateContextResponse createContext(final byte[] nameBytes) {
+        if (Arrays.equals(QueryMaximalAccessResponse.NAME, nameBytes)) {
+            return new QueryMaximalAccessResponse();
+        }
         return null;
     }
 

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/create/QueryMaximalAccessRequestTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/create/QueryMaximalAccessRequestTest.java
@@ -1,0 +1,69 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.internal.smb2.create;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class QueryMaximalAccessRequestTest {
+
+    @Test
+    @DisplayName("the context is named MxAc")
+    void nameIsMxAc() {
+        assertArrayEquals("MxAc".getBytes(StandardCharsets.US_ASCII), new QueryMaximalAccessRequest().getName());
+    }
+
+    @Test
+    @DisplayName("the name cannot be altered through the accessor")
+    void nameIsNotShared() {
+        final QueryMaximalAccessRequest request = new QueryMaximalAccessRequest();
+        final byte[] first = request.getName();
+        first[0] = 'X';
+        assertArrayEquals("MxAc".getBytes(StandardCharsets.US_ASCII), request.getName(),
+                "altering a returned name should not change the next one");
+        assertNotSame(first, request.getName());
+    }
+
+    @Test
+    @DisplayName("the request is the eight byte timestamp")
+    void sizeIsTheTimestamp() {
+        assertEquals(8, new QueryMaximalAccessRequest().size());
+    }
+
+    @Test
+    @DisplayName("a zero timestamp is written over whatever the buffer already held")
+    void encodeZeroesADirtyBuffer() {
+        // The transport buffer is reused, so a request that only advanced the index
+        // would send the previous message's bytes as its timestamp - and a non-zero
+        // timestamp is exactly what lets a server skip the response.
+        final byte[] dst = new byte[16];
+        Arrays.fill(dst, (byte) 0xFF);
+
+        final int written = new QueryMaximalAccessRequest().encode(dst, 4);
+
+        assertEquals(8, written);
+        assertArrayEquals(new byte[8], Arrays.copyOfRange(dst, 4, 12), "the timestamp should be eight zero bytes");
+        assertEquals((byte) 0xFF, dst[3], "nothing before the offset should be touched");
+        assertEquals((byte) 0xFF, dst[12], "nothing after the timestamp should be touched");
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/create/QueryMaximalAccessResponseTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/create/QueryMaximalAccessResponseTest.java
@@ -1,0 +1,81 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.internal.smb2.create;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.charset.StandardCharsets;
+
+import org.codelibs.jcifs.smb.internal.SMBProtocolDecodingException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class QueryMaximalAccessResponseTest {
+
+    /** QueryStatus 0, MaximalAccess 0x001F01FF, little endian. */
+    private static final byte[] FULL_ACCESS = { 0x00, 0x00, 0x00, 0x00, (byte) 0xFF, 0x01, 0x1F, 0x00 };
+
+    @Test
+    @DisplayName("the context is named MxAc")
+    void nameIsMxAc() {
+        assertArrayEquals("MxAc".getBytes(StandardCharsets.US_ASCII), new QueryMaximalAccessResponse().getName());
+    }
+
+    @Test
+    @DisplayName("the status and the access mask are read in that order")
+    void decodesStatusThenMask() throws Exception {
+        final QueryMaximalAccessResponse response = new QueryMaximalAccessResponse();
+
+        assertEquals(8, response.decode(FULL_ACCESS, 0, FULL_ACCESS.length));
+
+        assertEquals(0, response.getQueryStatus());
+        assertEquals(0x001F01FF, response.getMaximalAccess());
+    }
+
+    @Test
+    @DisplayName("the response is read from the offset it is given")
+    void decodesAtAnOffset() throws Exception {
+        final byte[] buffer = new byte[16];
+        System.arraycopy(FULL_ACCESS, 0, buffer, 5, FULL_ACCESS.length);
+        final QueryMaximalAccessResponse response = new QueryMaximalAccessResponse();
+
+        assertEquals(8, response.decode(buffer, 5, 8));
+
+        assertEquals(0x001F01FF, response.getMaximalAccess());
+    }
+
+    @Test
+    @DisplayName("a failed query keeps its status, so the mask is not mistaken for an answer")
+    void decodesAFailedQuery() throws Exception {
+        // 0xC0000022 is STATUS_ACCESS_DENIED. A server that reports a failure here
+        // has not computed an access mask, and what follows must not be read as one.
+        final byte[] refused = { 0x22, 0x00, 0x00, (byte) 0xC0, 0x00, 0x00, 0x00, 0x00 };
+        final QueryMaximalAccessResponse response = new QueryMaximalAccessResponse();
+
+        response.decode(refused, 0, refused.length);
+
+        assertEquals(0xC0000022, response.getQueryStatus());
+    }
+
+    @Test
+    @DisplayName("a response shorter than the structure is refused rather than read past")
+    void refusesAShortResponse() {
+        final QueryMaximalAccessResponse response = new QueryMaximalAccessResponse();
+        assertThrows(SMBProtocolDecodingException.class, () -> response.decode(FULL_ACCESS, 0, 7));
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/it/AccessIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/AccessIT.java
@@ -1,0 +1,144 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.impl.SmbException;
+import org.codelibs.jcifs.smb.impl.SmbFile;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * What a caller can find out about its own access to a file.
+ *
+ * <p>
+ * The fixture puts three files in one directory of a share both accounts may
+ * write: one ordinary, one the account may read but not write, and one it may
+ * not read at all. The share grants the same rights to all three, so anything
+ * that answers from the share alone answers the same for each of them - only
+ * the access the server computes for the file itself tells them apart.
+ * </p>
+ *
+ * <p>
+ * These cases pin what has to stay true either way. A file that denies its
+ * contents still reports that it exists, which is a different fact from being
+ * readable, and an ordinary file in the same directory is unaffected. What
+ * {@code canRead()} and {@code canWrite()} answer for the restricted two is
+ * asserted where that behaviour is implemented, not here.
+ * </p>
+ */
+class AccessIT extends AbstractSmbIT {
+
+    private SmbFile access(final String name) throws Exception {
+        return new SmbFile(server().url(server().share(), "access/" + name), server().context());
+    }
+
+    @Test
+    @DisplayName("an ordinary file reports that it exists, can be read and can be written")
+    void ordinaryFileIsUnrestricted() throws Exception {
+        try (SmbFile file = access("readable.txt")) {
+            assertTrue(file.exists(), "the fixture file should exist");
+            assertTrue(file.canRead(), "an ordinary file should report that it can be read");
+            assertTrue(file.canWrite(), "an ordinary file in a writable share should report that it can be written");
+            assertEquals("readable contents\n", contentsOf(file));
+        }
+    }
+
+    @Test
+    @DisplayName("a file the account may not read still reports that it exists")
+    void unreadableFileStillReportsThatItExists() throws Exception {
+        try (SmbFile file = access("noaccess.txt")) {
+            assertTrue(file.exists(), "a file whose contents are denied should still report that it exists");
+        }
+    }
+
+    @Test
+    @DisplayName("reading a file the account may not read is refused")
+    void readingAnUnreadableFileIsRefused() throws Exception {
+        try (SmbFile file = access("noaccess.txt")) {
+            assertThrows(SmbException.class, () -> {
+                try (InputStream in = file.getInputStream()) {
+                    in.read();
+                }
+            }, "the server should refuse the contents of a file the account may not read");
+        }
+    }
+
+    @Test
+    @DisplayName("a file the account may not write can still be read")
+    void readOnlyFileCanStillBeRead() throws Exception {
+        try (SmbFile file = access("readonly.txt")) {
+            assertTrue(file.exists(), "the fixture file should exist");
+            assertTrue(file.canRead(), "a read-only file should report that it can be read");
+            assertEquals("read-only contents\n", contentsOf(file));
+        }
+    }
+
+    @Test
+    @DisplayName("writing a file the account may not write is refused")
+    void writingAReadOnlyFileIsRefused() throws Exception {
+        try (SmbFile file = access("readonly.txt")) {
+            assertThrows(SmbException.class, () -> {
+                try (OutputStream out = file.getOutputStream()) {
+                    out.write('x');
+                }
+            }, "the server should refuse a write to a file the account may only read");
+        }
+    }
+
+    @Test
+    @DisplayName("a file that is not there reports neither read nor write")
+    void missingFileReportsNeither() throws Exception {
+        try (SmbFile file = access("missing-" + UUID.randomUUID() + ".txt")) {
+            assertFalse(file.exists(), "the file should not exist");
+            assertFalse(file.canRead(), "a file that is not there cannot be read");
+            assertFalse(file.canWrite(), "a file that is not there cannot be written");
+        }
+    }
+
+    @Test
+    @DisplayName("a directory reports that it can be read")
+    void directoryIsReadable() throws Exception {
+        final CIFSContext context = server().context();
+        try (SmbFile dir = new SmbFile(server().url(server().share(), "access/"), context)) {
+            assertTrue(dir.exists(), "the fixture directory should exist");
+            assertTrue(dir.canRead(), "a directory the account may list should report that it can be read");
+        }
+    }
+
+    private static String contentsOf(final SmbFile file) throws Exception {
+        try (InputStream in = file.getInputStream()) {
+            final ByteArrayOutputStream buf = new ByteArrayOutputStream();
+            final byte[] chunk = new byte[512];
+            int read;
+            while ((read = in.read(chunk)) > 0) {
+                buf.write(chunk, 0, read);
+            }
+            return buf.toString(StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/it/AccessIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/AccessIT.java
@@ -111,6 +111,24 @@ class AccessIT extends AbstractSmbIT {
     }
 
     @Test
+    @DisplayName("a file the account may not read reports that it cannot be read")
+    void unreadableFileReportsThatItCannotBeRead() throws Exception {
+        try (SmbFile file = access("noaccess.txt")) {
+            assertTrue(file.exists(), "the file should still report that it exists");
+            assertFalse(file.canRead(), "a file whose contents the server denies should not report that it can be read");
+        }
+    }
+
+    @Test
+    @DisplayName("a file the account may not write reports that it cannot be written")
+    void readOnlyFileReportsThatItCannotBeWritten() throws Exception {
+        try (SmbFile file = access("readonly.txt")) {
+            assertTrue(file.canRead(), "the file should still report that it can be read");
+            assertFalse(file.canWrite(), "a file the server will not let the account write should not report that it can be written");
+        }
+    }
+
+    @Test
     @DisplayName("a file that is not there reports neither read nor write")
     void missingFileReportsNeither() throws Exception {
         try (SmbFile file = access("missing-" + UUID.randomUUID() + ".txt")) {


### PR DESCRIPTION
## What this changes

`canRead()` answered `exists()`, and said so in its own documentation.
`canWrite()` added the read-only attribute to that. Neither is what a
server enforces: file attributes carry no permissions at all, so a file
the server would refuse to open reported that it could be read, and a
file protected by an ACL rather than by the read-only attribute reported
that it could be written.

The open that reads a file's attributes now also carries
`SMB2_CREATE_QUERY_MAXIMAL_ACCESS`, and the access the server reports is
what both methods answer from. **No extra round trip** - that open
already happens, and the context rides along on it.

## The response side is what was missing

`Smb2CreateResponse` already walked the create-context chain,
bounds-checked each entry and collected the results, and then handed
every name to a factory that was `return null` - so each one was
dropped. That factory now resolves `MxAc`. Every other context is still
skipped, which is the branch leases and durable handles would each add.

## Measured, not assumed

Three files in one directory of a share both accounts may write, against
Samba 4.22.10:

| fixture file | permissions | reported access | reading it |
| --- | --- | --- | --- |
| `readable.txt` | 0666 | `0x0013019F` | ok |
| `readonly.txt` | root, 0444 | `0x00130089` - the same without `WRITE_DATA` | ok |
| `noaccess.txt` | root, 0600 | `0x00010080` - `READ_ATTRS` and `DELETE`, no `READ_DATA` | **refused** |

All three answer `QueryStatus` 0. **The attributes are identical across
all three**, which is why the attributes could never have told them
apart.

## Not knowing is kept apart from being denied

Where the server reports no access, both methods answer exactly what
they answered before. SMB1 cannot be asked, a server may decline, and a
failed `QueryStatus` means the server did not work the access out - in
each case what follows is not an answer. Folding those into a zero mask
would report readable files as unreadable, which is the one direction
that loses data rather than surfacing it.

An open made for a particular access reports nothing about the rest, so
it clears the recorded access rather than narrowing it.

## The guard landed first

Its own commit, green before any of this was written, and it does not
assert which path ran - only what a caller can rely on: a file whose
contents are denied still reports that it exists, reading it is refused,
a file that may only be read can still be read, writing it is refused,
an ordinary file in the same directory is unaffected, a missing file
reports neither, and a directory reports that it can be read.

Falsified: with both restrictions removed from the fixture, exactly the
two refusal cases fail and the other five stay green.

## Falsified, not trusted

With the reported access suppressed, exactly the two cases that depend
on it fail - the unreadable file and the read-only one - while all seven
guard cases stay green. They have to read the same either way.

## Verification

- Unit tests **8872** and integration tests **263** against Samba 4.22.10,
  no failures, with the nine usual skips unchanged. The nine added unit
  cases and two added integration cases are the whole difference.
- apache-rat reports nothing unapproved. clirr compares clean against
  3.0.3 and needs **no new entry**: no public signature changed, only the
  documentation of `canRead()` and `canWrite()`.
- Built with `clean`, so none of the falsification run's classes survived
  into the run that proves it.
- The Windows backend is verified by CI rather than locally. Both added
  cases carry no backend annotation, so `windows-smb` is what proves
  Server 2025 reports this the way the POSIX modes do - including that
  denying `(RD)` rather than `(R)` leaves the file reporting that it
  exists.

## What is not covered

The `MxAc` context is sent on the attributes path only. A resource whose
attributes came from a directory listing, or from an open made for a
specific access, reports no access until something queries it again, and
falls back to the previous behaviour in the meantime.
