### PR TITLE
feat(smb3): decompress what a server compresses when asked to

### DIFF
--- a/docs/SMB3_SUPPORT.md
+++ b/docs/SMB3_SUPPORT.md
@@ -124,7 +124,7 @@ the fix in #92.
 | --- | --- |
 | `PREAUTH_INTEGRITY_CAPABILITIES` (0x1) | Supported, SHA-512 only. A response without it fails the connection. |
 | `ENCRYPTION_CAPABILITIES` (0x2) | Supported, all four ciphers: AES-128-CCM, AES-128-GCM, AES-256-CCM, AES-256-GCM. Sent only when encryption is enabled. |
-| `COMPRESSION_CAPABILITIES` (0x3) | Not implemented |
+| `COMPRESSION_CAPABILITIES` (0x3) | Supported | Sent only when `jcifs.client.compressionEnabled` is set, and it offers LZ77 alone, because that is the one algorithm this client can decompress. |
 | `NETNAME_NEGOTIATE_CONTEXT_ID` (0x5) | Not implemented |
 | `TRANSPORT_CAPABILITIES` (0x6) | Not implemented |
 | `RDMA_TRANSFORM_CAPABILITIES` (0x7) | Not implemented |
@@ -333,9 +333,43 @@ file on its first open, as it always has.
 | Named pipes | Supported | Transceive and peek. |
 | Symbolic links / reparse points | Partial | A path that crosses a symbolic link fails with `SmbSymlinkException`, which carries the target decoded from the `STATUS_STOPPED_ON_SYMLINK` error response: `getSubstituteName()`, `getPrintName()`, `isRelative()` and `getUnparsedPathLength()`. Set `jcifs.client.followSymlinks=true` and a link whose target is **relative** is resolved and the request reissued against it, which covers every operation rather than just opening, because the retry sits where DFS referrals are already retried and is bounded the same way. An **absolute** target is never followed: it is expressed in the server's own namespace (`\??\C:\...` from Windows, a POSIX path from Samba) and names something this share cannot address, so it is reported exactly as it is with following off. Following is off by default, so nothing changes for a caller who does not ask for it. Which server you are talking to decides whether any of this comes up: Samba resolves a link inside the share itself unless the share sets `follow symlinks = no`, and only does that from 4.22 onwards, so the error surfaces mainly against Windows. |
 | Multi-channel | Not functional | One unused capability constant, an unused `FSCTL_QUERY_NETWORK_INTERFACE_INFO` constant with no response decoder, and `Smb2SessionSetupRequest.setSessionBinding()`, which encodes the binding flag correctly but is called only from unit tests. A session is pinned to one transport. |
-| Compression | Not implemented | No context, no transform header, no LZ77/LZNT1. |
+| Compression | Partial | Off by default. With `jcifs.client.compressionEnabled` set the client offers LZ77, asks the server to compress what it reads, and decompresses what arrives. It never compresses what it sends. See [Compression](#compression-what-is-and-is-not-done) below. |
 | RDMA (SMB Direct) | Not implemented | Two unused read-channel constants. No RDMA transport and no dependency. |
 | Witness protocol | Not implemented | Nothing in the source tree. |
+
+### Compression: what is and is not done
+
+Reading only, and off by default. Set `jcifs.client.compressionEnabled=true` and
+the client offers a compression algorithm during SMB 3.1.1 negotiation, sets
+`SMB2_READFLAG_REQUEST_COMPRESSED` on its reads, and decompresses what comes
+back. **It never compresses what it sends.** A client is not obliged to, and not
+doing so keeps the whole compressor out of the code.
+
+Only **LZ77** (XPRESS) is offered, and that is deliberately not configurable. A
+server may answer with any algorithm from the offer, and MS-SMB2 3.2.5.2
+requires the connection to fail if it names one the client did not offer — so
+the offer is a statement of what this client can actually read. A settable list
+would let a caller promise something it cannot honour and break the connection
+doing it.
+
+Two things were measured rather than read off the documentation, and one of them
+is easy to get wrong:
+
+- **Samba 4.22 does not implement compression at all.** Its `smb2_negprot.c`
+  never mentions the context, and a negotiate probe confirms it answers with
+  only the pre-auth and encryption contexts. Offering compression to it changes
+  nothing, which is what the Samba integration tests pin.
+- **Windows Server 2025 supports LZNT1, LZ77, LZ77+Huffman, Pattern_V1 and
+  LZ4** — each confirmed by offering it alone. Offering all five returns
+  `LZNT1` and `Pattern_V1`, which looks like LZ77 being unsupported and is not:
+  the server returns a subset of the offer by its own preference. Offering
+  `LZ77` alone returns `LZ77`.
+
+Chained compression is never negotiated, so the chained header is not read. A
+chained message, an algorithm that was not agreed, or data that does not
+decompress to the size the sender declared each fail the connection rather than
+being skipped, as MS-SMB2 3.2.5.1.1.2 requires: a frame that cannot be
+decompressed cannot be measured either, so there is no way to find the next one.
 
 ## Configuration knobs referenced above
 
@@ -349,6 +383,7 @@ file on its first open, as it always has.
 | `jcifs.client.ipcSigningEnforced` | `true` | Require signing on IPC$. |
 | `jcifs.client.requireSecureNegotiate` | `true` | Validate the negotiate exchange on tree connect. |
 | `jcifs.client.encryptionEnabled` | `false` | Opt in to SMB3 encryption — see [Encryption](#encryption). |
+| `jcifs.client.compressionEnabled` | `false` | Opt in to SMB 3.1.1 compression of what the client reads — see [Compression](#compression-what-is-and-is-not-done). No effect below SMB 3.1.1, and none against a server that does not implement it. |
 | `jcifs.client.signingAlgorithms` | `AES-CMAC, AES-GMAC, HMAC-SHA256` | The SMB 3.1.1 signing algorithms to offer, in preference order. An unrecognised name fails configuration rather than being ignored. AES-CMAC leads because it is what this client has always signed with, and the server chooses from the offered list by its own preference — so the negotiated algorithm is unchanged unless this property is. Offering only `AES-GMAC` requires it. No effect below SMB 3.1.1, which does not negotiate a signing algorithm. |
 | `jcifs.client.encryptionCiphers` | `AES-128-GCM, AES-128-CCM, AES-256-GCM, AES-256-CCM` | The SMB 3.1.1 ciphers to offer, in preference order. An unrecognised name fails configuration rather than being ignored. Note that the server chooses one from the offered list and may apply its own preference when doing so, so listing AES-256 first does not make AES-256 the negotiated cipher; offering only the AES-256 ciphers does require them. No effect below SMB 3.1.1, which does not negotiate a cipher. |
 | `jcifs.client.maxTransferSize` | `1048576` | Largest payload a single SMB2 read or write may carry. The negotiated size is the smaller of this and the server's offer. Has no effect below SMB 2.1, which cannot carry more than 64 KiB in one request. |

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,11 @@
 							<differenceType>7012</differenceType>
 							<method>boolean isFollowSymlinks()</method>
 						</difference>
+						<difference>
+							<className>org/codelibs/jcifs/smb/Configuration</className>
+							<differenceType>7012</differenceType>
+							<method>boolean isCompressionEnabled()</method>
+						</difference>
 					</ignored>
 				</configuration>
 			</plugin>

--- a/src/main/java/org/codelibs/jcifs/smb/Configuration.java
+++ b/src/main/java/org/codelibs/jcifs/smb/Configuration.java
@@ -525,6 +525,28 @@ public interface Configuration {
     boolean isEncryptionEnabled();
 
     /**
+     * Property {@code jcifs.client.compressionEnabled} (boolean, default false)
+     *
+     * Enables SMB 3.1.1 compression. When enabled the client offers the compression algorithms it is able to
+     * decompress during protocol negotiation, and asks the server to compress the data it reads back. Nothing
+     * this client sends is compressed: a client is never obliged to compress, and a server does not require it.
+     *
+     * <p>
+     * Which algorithms are offered is deliberately not configurable, unlike {@link #getEncryptionCiphers()}.
+     * MS-SMB2 3.2.5.2 requires the connection to fail when a server names an algorithm the client did not
+     * offer, so the offer states what this client can actually read rather than what it would prefer - and a
+     * settable list would let a caller promise something it cannot honour.
+     * </p>
+     *
+     * <p>
+     * Has no effect below SMB 3.1.1, which has no negotiate context to carry the offer.
+     * </p>
+     *
+     * @return whether SMB3 compression is enabled
+     */
+    boolean isCompressionEnabled();
+
+    /**
      * Property {@code jcifs.client.encryptionCiphers} (comma-separated, default
      * {@code AES-128-GCM, AES-128-CCM, AES-256-GCM, AES-256-CCM})
      *

--- a/src/main/java/org/codelibs/jcifs/smb/config/BaseConfiguration.java
+++ b/src/main/java/org/codelibs/jcifs/smb/config/BaseConfiguration.java
@@ -78,6 +78,8 @@ public class BaseConfiguration implements Configuration {
     protected boolean ipcSigningEnforced = true;
     /** Whether SMB3 encryption is enabled */
     protected boolean encryptionEnabled = false;
+    /** Whether SMB3 compression is enabled */
+    protected boolean compressionEnabled = false;
     /** SMB 3.1.1 encryption ciphers to offer, in preference order */
     protected int[] encryptionCiphers;
     /** SMB 3.1.1 signing algorithms to offer, in preference order */
@@ -577,6 +579,11 @@ public class BaseConfiguration implements Configuration {
     @Override
     public boolean isEncryptionEnabled() {
         return this.encryptionEnabled;
+    }
+
+    @Override
+    public boolean isCompressionEnabled() {
+        return this.compressionEnabled;
     }
 
     @Override

--- a/src/main/java/org/codelibs/jcifs/smb/config/DelegatingConfiguration.java
+++ b/src/main/java/org/codelibs/jcifs/smb/config/DelegatingConfiguration.java
@@ -639,6 +639,16 @@ public class DelegatingConfiguration implements Configuration {
     /**
      * {@inheritDoc}
      *
+     * @see org.codelibs.jcifs.smb.Configuration#isCompressionEnabled()
+     */
+    @Override
+    public boolean isCompressionEnabled() {
+        return this.delegate.isCompressionEnabled();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * @see org.codelibs.jcifs.smb.Configuration#getEncryptionCiphers()
      */
     @Override

--- a/src/main/java/org/codelibs/jcifs/smb/config/PropertyConfiguration.java
+++ b/src/main/java/org/codelibs/jcifs/smb/config/PropertyConfiguration.java
@@ -114,6 +114,7 @@ public final class PropertyConfiguration extends BaseConfiguration implements Co
         this.signingEnforced = Config.getBoolean(p, "jcifs.client.signingEnforced", false);
         this.ipcSigningEnforced = Config.getBoolean(p, "jcifs.client.ipcSigningEnforced", true);
         this.encryptionEnabled = Config.getBoolean(p, "jcifs.client.encryptionEnabled", false);
+        this.compressionEnabled = Config.getBoolean(p, "jcifs.client.compressionEnabled", false);
         initEncryptionCiphers(p.getProperty("jcifs.client.encryptionCiphers"));
         initSigningAlgorithms(p.getProperty("jcifs.client.signingAlgorithms"));
         this.requireSecureNegotiate = Config.getBoolean(p, "jcifs.client.requireSecureNegotiate", true);

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbFileInputStream.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbFileInputStream.java
@@ -313,6 +313,12 @@ public class SmbFileInputStream extends InputStream {
                         request.setOffset(type == SmbConstants.TYPE_NAMED_PIPE ? 0 : this.fp);
                         request.setReadLength(r);
                         request.setRemainingBytes(len - r);
+                        if (th.isCompressionNegotiated()) {
+                            // Asked for rather than hoped for: without this flag a server decides
+                            // for itself whether to compress the reply, and both of the servers
+                            // this is tested against decide not to.
+                            request.setReadFlags(Smb2ReadRequest.SMB2_READFLAG_REQUEST_COMPRESSED);
+                        }
 
                         try {
                             final Smb2ReadResponse resp = th.send(request, RequestParam.NO_RETRY);

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbRandomAccessFile.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbRandomAccessFile.java
@@ -271,6 +271,9 @@ public class SmbRandomAccessFile implements SmbRandomAccess {
                     request.setOffset(this.fp);
                     request.setReadLength(r);
                     request.setRemainingBytes(len);
+                    if (th.isCompressionNegotiated()) {
+                        request.setReadFlags(Smb2ReadRequest.SMB2_READFLAG_REQUEST_COMPRESSED);
+                    }
                     try {
                         final Smb2ReadResponse resp = th.send(request, RequestParam.NO_RETRY);
                         n = resp.getDataLength();

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbTransportImpl.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbTransportImpl.java
@@ -846,6 +846,13 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
                 return peekTransformedKey();
             }
 
+            if (this.sbuf[0] == (byte) 0x00 && this.sbuf[4] == (byte) 0xFC && this.sbuf[5] == (byte) 'S' && this.sbuf[6] == (byte) 'M'
+                    && this.sbuf[7] == (byte) 'B') {
+                // SMB2 COMPRESSION_TRANSFORM_HEADER, for the same reason as the encrypted case: the
+                // message id is inside the compressed data.
+                return peekCompressedKey();
+            }
+
             if (this.sbuf[0] == (byte) 0x00 && this.sbuf[1] == (byte) 0x00 && this.sbuf[4] == (byte) 0xFF && this.sbuf[5] == (byte) 'S'
                     && this.sbuf[6] == (byte) 'M' && this.sbuf[7] == (byte) 'B') {
                 break; /* all good (SMB) */
@@ -1252,6 +1259,104 @@ class SmbTransportImpl extends Transport implements SmbTransportInternal, SmbCon
         System.arraycopy(plaintext, 0, this.sbuf, 4, Smb2Constants.SMB2_HEADER_LENGTH);
 
         return (long) Encdec.dec_uint64le(this.sbuf, 28);
+    }
+
+    /**
+     * Reads and decompresses a complete SMB2 COMPRESSION_TRANSFORM_HEADER message, then presents the original
+     * message to the normal receive path, exactly as {@link #peekTransformedKey()} does for an encrypted one.
+     *
+     * <p>
+     * Every failure here throws rather than skipping the frame. MS-SMB2 3.2.5.1.1.2 requires the connection to be
+     * dropped when a compressed message cannot be read, and the reason is the stream rather than the message: a
+     * frame that cannot be decompressed cannot be measured either, so there is no way to find where the next one
+     * begins.
+     * </p>
+     *
+     * @return the message id of the decompressed message, or null at end of stream
+     */
+    private Long peekCompressedKey() throws IOException {
+        final int headerSize = org.codelibs.jcifs.smb.internal.smb2.compress.Smb2CompressionTransformHeader.HEADER_SIZE;
+        final int size = Encdec.dec_uint16be(this.sbuf, 2) & 0xFFFF | (this.sbuf[1] & 0xFF) << 16;
+        final int maximumBufferSize = getContext().getConfig().getMaximumBufferSize();
+        if (size < headerSize + Smb2Constants.SMB2_HEADER_LENGTH || size > maximumBufferSize + headerSize) {
+            throw new IOException("Invalid compressed message size: " + size);
+        }
+
+        final byte[] wire = new byte[size];
+        // peekKey has already pulled the NetBIOS header plus the first 32 bytes of the frame.
+        System.arraycopy(this.sbuf, 4, wire, 0, SmbConstants.SMB1_HEADER_LENGTH);
+        final int remaining = size - SmbConstants.SMB1_HEADER_LENGTH;
+        if (readn(this.in, wire, SmbConstants.SMB1_HEADER_LENGTH, remaining) < remaining) {
+            return null;
+        }
+
+        final byte[] original;
+        try {
+            final org.codelibs.jcifs.smb.internal.smb2.compress.Smb2CompressionTransformHeader header =
+                    org.codelibs.jcifs.smb.internal.smb2.compress.Smb2CompressionTransformHeader.decode(wire, 0, size);
+            if (header.isChained()) {
+                throw new IOException("Server sent a chained compressed message, which this client does not negotiate");
+            }
+            if (!isNegotiatedCompression(header.getAlgorithm())) {
+                throw new IOException("Server compressed with algorithm " + header.getAlgorithm() + ", which was not negotiated");
+            }
+            if (header.getOriginalSize() > maximumBufferSize) {
+                throw new IOException("Compressed message claims to expand to " + header.getOriginalSize() + " bytes");
+            }
+
+            // Everything between the header and Offset travels uncompressed, and the
+            // compressed segment follows it. Handing the declared size to the decompressor
+            // is what makes a misreading of either field an error rather than corruption:
+            // it produces the wrong number of bytes and says so.
+            final int dataStart = headerSize + header.getOffset();
+            final byte[] segment = org.codelibs.jcifs.smb.internal.smb2.compress.PlainLz77.decompress(wire, dataStart, size - dataStart,
+                    header.getOriginalSize());
+            original = new byte[header.getOffset() + segment.length];
+            System.arraycopy(wire, headerSize, original, 0, header.getOffset());
+            System.arraycopy(segment, 0, original, header.getOffset(), segment.length);
+        } catch (final SMBProtocolDecodingException e) {
+            throw new IOException("Failed to decompress message", e);
+        }
+
+        if (original.length < Smb2Constants.SMB2_HEADER_LENGTH) {
+            throw new IOException("Decompressed message is shorter than an SMB2 header");
+        }
+        if (original[0] != (byte) 0xFE || original[1] != (byte) 'S' || original[2] != (byte) 'M' || original[3] != (byte) 'B') {
+            throw new IOException("Decompressed message is not an SMB2 message");
+        }
+
+        this.smb2 = true;
+        this.transformPayload = original;
+        this.transformPayloadOffset = Smb2Constants.SMB2_HEADER_LENGTH;
+
+        // Present it exactly as an uncompressed message would have arrived.
+        this.sbuf[0] = 0;
+        this.sbuf[1] = (byte) (original.length >> 16);
+        this.sbuf[2] = (byte) (original.length >> 8);
+        this.sbuf[3] = (byte) original.length;
+        System.arraycopy(original, 0, this.sbuf, 4, Smb2Constants.SMB2_HEADER_LENGTH);
+
+        return (long) Encdec.dec_uint64le(this.sbuf, 28);
+    }
+
+    /**
+     * Whether an inbound message may be compressed with the given algorithm.
+     *
+     * @param algorithm the algorithm named in the compression transform header
+     * @return true only when that algorithm was agreed during negotiation
+     */
+    private boolean isNegotiatedCompression(final int algorithm) throws SmbException {
+        if (getNegotiateResponse() instanceof final Smb2NegotiateResponse resp) {
+            final int[] negotiated = resp.getCompressionAlgorithms();
+            if (negotiated != null) {
+                for (final int candidate : negotiated) {
+                    if (candidate == algorithm) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/org/codelibs/jcifs/smb/impl/SmbTreeHandleImpl.java
+++ b/src/main/java/org/codelibs/jcifs/smb/impl/SmbTreeHandleImpl.java
@@ -309,6 +309,19 @@ class SmbTreeHandleImpl implements SmbTreeHandleInternal {
     }
 
     /**
+     * Whether a message on this connection may arrive compressed.
+     *
+     * @return true when compression was negotiated with the server
+     * @throws SmbException if the connection cannot be established
+     */
+    boolean isCompressionNegotiated() throws SmbException {
+        try (SmbSessionImpl session = this.treeConnection.getSession(); SmbTransportImpl transport = session.getTransport()) {
+            return transport.getNegotiateResponse() instanceof final org.codelibs.jcifs.smb.internal.smb2.nego.Smb2NegotiateResponse resp
+                    && resp.isCompressionNegotiated();
+        }
+    }
+
+    /**
      * @return whether this tree handle uses SMB2
      */
     @Override

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/compress/PlainLz77.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/compress/PlainLz77.java
@@ -1,0 +1,185 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package org.codelibs.jcifs.smb.internal.smb2.compress;
+
+import org.codelibs.jcifs.smb.internal.SMBProtocolDecodingException;
+import org.codelibs.jcifs.smb.internal.util.SMBUtil;
+
+/**
+ * Plain LZ77 (XPRESS) decompression, MS-XCA 2.4.
+ *
+ * <p>
+ * Decompression only. A client is never obliged to compress what it sends, and
+ * this one does not, so only the reading half of the format is implemented.
+ * </p>
+ *
+ * <p>
+ * The format: a 32-bit little-endian indicator word whose bits are consumed from
+ * the top down, a zero bit meaning a literal byte and a one bit meaning a match.
+ * A match is a 16-bit little-endian word holding a 13-bit distance and a 3-bit
+ * length, each biased. A length of 7 escapes to a 4-bit nibble, 15 to a byte, 255
+ * to 16 bits and 0 to 32 bits.
+ * </p>
+ *
+ * <p>
+ * The nibble is the part worth reading twice: one byte carries the nibbles of two
+ * consecutive matches, the first taking its low half and the second the high half
+ * of that same byte, which is why the position is remembered rather than the
+ * value. Deriving the arithmetic from the specification's worked examples instead
+ * gets this right for those examples and wrong for a long match.
+ * </p>
+ */
+public final class PlainLz77 {
+
+    /** A match is at least this long, and the encoded length is the excess over it. */
+    private static final int MIN_MATCH = 3;
+
+    /** The 3-bit length field escapes to a nibble at this value. */
+    private static final int LENGTH_ESCAPE = 7;
+
+    /** The nibble escapes to a byte at this value. */
+    private static final int NIBBLE_ESCAPE = 15;
+
+    /** The byte escapes to sixteen bits at this value. */
+    private static final int BYTE_ESCAPE = 255;
+
+    private PlainLz77() {
+    }
+
+    /**
+     * Decompresses a plain LZ77 segment.
+     *
+     * @param input            the compressed bytes
+     * @param inputIndex       where the compressed data starts
+     * @param inputLength      how many compressed bytes there are
+     * @param originalSize     the decompressed size the sender declared
+     * @return the decompressed bytes, exactly {@code originalSize} of them
+     * @throws SMBProtocolDecodingException if the data is malformed or does not produce that size
+     */
+    public static byte[] decompress(final byte[] input, final int inputIndex, final int inputLength, final int originalSize)
+            throws SMBProtocolDecodingException {
+        if (inputIndex < 0 || inputLength < 0 || originalSize < 0 || (long) inputIndex + inputLength > input.length) {
+            throw new SMBProtocolDecodingException("Compressed segment lies outside the message");
+        }
+
+        final byte[] output = new byte[originalSize];
+        final int inputEnd = inputIndex + inputLength;
+        int in = inputIndex;
+        int out = 0;
+        int indicator = 0;
+        int indicatorBit = 0;
+        // The position of the byte holding a pending high nibble, or 0 for none. A
+        // position is kept rather than the value because the byte is shared with the
+        // next match, which reads its high half.
+        int nibbleIndex = 0;
+
+        while (out < originalSize && in < inputEnd) {
+            if (indicatorBit == 0) {
+                if (in + 4 > inputEnd) {
+                    throw new SMBProtocolDecodingException("Truncated indicator word");
+                }
+                indicator = SMBUtil.readInt4(input, in);
+                in += 4;
+                if (in == inputEnd) {
+                    // Flags written for data that was never emitted.
+                    break;
+                }
+                indicatorBit = 32;
+            }
+            indicatorBit--;
+
+            if ((indicator >>> indicatorBit & 1) == 0) {
+                if (in + 1 > inputEnd || out + 1 > originalSize) {
+                    throw new SMBProtocolDecodingException("Truncated literal");
+                }
+                output[out] = input[in];
+                in++;
+                out++;
+                continue;
+            }
+
+            if (in + 2 > inputEnd) {
+                throw new SMBProtocolDecodingException("Truncated match");
+            }
+            final int match = SMBUtil.readInt2(input, in);
+            in += 2;
+            final int distance = (match >>> 3) + 1;
+            int length = match & 7;
+
+            if (length == LENGTH_ESCAPE) {
+                if (nibbleIndex == 0) {
+                    if (in + 1 > inputEnd) {
+                        throw new SMBProtocolDecodingException("Truncated match length nibble");
+                    }
+                    nibbleIndex = in;
+                    length = input[in] & 0x0F;
+                    in++;
+                } else {
+                    length = (input[nibbleIndex] & 0xFF) >>> 4;
+                    nibbleIndex = 0;
+                }
+
+                if (length == NIBBLE_ESCAPE) {
+                    if (in + 1 > inputEnd) {
+                        throw new SMBProtocolDecodingException("Truncated match length byte");
+                    }
+                    length = input[in] & 0xFF;
+                    in++;
+                    if (length == BYTE_ESCAPE) {
+                        if (in + 2 > inputEnd) {
+                            throw new SMBProtocolDecodingException("Truncated match length word");
+                        }
+                        length = SMBUtil.readInt2(input, in);
+                        in += 2;
+                        if (length == 0) {
+                            if (in + 4 > inputEnd) {
+                                throw new SMBProtocolDecodingException("Truncated match length long word");
+                            }
+                            length = SMBUtil.readInt4(input, in);
+                            in += 4;
+                        }
+                        if (length < NIBBLE_ESCAPE + LENGTH_ESCAPE) {
+                            throw new SMBProtocolDecodingException("Match length " + length + " is below its own encoding");
+                        }
+                        length -= NIBBLE_ESCAPE + LENGTH_ESCAPE;
+                    }
+                    length += NIBBLE_ESCAPE;
+                }
+                length += LENGTH_ESCAPE;
+            }
+            length += MIN_MATCH;
+
+            if (distance > out) {
+                throw new SMBProtocolDecodingException("Match reaches back past the start of the data");
+            }
+            if (length < 0 || out + length > originalSize) {
+                throw new SMBProtocolDecodingException("Match runs past the declared decompressed size");
+            }
+            // One byte at a time on purpose: the length may exceed the distance, which
+            // is how a run is encoded, and a bulk copy would read bytes it has not
+            // written yet.
+            for (int i = 0; i < length; i++) {
+                output[out] = output[out - distance];
+                out++;
+            }
+        }
+
+        if (out != originalSize) {
+            throw new SMBProtocolDecodingException("Decompressed " + out + " bytes, the sender declared " + originalSize);
+        }
+        return output;
+    }
+}

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/compress/Smb2CompressionTransformHeader.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/compress/Smb2CompressionTransformHeader.java
@@ -1,0 +1,133 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package org.codelibs.jcifs.smb.internal.smb2.compress;
+
+import org.codelibs.jcifs.smb.internal.SMBProtocolDecodingException;
+import org.codelibs.jcifs.smb.internal.util.SMBUtil;
+
+/**
+ * SMB2_COMPRESSION_TRANSFORM_HEADER_UNCHAINED, MS-SMB2 2.2.42.1.
+ *
+ * <p>
+ * Reading only. This client never compresses what it sends, so the header is
+ * parsed and never written. The chained form, 2.2.42.2, is not read either: it
+ * only arrives when both ends set the chained flag, and this client does not.
+ * </p>
+ */
+public final class Smb2CompressionTransformHeader {
+
+    /** The header is a fixed sixteen bytes. */
+    public static final int HEADER_SIZE = 16;
+
+    /** ProtocolId, 0xFC 'S' 'M' 'B' on the wire. */
+    public static final int PROTOCOL_ID = 0x424D53FC;
+
+    /** Flags value for the unchained form. */
+    public static final int FLAG_NONE = 0x0;
+
+    /** Flags value that makes the header the chained form instead. */
+    public static final int FLAG_CHAINED = 0x1;
+
+    private final int originalSize;
+    private final int algorithm;
+    private final int flags;
+    private final int offset;
+
+    private Smb2CompressionTransformHeader(final int originalSize, final int algorithm, final int flags, final int offset) {
+        this.originalSize = originalSize;
+        this.algorithm = algorithm;
+        this.flags = flags;
+        this.offset = offset;
+    }
+
+    /**
+     * The size the sender says the decompressed segment has.
+     *
+     * @return the declared decompressed size in bytes
+     */
+    public int getOriginalSize() {
+        return this.originalSize;
+    }
+
+    /**
+     * The algorithm the segment was compressed with, never NONE.
+     *
+     * @return the compression algorithm identifier
+     */
+    public int getAlgorithm() {
+        return this.algorithm;
+    }
+
+    /**
+     * The header flags, which decide whether this is the chained form.
+     *
+     * @return {@link #FLAG_NONE} or {@link #FLAG_CHAINED}
+     */
+    public int getFlags() {
+        return this.flags;
+    }
+
+    /**
+     * How far past the end of this header the compressed segment starts. What lies
+     * in between is carried uncompressed.
+     *
+     * @return the offset in bytes from the end of the header
+     */
+    public int getOffset() {
+        return this.offset;
+    }
+
+    /**
+     * Whether this is the chained form, which this client does not negotiate and
+     * cannot read.
+     *
+     * @return true when the chained flag is set
+     */
+    public boolean isChained() {
+        return (this.flags & FLAG_CHAINED) != 0;
+    }
+
+    /**
+     * Parses a compression transform header.
+     *
+     * @param buffer      the message
+     * @param bufferIndex where the header starts
+     * @param len         how many bytes of the message are available from there
+     * @return the parsed header
+     * @throws SMBProtocolDecodingException if the header is truncated or is not one
+     */
+    public static Smb2CompressionTransformHeader decode(final byte[] buffer, final int bufferIndex, final int len)
+            throws SMBProtocolDecodingException {
+        if (len < HEADER_SIZE || bufferIndex < 0 || (long) bufferIndex + HEADER_SIZE > buffer.length) {
+            throw new SMBProtocolDecodingException("Message is shorter than a compression transform header");
+        }
+        if (SMBUtil.readInt4(buffer, bufferIndex) != PROTOCOL_ID) {
+            throw new SMBProtocolDecodingException("Not a compression transform header");
+        }
+        final int originalSize = SMBUtil.readInt4(buffer, bufferIndex + 4);
+        final int algorithm = SMBUtil.readInt2(buffer, bufferIndex + 8);
+        final int flags = SMBUtil.readInt2(buffer, bufferIndex + 10);
+        final int offset = SMBUtil.readInt4(buffer, bufferIndex + 12);
+
+        if (originalSize < 0) {
+            throw new SMBProtocolDecodingException("Compressed segment declares a negative decompressed size");
+        }
+        if (offset < 0 || (long) HEADER_SIZE + offset > len) {
+            throw new SMBProtocolDecodingException("Compressed segment starts past the end of the message");
+        }
+        return new Smb2CompressionTransformHeader(originalSize, algorithm, flags, offset);
+    }
+}

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/io/Smb2ReadRequest.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/io/Smb2ReadRequest.java
@@ -39,6 +39,12 @@ public class Smb2ReadRequest extends ServerMessageBlock2Request<Smb2ReadResponse
      */
     public static byte SMB2_READFLAG_READ_UNBUFFERED = 0x1;
     /**
+     * Asks the server to compress the response (SMB 3.1.1). Without this a server
+     * decides for itself whether to compress what it sends, so setting it is what
+     * makes a compressed reply something the client can rely on rather than hope for.
+     */
+    public static byte SMB2_READFLAG_REQUEST_COMPRESSED = 0x2;
+    /**
      * Channel type for standard read without RDMA
      */
     public static int SMB2_CHANNEL_NONE = 0x0;

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/nego/CompressionNegotiateContext.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/nego/CompressionNegotiateContext.java
@@ -1,0 +1,217 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package org.codelibs.jcifs.smb.internal.smb2.nego;
+
+import org.codelibs.jcifs.smb.Configuration;
+import org.codelibs.jcifs.smb.internal.SMBProtocolDecodingException;
+import org.codelibs.jcifs.smb.internal.util.SMBUtil;
+
+/**
+ * SMB2_COMPRESSION_CAPABILITIES, MS-SMB2 2.2.3.1.3 and 2.2.4.1.3.
+ *
+ * <p>
+ * The request names the algorithms the client can handle, in order of
+ * preference. The response takes the same shape and names what the server
+ * picked from them - which is a selection rather than a statement of what the
+ * server supports: Windows Server 2025 answers an offer of all five algorithms
+ * with two of them, and answers an offer of one with that one.
+ * </p>
+ *
+ * <p>
+ * That is why a client offers only what it can actually decompress. MS-SMB2
+ * 3.2.5.2 requires the connection to fail if the server names an algorithm the
+ * client did not offer, so the offer is a promise, not a wish.
+ * </p>
+ */
+public class CompressionNegotiateContext implements NegotiateContextRequest, NegotiateContextResponse {
+
+    /**
+     * Context type
+     */
+    public static final int NEGO_CTX_COMPRESSION_TYPE = 0x3;
+
+    /**
+     * No compression
+     */
+    public static final int COMPRESSION_NONE = 0x0;
+
+    /**
+     * LZNT1, the NTFS compression format
+     */
+    public static final int COMPRESSION_LZNT1 = 0x1;
+
+    /**
+     * Plain LZ77, also called XPRESS
+     */
+    public static final int COMPRESSION_LZ77 = 0x2;
+
+    /**
+     * LZ77 with Huffman coding, also called XPRESS Huffman
+     */
+    public static final int COMPRESSION_LZ77_HUFFMAN = 0x3;
+
+    /**
+     * A run of one repeated byte, only meaningful inside a chained message
+     */
+    public static final int COMPRESSION_PATTERN_V1 = 0x4;
+
+    /**
+     * LZ4, added in Windows Server 2025
+     */
+    public static final int COMPRESSION_LZ4 = 0x5;
+
+    /**
+     * Chained compression is not supported
+     */
+    public static final int FLAG_NONE = 0x0;
+
+    /**
+     * Chained compression is supported on this connection
+     */
+    public static final int FLAG_CHAINED = 0x1;
+
+    /**
+     * An algorithm identifier at or above this value is invalid (MS-SMB2 3.2.5.2).
+     */
+    private static final int ALGORITHM_LIMIT = 32;
+
+    /** CompressionAlgorithmCount, Padding and Flags, ahead of the identifiers. */
+    private static final int PREAMBLE_SIZE = 8;
+
+    private int[] algorithms;
+    private int flags;
+
+    /**
+     * Constructs a compression negotiate context.
+     *
+     * @param config     the configuration (currently unused)
+     * @param algorithms the compression algorithm identifiers to offer, in preference order
+     */
+    public CompressionNegotiateContext(final Configuration config, final int[] algorithms) {
+        this.algorithms = algorithms;
+        this.flags = FLAG_NONE;
+    }
+
+    /**
+     * Default constructor for decoding.
+     */
+    public CompressionNegotiateContext() {
+    }
+
+    /**
+     * Gets the compression algorithms.
+     *
+     * @return the algorithm identifiers, in the order they appeared
+     */
+    public int[] getAlgorithms() {
+        return this.algorithms;
+    }
+
+    /**
+     * Gets the context flags.
+     *
+     * @return {@link #FLAG_CHAINED} when chained compression is supported, otherwise {@link #FLAG_NONE}
+     */
+    public int getFlags() {
+        return this.flags;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.codelibs.jcifs.smb.internal.smb2.nego.NegotiateContextRequest#getContextType()
+     */
+    @Override
+    public int getContextType() {
+        return NEGO_CTX_COMPRESSION_TYPE;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.codelibs.jcifs.smb.Encodable#encode(byte[], int)
+     */
+    @Override
+    public int encode(final byte[] dst, int dstIndex) {
+        final int start = dstIndex;
+        final int count = this.algorithms != null ? this.algorithms.length : 0;
+        SMBUtil.writeInt2(count, dst, dstIndex);
+        dstIndex += 2;
+        SMBUtil.writeInt2(0, dst, dstIndex); // Padding, the sender must set this to zero
+        dstIndex += 2;
+        SMBUtil.writeInt4(this.flags, dst, dstIndex);
+        dstIndex += 4;
+
+        if (this.algorithms != null) {
+            for (final int algorithm : this.algorithms) {
+                SMBUtil.writeInt2(algorithm, dst, dstIndex);
+                dstIndex += 2;
+            }
+        }
+        return dstIndex - start;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.codelibs.jcifs.smb.Decodable#decode(byte[], int, int)
+     */
+    @Override
+    public int decode(final byte[] buffer, int bufferIndex, final int len) throws SMBProtocolDecodingException {
+        if (len < PREAMBLE_SIZE) {
+            throw new SMBProtocolDecodingException("Compression negotiate context is shorter than its own header");
+        }
+        final int start = bufferIndex;
+        final int count = SMBUtil.readInt2(buffer, bufferIndex);
+        bufferIndex += 2;
+        bufferIndex += 2; // Padding, ignored on receipt
+        this.flags = SMBUtil.readInt4(buffer, bufferIndex);
+        bufferIndex += 4;
+
+        if (count == 0) {
+            throw new SMBProtocolDecodingException("Compression negotiate context names no algorithm");
+        }
+        if (PREAMBLE_SIZE + 2 * count > len || (long) bufferIndex + 2L * count > buffer.length) {
+            throw new SMBProtocolDecodingException("Compression negotiate context runs past its own length");
+        }
+
+        this.algorithms = new int[count];
+        for (int i = 0; i < count; i++) {
+            this.algorithms[i] = SMBUtil.readInt2(buffer, bufferIndex);
+            bufferIndex += 2;
+            if (this.algorithms[i] >= ALGORITHM_LIMIT) {
+                throw new SMBProtocolDecodingException("Invalid compression algorithm " + this.algorithms[i]);
+            }
+            for (int j = 0; j < i; j++) {
+                if (this.algorithms[j] == this.algorithms[i]) {
+                    throw new SMBProtocolDecodingException("Duplicate compression algorithm " + this.algorithms[i]);
+                }
+            }
+        }
+
+        return bufferIndex - start;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.codelibs.jcifs.smb.Encodable#size()
+     */
+    @Override
+    public int size() {
+        return PREAMBLE_SIZE + (this.algorithms != null ? 2 * this.algorithms.length : 0);
+    }
+}

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/nego/Smb2NegotiateRequest.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/nego/Smb2NegotiateRequest.java
@@ -101,6 +101,14 @@ public class Smb2NegotiateRequest extends ServerMessageBlock2Request<Smb2Negotia
                 negoContexts.add(new EncryptionNegotiateContext(config, config.getEncryptionCiphers()));
             }
 
+            if (config.isCompressionEnabled()) {
+                // Only what this client can actually decompress is offered, and that is not
+                // configurable. MS-SMB2 3.2.5.2 requires the connection to fail if the server
+                // names an algorithm that was not offered, so offering one we cannot read would
+                // turn a working connection into a broken one.
+                negoContexts.add(new CompressionNegotiateContext(config, new int[] { CompressionNegotiateContext.COMPRESSION_LZ77 }));
+            }
+
             // Unconditionally, unlike the encryption context: signing is negotiated whether or not encryption is
             // in use, and a signed but unencrypted session is the ordinary case. Without this context a 3.1.1
             // server signs with AES-128-CMAC (MS-SMB2 3.3.5.4), which is what the client did before.

--- a/src/main/java/org/codelibs/jcifs/smb/internal/smb2/nego/Smb2NegotiateResponse.java
+++ b/src/main/java/org/codelibs/jcifs/smb/internal/smb2/nego/Smb2NegotiateResponse.java
@@ -67,6 +67,12 @@ public class Smb2NegotiateResponse extends ServerMessageBlock2Response implement
     private int selectedCipher = -1;
     private int selectedPreauthHash = -1;
     private int selectedSigningAlgorithm = -1;
+    /**
+     * What the server agreed to compress with, empty when it declined and null when
+     * compression was never asked for. Empty and null are kept apart because only the
+     * first means the question was put and answered.
+     */
+    private int[] compressionAlgorithms;
 
     /**
      * Constructs an SMB2 negotiate response with the given configuration.
@@ -120,6 +126,25 @@ public class Smb2NegotiateResponse extends ServerMessageBlock2Response implement
      */
     public int getSelectedCipher() {
         return this.selectedCipher;
+    }
+
+    /**
+     * Gets the compression algorithms the server agreed to.
+     *
+     * @return the agreed algorithms, an empty array if the server declined, or null if
+     *         compression was not negotiated at all
+     */
+    public int[] getCompressionAlgorithms() {
+        return this.compressionAlgorithms;
+    }
+
+    /**
+     * Whether a message on this connection may arrive compressed.
+     *
+     * @return true when at least one compression algorithm was agreed
+     */
+    public boolean isCompressionNegotiated() {
+        return this.compressionAlgorithms != null && this.compressionAlgorithms.length > 0;
     }
 
     /**
@@ -336,7 +361,7 @@ public class Smb2NegotiateResponse extends ServerMessageBlock2Response implement
             return false;
         }
 
-        boolean foundPreauth = false, foundEnc = false, foundSigning = false;
+        boolean foundPreauth = false, foundEnc = false, foundSigning = false, foundCompression = false;
         for (final NegotiateContextResponse ncr : this.negotiateContexts) {
             if (ncr == null) {
                 continue;
@@ -352,6 +377,27 @@ public class Smb2NegotiateResponse extends ServerMessageBlock2Response implement
             }
             if (ncr.getContextType() == SigningNegotiateContext.NEGO_CTX_SIGNING_TYPE) {
                 log.error("Multiple signing negotiate contexts");
+                return false;
+            }
+            if (!foundCompression && ncr.getContextType() == CompressionNegotiateContext.NEGO_CTX_COMPRESSION_TYPE) {
+                foundCompression = true;
+                final CompressionNegotiateContext comp = (CompressionNegotiateContext) ncr;
+                final int[] selected = comp.getAlgorithms();
+                if (selected.length == 1 && selected[0] == CompressionNegotiateContext.COMPRESSION_NONE) {
+                    // MS-SMB2 3.2.5.2: NONE on its own is the server declining, which is not
+                    // an error. Recording it as an empty list rather than failing is what
+                    // keeps a connection to such a server working exactly as it did before.
+                    this.compressionAlgorithms = new int[0];
+                    continue;
+                }
+                if (!checkCompressionContext(req, comp)) {
+                    return false;
+                }
+                this.compressionAlgorithms = selected;
+                continue;
+            }
+            if (ncr.getContextType() == CompressionNegotiateContext.NEGO_CTX_COMPRESSION_TYPE) {
+                log.error("Multiple compression negotiate contexts");
                 return false;
             }
             if (!foundEnc && ncr.getContextType() == EncryptionNegotiateContext.NEGO_CTX_ENC_TYPE) {
@@ -484,6 +530,41 @@ public class Smb2NegotiateResponse extends ServerMessageBlock2Response implement
         if (!valid) {
             log.error("Server returned invalid cipher selection");
             return false;
+        }
+        return true;
+    }
+
+    private static boolean checkCompressionContext(final Smb2NegotiateRequest req, final CompressionNegotiateContext cc) {
+        if (cc.getAlgorithms() == null || cc.getAlgorithms().length == 0) {
+            log.error("Server returned no compression selection");
+            return false;
+        }
+
+        CompressionNegotiateContext offered = null;
+        for (final NegotiateContextRequest rnc : req.getNegotiateContexts()) {
+            if (rnc instanceof CompressionNegotiateContext) {
+                offered = (CompressionNegotiateContext) rnc;
+            }
+        }
+        if (offered == null) {
+            log.error("Server returned a compression selection that was never asked for");
+            return false;
+        }
+
+        // MS-SMB2 3.2.5.2: every algorithm named has to be one that was offered. The
+        // offer says what this client can decompress, so agreeing to anything else
+        // would be promising to read something it cannot.
+        for (final int selected : cc.getAlgorithms()) {
+            boolean offeredIt = false;
+            for (final int algorithm : offered.getAlgorithms()) {
+                if (algorithm == selected) {
+                    offeredIt = true;
+                }
+            }
+            if (!offeredIt) {
+                log.error("Server selected compression algorithm " + selected + ", which was not offered");
+                return false;
+            }
         }
         return true;
     }
@@ -654,6 +735,8 @@ public class Smb2NegotiateResponse extends ServerMessageBlock2Response implement
      */
     protected static NegotiateContextResponse createContext(final int type) {
         switch (type) {
+        case CompressionNegotiateContext.NEGO_CTX_COMPRESSION_TYPE:
+            return new CompressionNegotiateContext();
         case EncryptionNegotiateContext.NEGO_CTX_ENC_TYPE:
             return new EncryptionNegotiateContext();
         case PreauthIntegrityNegotiateContext.NEGO_CTX_PREAUTH_TYPE:

--- a/src/test/java/org/codelibs/jcifs/smb/impl/SmbCompressionProbe.java
+++ b/src/test/java/org/codelibs/jcifs/smb/impl/SmbCompressionProbe.java
@@ -1,0 +1,48 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.impl;
+
+import org.codelibs.jcifs.smb.CIFSException;
+
+/**
+ * Test-only access to whether a connection negotiated compression.
+ *
+ * <p>
+ * Without this a test cannot tell a server that compressed the reply from one
+ * that quietly did not, and an assertion that only checks the bytes would pass
+ * either way. It sits in the implementation package because the state hangs off
+ * {@code SmbTreeHandleImpl}, which is package private, the same way
+ * {@code SmbBufferSizeProbe} does.
+ * </p>
+ */
+public final class SmbCompressionProbe {
+
+    private SmbCompressionProbe() {
+    }
+
+    /**
+     * Whether the connection this file is reached through negotiated compression.
+     *
+     * @param file any file on the connection to ask about
+     * @return true when the server agreed to at least one compression algorithm
+     * @throws CIFSException if the connection cannot be established
+     */
+    public static boolean negotiated(final SmbFile file) throws CIFSException {
+        try (SmbTreeHandleImpl th = (SmbTreeHandleImpl) file.getTreeHandle()) {
+            return th.isCompressionNegotiated();
+        }
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/compress/PlainLz77Test.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/compress/PlainLz77Test.java
@@ -1,0 +1,131 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.internal.smb2.compress;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.charset.StandardCharsets;
+
+import org.codelibs.jcifs.smb.internal.SMBProtocolDecodingException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The two worked examples in MS-XCA 2.4, plus the cases they do not reach.
+ */
+class PlainLz77Test {
+
+    private static byte[] hex(final String spaced) {
+        final String[] parts = spaced.trim().split("\\s+");
+        final byte[] out = new byte[parts.length];
+        for (int i = 0; i < parts.length; i++) {
+            out[i] = (byte) Integer.parseInt(parts[i], 16);
+        }
+        return out;
+    }
+
+    private static String decompress(final byte[] input, final int originalSize) throws Exception {
+        return new String(PlainLz77.decompress(input, 0, input.length, originalSize), StandardCharsets.US_ASCII);
+    }
+
+    @Test
+    @DisplayName("the specification's all-literal example")
+    void decompressesTheLiteralExample() throws Exception {
+        // 26 zero flag bits for 26 literals, then six one-bits of padding: 0x0000003F
+        // read from the top down.
+        final byte[] compressed = hex("3f 00 00 00 61 62 63 64 65 66 67 68 69 6a 6b 6c 6d 6e 6f 70 71 72 73 74 75 76 77 78 79 7a");
+
+        assertEquals("abcdefghijklmnopqrstuvwxyz", decompress(compressed, 26));
+    }
+
+    @Test
+    @DisplayName("the specification's long-match example, whose match is longer than its distance")
+    void decompressesTheLongMatchExample() throws Exception {
+        // abc, then a match of distance 3 and length 297. The length escapes through
+        // the nibble (15) and the byte (255) to a 16-bit 294, which is 297 once the
+        // encoding's own bias is taken back off.
+        final byte[] compressed = hex("ff ff ff 1f 61 62 63 17 00 0f ff 26 01");
+
+        final String expected = "abc".repeat(100);
+        assertEquals(300, expected.length());
+        assertEquals(expected, decompress(compressed, 300));
+    }
+
+    @Test
+    @DisplayName("two consecutive matches share one nibble byte")
+    void sharesTheNibbleByteBetweenTwoMatches() throws Exception {
+        // Four literals, then two matches that both escape to a nibble. The first
+        // takes the low half of the single nibble byte and the second takes the high
+        // half of that same byte - so the byte appears once, between the two match
+        // words, and the second match reads backwards into it.
+        //
+        // flags 0x0FFFFFFF: bits 31..28 clear for the literals, 27 and 26 set for the
+        // matches, the rest padding. Each match word 0x001F is distance 4, length 7.
+        // The nibble byte 0x32 gives the first match 2 and the second 3, so the
+        // lengths are 2+7+3 = 12 and 3+7+3 = 13.
+        final byte[] compressed = hex("ff ff ff 0f 61 62 63 64 1f 00 32 1f 00");
+
+        // 4 literals + 12 + 13 = 29 bytes of "abcd" repeating.
+        final String expected = "abcd".repeat(8).substring(0, 29);
+        assertEquals("abcdabcdabcdabcdabcdabcdabcda", expected);
+        assertEquals(expected, decompress(compressed, 29));
+    }
+
+    @Test
+    @DisplayName("a match reaching back before the start is refused")
+    void refusesAMatchBeforeTheStart() {
+        // One literal, then a match of distance 4 with only one byte written.
+        final byte[] compressed = hex("ff ff ff 7f 61 1f 00");
+
+        assertThrows(SMBProtocolDecodingException.class, () -> PlainLz77.decompress(compressed, 0, compressed.length, 16));
+    }
+
+    @Test
+    @DisplayName("data that does not produce the declared size is refused")
+    void refusesAShortResult() {
+        final byte[] compressed = hex("3f 00 00 00 61 62 63");
+
+        assertThrows(SMBProtocolDecodingException.class, () -> PlainLz77.decompress(compressed, 0, compressed.length, 26));
+    }
+
+    @Test
+    @DisplayName("a truncated indicator word is refused")
+    void refusesATruncatedIndicator() {
+        final byte[] compressed = hex("3f 00");
+
+        assertThrows(SMBProtocolDecodingException.class, () -> PlainLz77.decompress(compressed, 0, compressed.length, 4));
+    }
+
+    @Test
+    @DisplayName("a segment outside the message is refused")
+    void refusesASegmentOutsideTheMessage() {
+        final byte[] compressed = hex("3f 00 00 00 61");
+
+        assertThrows(SMBProtocolDecodingException.class, () -> PlainLz77.decompress(compressed, 2, compressed.length, 1));
+    }
+
+    @Test
+    @DisplayName("the segment is read from the offset it is given")
+    void decompressesAtAnOffset() throws Exception {
+        final byte[] framed = hex("de ad be ef 3f 00 00 00 61 62 63");
+
+        final byte[] out = PlainLz77.decompress(framed, 4, framed.length - 4, 3);
+
+        assertArrayEquals("abc".getBytes(StandardCharsets.US_ASCII), out);
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/internal/smb2/nego/CompressionNegotiateContextTest.java
+++ b/src/test/java/org/codelibs/jcifs/smb/internal/smb2/nego/CompressionNegotiateContextTest.java
@@ -1,0 +1,116 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.internal.smb2.nego;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.Arrays;
+
+import org.codelibs.jcifs.smb.internal.SMBProtocolDecodingException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CompressionNegotiateContextTest {
+
+    @Test
+    @DisplayName("the context type is 0x3")
+    void contextTypeIsThree() {
+        assertEquals(0x3, new CompressionNegotiateContext().getContextType());
+    }
+
+    @Test
+    @DisplayName("the offer is a count, a zero padding, the flags and then the identifiers")
+    void encodesThePreambleThenTheAlgorithms() {
+        final CompressionNegotiateContext ctx =
+                new CompressionNegotiateContext(null, new int[] { CompressionNegotiateContext.COMPRESSION_LZ77 });
+        final byte[] dst = new byte[32];
+        Arrays.fill(dst, (byte) 0xFF);
+
+        final int written = ctx.encode(dst, 0);
+
+        assertEquals(10, written);
+        assertEquals(10, ctx.size(), "size has to cover what encode writes");
+        assertArrayEquals(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0, 2, 0 }, Arrays.copyOfRange(dst, 0, 10));
+    }
+
+    @Test
+    @DisplayName("what the server selected is read back")
+    void decodesTheServerSelection() throws Exception {
+        // count 2, padding 0, flags 0, LZNT1 and Pattern_V1 - which is what Windows
+        // Server 2025 answers when offered all five.
+        final byte[] wire = { 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 4, 0 };
+        final CompressionNegotiateContext ctx = new CompressionNegotiateContext();
+
+        assertEquals(12, ctx.decode(wire, 0, wire.length));
+
+        assertArrayEquals(new int[] { CompressionNegotiateContext.COMPRESSION_LZNT1, CompressionNegotiateContext.COMPRESSION_PATTERN_V1 },
+                ctx.getAlgorithms());
+        assertEquals(CompressionNegotiateContext.FLAG_NONE, ctx.getFlags());
+        assertFalse(ctx.getFlags() == CompressionNegotiateContext.FLAG_CHAINED);
+    }
+
+    @Test
+    @DisplayName("the chained flag is read back")
+    void decodesTheChainedFlag() throws Exception {
+        final byte[] wire = { 1, 0, 0, 0, 1, 0, 0, 0, 2, 0 };
+        final CompressionNegotiateContext ctx = new CompressionNegotiateContext();
+
+        ctx.decode(wire, 0, wire.length);
+
+        assertEquals(CompressionNegotiateContext.FLAG_CHAINED, ctx.getFlags());
+    }
+
+    @Test
+    @DisplayName("a context shorter than its own header is refused")
+    void refusesAShortContext() {
+        final byte[] wire = { 1, 0, 0, 0, 0, 0, 0 };
+        assertThrows(SMBProtocolDecodingException.class, () -> new CompressionNegotiateContext().decode(wire, 0, wire.length));
+    }
+
+    @Test
+    @DisplayName("a context naming no algorithm is refused")
+    void refusesAnEmptySelection() {
+        // MS-SMB2 3.2.5.2: CompressionAlgorithmCount of zero is an error.
+        final byte[] wire = { 0, 0, 0, 0, 0, 0, 0, 0 };
+        assertThrows(SMBProtocolDecodingException.class, () -> new CompressionNegotiateContext().decode(wire, 0, wire.length));
+    }
+
+    @Test
+    @DisplayName("a context claiming more algorithms than it carries is refused")
+    void refusesACountPastTheEnd() {
+        final byte[] wire = { 4, 0, 0, 0, 0, 0, 0, 0, 2, 0 };
+        assertThrows(SMBProtocolDecodingException.class, () -> new CompressionNegotiateContext().decode(wire, 0, wire.length));
+    }
+
+    @Test
+    @DisplayName("an identifier at or above 32 is refused")
+    void refusesAnOutOfRangeAlgorithm() {
+        // MS-SMB2 3.2.5.2 names 32 as the limit.
+        final byte[] wire = { 1, 0, 0, 0, 0, 0, 0, 0, 32, 0 };
+        assertThrows(SMBProtocolDecodingException.class, () -> new CompressionNegotiateContext().decode(wire, 0, wire.length));
+    }
+
+    @Test
+    @DisplayName("a repeated identifier is refused")
+    void refusesADuplicate() {
+        // MS-SMB2 3.2.5.2: a duplicate in the list is an error.
+        final byte[] wire = { 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 2, 0 };
+        assertThrows(SMBProtocolDecodingException.class, () -> new CompressionNegotiateContext().decode(wire, 0, wire.length));
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/it/CompressionIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/CompressionIT.java
@@ -1,0 +1,123 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.codelibs.jcifs.smb.it;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.impl.SmbFile;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Payloads survive a round trip whatever they are made of.
+ *
+ * <p>
+ * These assert nothing about compression, and deliberately so: they are the net
+ * under it. A message may be compressed or not, by either end, for reasons the
+ * client does not control - so what a caller can rely on is that the bytes it
+ * reads back are the bytes it wrote, for content that compresses well, content
+ * that does not compress at all, and content too small to be worth compressing.
+ * </p>
+ *
+ * <p>
+ * The payload is larger than a single read or write request, so it spans several
+ * messages. That matters here because compression applies per message: a defect
+ * that only shows on the second message would otherwise go unseen.
+ * </p>
+ */
+class CompressionIT extends AbstractSmbIT {
+
+    /** Larger than the default one-mebibyte transfer size, so a transfer is several messages. */
+    private static final int PAYLOAD = 2 * 1024 * 1024;
+
+    private SmbFile workDir;
+
+    @AfterEach
+    void removeWorkDir() {
+        deleteQuietly(this.workDir);
+    }
+
+    @Test
+    @DisplayName("a payload that compresses well comes back byte for byte")
+    void compressiblePayloadRoundTrips() throws Exception {
+        assertRoundTrip("compressible.txt", compressible(PAYLOAD));
+    }
+
+    @Test
+    @DisplayName("a payload that does not compress comes back byte for byte")
+    void incompressiblePayloadRoundTrips() throws Exception {
+        final byte[] payload = new byte[PAYLOAD];
+        new Random(11).nextBytes(payload);
+        assertRoundTrip("incompressible.bin", payload);
+    }
+
+    @Test
+    @DisplayName("a payload too small to be worth compressing comes back byte for byte")
+    void tinyPayloadRoundTrips() throws Exception {
+        assertRoundTrip("tiny.txt", "x".getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    @DisplayName("an empty payload comes back empty")
+    void emptyPayloadRoundTrips() throws Exception {
+        assertRoundTrip("empty.txt", new byte[0]);
+    }
+
+    /**
+     * Bytes that repeat, so that a server willing to compress has every reason to.
+     */
+    private static byte[] compressible(final int length) {
+        final byte[] unit = "the quick brown fox jumps over the lazy dog ".getBytes(StandardCharsets.UTF_8);
+        final byte[] payload = new byte[length];
+        for (int i = 0; i < length; i++) {
+            payload[i] = unit[i % unit.length];
+        }
+        return payload;
+    }
+
+    private void assertRoundTrip(final String name, final byte[] payload) throws Exception {
+        final CIFSContext context = server().context();
+        this.workDir = createWorkDir(context, server().share());
+        final SmbFile file = new SmbFile(this.workDir, name);
+
+        try (OutputStream out = file.getOutputStream()) {
+            out.write(payload);
+        }
+
+        assertEquals(payload.length, file.length(), "the file on the server should be the size that was written");
+
+        final byte[] readBack = new byte[payload.length];
+        try (InputStream in = file.getInputStream()) {
+            int off = 0;
+            int n;
+            while (off < payload.length && (n = in.read(readBack, off, payload.length - off)) > 0) {
+                off += n;
+            }
+            assertEquals(payload.length, off, "the whole file should have been read back");
+            assertEquals(-1, in.read(), "there should be nothing after the payload");
+        }
+
+        assertArrayEquals(payload, readBack, "every byte should survive the round trip");
+    }
+}

--- a/src/test/java/org/codelibs/jcifs/smb/it/CompressionIT.java
+++ b/src/test/java/org/codelibs/jcifs/smb/it/CompressionIT.java
@@ -17,14 +17,22 @@ package org.codelibs.jcifs.smb.it;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Properties;
 import java.util.Random;
 
 import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.DialectVersion;
+import org.codelibs.jcifs.smb.impl.SmbCompressionProbe;
 import org.codelibs.jcifs.smb.impl.SmbFile;
+import org.codelibs.jcifs.smb.it.env.RequiresBackend;
+import org.codelibs.jcifs.smb.it.env.RequiresDialect;
+import org.codelibs.jcifs.smb.it.env.SmbBackend;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -84,6 +92,75 @@ class CompressionIT extends AbstractSmbIT {
         assertRoundTrip("empty.txt", new byte[0]);
     }
 
+    @Test
+    @DisplayName("compression is not negotiated unless it is asked for")
+    void compressionIsOffByDefault() throws Exception {
+        final CIFSContext context = server().context();
+        this.workDir = createWorkDir(context, server().share());
+        final SmbFile file = writeFile(this.workDir, "default.txt", "default configuration");
+
+        assertFalse(SmbCompressionProbe.negotiated(file), "the default configuration should not negotiate compression");
+    }
+
+    @Test
+    @DisplayName("a payload that compresses well comes back byte for byte with compression asked for")
+    void compressiblePayloadRoundTripsWithCompressionEnabled() throws Exception {
+        assertRoundTripCompressed("compressible-on.txt", compressible(PAYLOAD));
+    }
+
+    @Test
+    @DisplayName("a payload that does not compress comes back byte for byte with compression asked for")
+    void incompressiblePayloadRoundTripsWithCompressionEnabled() throws Exception {
+        final byte[] payload = new byte[PAYLOAD];
+        new Random(13).nextBytes(payload);
+        assertRoundTripCompressed("incompressible-on.bin", payload);
+    }
+
+    @Test
+    @RequiresBackend(SmbBackend.WINDOWS)
+    @RequiresDialect(DialectVersion.SMB311)
+    @DisplayName("a server that supports compression agrees to it when asked")
+    void compressionIsNegotiatedWhereTheServerSupportsIt() throws Exception {
+        // Samba 4.22 does not implement compression at all, so only Windows can show
+        // that the offer is accepted rather than quietly ignored. Without this the
+        // round trips above would pass against a server that never compressed a byte.
+        final CIFSContext context = server().context(compressionEnabled());
+        this.workDir = createWorkDir(context, server().share());
+        final SmbFile file = writeFile(this.workDir, "negotiated.txt", "compression negotiated");
+
+        assertTrue(SmbCompressionProbe.negotiated(file), "Windows should agree to the compression algorithm that was offered");
+    }
+
+    @Test
+    @RequiresBackend(SmbBackend.SAMBA)
+    @DisplayName("a server that does not support compression is left working")
+    void offeringCompressionToASambaServerChangesNothing() throws Exception {
+        // The offer has to be harmless where it is not understood: Samba answers the
+        // negotiate without a compression context at all.
+        final CIFSContext context = server().context(compressionEnabled());
+        this.workDir = createWorkDir(context, server().share());
+        final SmbFile file = writeFile(this.workDir, "ignored.txt", "compression ignored");
+
+        assertFalse(SmbCompressionProbe.negotiated(file), "Samba should not agree to compression");
+        assertEquals("compression ignored", readBack(file));
+    }
+
+    private static Properties compressionEnabled() {
+        final Properties props = new Properties();
+        props.setProperty("jcifs.client.compressionEnabled", "true");
+        return props;
+    }
+
+    private void assertRoundTripCompressed(final String name, final byte[] payload) throws Exception {
+        assertRoundTrip(name, payload, server().context(compressionEnabled()));
+    }
+
+    private static String readBack(final SmbFile file) throws Exception {
+        try (InputStream in = file.getInputStream()) {
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
     /**
      * Bytes that repeat, so that a server willing to compress has every reason to.
      */
@@ -97,7 +174,10 @@ class CompressionIT extends AbstractSmbIT {
     }
 
     private void assertRoundTrip(final String name, final byte[] payload) throws Exception {
-        final CIFSContext context = server().context();
+        assertRoundTrip(name, payload, server().context());
+    }
+
+    private void assertRoundTrip(final String name, final byte[] payload, final CIFSContext context) throws Exception {
         this.workDir = createWorkDir(context, server().share());
         final SmbFile file = new SmbFile(this.workDir, name);
 


### PR DESCRIPTION
## What this changes

SMB 3.1.1 can carry a message compressed, and jcifs had none of it: no
negotiate context, no transform header, no decompressor. Set
`jcifs.client.compressionEnabled=true` and the client offers a compression
algorithm during negotiation, sets `SMB2_READFLAG_REQUEST_COMPRESSED` on
its reads, and decompresses what comes back. **Off by default.**

**Reading only.** A client is never obliged to compress what it sends, and
not doing so keeps an entire compressor - and every judgement about when
compressing is worth the CPU - out of the code.

## Only LZ77, and not configurable

A server may answer with any algorithm from the offer, and MS-SMB2 3.2.5.2
requires the connection to **fail** if it names one the client did not
offer. So the offer is a statement of what this client can actually read.
A settable list, as `encryptionCiphers` is, would let a caller promise
something it cannot honour and break the connection doing it.

## Measured, not read off the documentation

| server | result |
| --- | --- |
| Samba 4.22.10 | **no compression at all** - `smb2_negprot.c` never mentions the context, and a raw negotiate probe answers with only pre-auth and encryption |
| Windows Server 2025 | **LZNT1, LZ77, LZ77+Huffman, Pattern_V1, LZ4**, each confirmed by offering it alone |

**A misreading worth recording, because it nearly changed the design.**
Offering all five to Windows returns `LZNT1` and `Pattern_V1` — no LZ77 —
which reads as LZ77 being unsupported and would have meant implementing
LZNT1 instead. It is not: a server returns a *subset of the offer by its own
preference*. Offering `[LZ77, LZ77+Huffman]` returns `LZ77` alone; offering
`LZ77` alone returns `LZ77`. **A response to a multi-algorithm offer is a
selection, not a declaration of capability.**

## The decompressor

MS-XCA 2.4 plain LZ77. Both of the specification's worked examples are unit
tests, plus a case neither reaches: one byte carrying the length nibbles of
two consecutive matches, the first taking its low half and the second the
high half of the same byte.

The arithmetic **cannot** be derived from those examples. Both come out
right under a simpler rule that is wrong for any longer match, because it
misses subtracting the encoding's own bias and the further 32-bit escape.
The authority used is Samba's `lzxpress.c`, which cites the same section and
interoperates with Windows in production.

## Failing closed

Every failure on the receive path throws rather than skipping the frame, as
MS-SMB2 3.2.5.1.1.2 requires: a frame that cannot be decompressed cannot be
measured either, so there is no way to find where the next one begins. A
chained message, an algorithm that was not agreed, and data that does not
produce the declared size are each refused that way.

That also contains the one ambiguity in the specification. Whether
`OriginalCompressedSegmentSize` covers the uncompressed prefix as well as
the compressed segment is not stated; either reading produces the wrong
byte count and says so, rather than corrupting a message.

## What the tests actually prove — and what they do not

The guard landed first, in its own commit, green before any of this existed:
a payload that compresses well, one that does not, one too small to bother
with, and an empty one all come back byte for byte. They assert nothing
about compression, because there was nothing yet to observe.

**No local test decompresses a single byte.** Samba does not implement
compression, so `peekCompressedKey` never runs against it and the LZ77
decoder is exercised only by its unit vectors. What the Samba checks prove
is that offering compression to a server that does not understand it changes
nothing. **The `windows-smb` checks are the only place the receive path
executes at all**, and the case asserting the offer is actually accepted is
Windows-only for the same reason.

Falsification is limited by the same fact and is reported honestly rather
than performed for show: the decompression path cannot be falsified locally,
because disabling it changes nothing against a server that never compresses.
What was falsified is the knob wiring — see the verification section.

## Verification

- Unit tests **8889** and integration tests **272** against Samba 4.22.10,
  no failures. The seventeen added unit cases and five added integration
  cases are the whole difference from 8872 and 267; the tenth skip is the
  Windows-only case asserting the offer is accepted.
- apache-rat reports nothing unapproved. clirr compares clean against 3.0.3
  with the new `Configuration` method recorded in the pom, as the previous
  few changes did.
- The documentation is the one part this run did not cover, having been
  written after it started. It is prose, and CI rebuilds the exact commit.

**What was falsified, and what could not be.** Flipping the knob's default
would not fail `compressionIsOffByDefault` locally, because the probe
reports nothing negotiated with it on or off — Samba answers without a
compression context whatever is offered. Disabling the decompressor changes
nothing locally for the same reason. So no local falsification run was
performed; it would have been unable to fail. **This PR's `windows-smb`
check is the first time the decompression path runs anywhere**, and the
round trips with compression enabled are what exercise it, failing closed
with an `IOException` if the frame cannot be read.
